### PR TITLE
fix(ci): prepare for PyPI v0.2.0 first publish (#18)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -5,6 +5,7 @@ on:
     types: [published]
 
 permissions:
+  contents: read
   id-token: write
 
 jobs:
@@ -19,11 +20,15 @@ jobs:
           python-version: "3.12"
 
       - name: Install build tools
-        run: pip install build
+        run: pip install build twine
 
       - name: Build package
         working-directory: python
         run: python -m build
+
+      - name: Verify package
+        working-directory: python
+        run: twine check dist/*
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

- Fix Python lint error (ruff E741): rename ambiguous variable `l` to `last` in `test_cli.py`
- Harden `publish-pypi.yml` workflow: add `contents: read` permission, add `twine check` verification step before publish

## Release checklist

- [x] Version in `pyproject.toml` set to `0.2.0`
- [x] `__init__.py` version matches: `0.2.0`
- [x] Python lint (ruff) passes
- [x] All 84 Python tests pass
- [x] `python -m build` produces valid wheel and sdist
- [x] `twine check dist/*` passes
- [x] `publish-pypi.yml` workflow has correct permissions and verification
- [ ] **Manual:** Configure PyPI trusted publisher for this repo at pypi.org
- [ ] **Manual:** Create `pypi` environment in GitHub repo settings
- [ ] **Manual:** Create GitHub Release with tag `v0.2.0` to trigger publish workflow
- [ ] **Manual:** Verify package visible on pypi.org after workflow completes

## Blocked: Node CI failures (not in scope)

5 Node tests fail on main (preset loading and findRosterCards — functions not exported). These are from the Node test expansion (GH#15) and need to be fixed separately.

## Test plan

- [x] `ruff check src/ tests/` passes
- [x] `pytest tests/ -v` — 84 tests pass
- [x] `python -m build` succeeds
- [x] `twine check dist/*` passes
- [x] Clean venv install from wheel works

Closes #18