### PR TITLE
npm first publish prep: fix CI and verify v0.2.0 (#19)

### DIFF
--- a/node/src/bootstrap.ts
+++ b/node/src/bootstrap.ts
@@ -120,7 +120,7 @@ export function makeEmail(first: string, last: string, prefix: string = ""): str
   return `${clean(first)}.${clean(last)}@gmail.com`;
 }
 
-function loadPreset(name: string): Preset {
+export function loadPreset(name: string): Preset {
   const path = join(PRESETS_DIR, `${name}.json`);
   if (!existsSync(path)) {
     throw new Error(`Unknown preset: ${name}`);
@@ -384,6 +384,13 @@ export function replaceField(content: string, field: string, value: string): str
 
 export function safeName(name: string): string {
   return name.toLowerCase().replace(/ /g, "_").replace(/-/g, "_");
+}
+
+export function findRosterCards(rosterDir: string, name: string): string[] {
+  if (!existsSync(rosterDir)) return [];
+  const safe = safeName(name);
+  return readdirSync(rosterDir)
+    .filter((f) => f.endsWith(".md") && f.includes(safe) && !f.startsWith("_departed_"));
 }
 
 export function updateMember(opts: MemberOptions): void {

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -104,7 +104,7 @@ class TestNameGeneration:
 
     def test_generate_name_exhaustion(self):
         """Should raise when no unique name can be generated."""
-        used = {f"{f} {l}" for f in FIRST_NAMES for l in LAST_NAMES}
+        used = {f"{fn} {ln}" for fn in FIRST_NAMES for ln in LAST_NAMES}
         with pytest.raises(RuntimeError, match="Could not generate"):
             generate_name(used)
 


### PR DESCRIPTION
## Summary
- Export `loadPreset` and add `findRosterCards` to `bootstrap.ts` — fixes CI test import failures on main
- Fix Python ruff E741 lint error (ambiguous variable name) in test file
- All 73 Node tests and 84 Python tests pass
- `npm pack` verified: 24-file tarball, correct contents
- Local install smoke test: `--help`, `--version`, `init` all work
- Version confirmed at `0.2.0`
- `publish-npm.yml` workflow verified: provenance signing, NPM_TOKEN env var

## Manual steps required for actual publish
- [ ] `NPM_TOKEN` secret must be configured in repo settings
- [ ] GitHub Release with tag `v0.2.0` triggers the publish workflow
- [ ] Verify package name `2real-team-framework` is available on npm (or use scoped `@2real/team-framework`)
- [ ] Post-publish smoke test: `npm install -g 2real-team-framework && 2real-team --help`

## Test plan
- [x] 73 Node tests pass (all matrix: 18, 20, 22)
- [x] 84 Python tests pass (all matrix: 3.10-3.13)
- [x] `ruff check` passes
- [x] `npm pack --dry-run` verified
- [x] Local install and `init` command verified

Closes #19