### PR TITLE
feat: AI persona generation via Claude API (#13)

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -58,5 +58,8 @@
     "@types/mustache": "^4.2.0",
     "@types/inquirer": "^9.0.0",
     "@types/node": "^22.0.0"
+  },
+  "optionalDependencies": {
+    "@anthropic-ai/sdk": ">=0.30.0"
   }
 }

--- a/node/src/bootstrap.ts
+++ b/node/src/bootstrap.ts
@@ -36,6 +36,8 @@ interface BootstrapOptions {
   projectName?: string;
   target: string;
   interactive: boolean;
+  aiPersonas?: boolean;
+  seed?: number;
 }
 
 interface PresetRole {
@@ -306,8 +308,33 @@ export async function bootstrap(opts: BootstrapOptions): Promise<void> {
     }
   }
 
+  // Apply AI-generated personas if requested
+  if (opts.aiPersonas) {
+    const { generatePersonas } = await import("./personas.js");
+    const roleSpecs = members.map((m) => ({ role: m.role, level: m.level }));
+    const personas = await generatePersonas(
+      { name: preset.name, description: preset.description ?? preset.name },
+      roleSpecs,
+      members.length,
+      opts.seed,
+    );
+    if (personas.length > 0) {
+      for (let i = 0; i < personas.length && i < members.length; i++) {
+        members[i].name = personas[i].name;
+        members[i].agent_name = toAgentName(personas[i].name);
+        const nameParts = personas[i].name.split(" ");
+        members[i].email = makeEmail(nameParts[0], nameParts.slice(1).join(" "));
+        members[i].personality = personas[i].personality;
+      }
+      console.log("AI personas generated successfully");
+    } else {
+      console.log("Using local name pool (AI generation unavailable)");
+    }
+  }
+
   // Use config skills override if provided, otherwise preset defaults
   const skillsList = configSkills ?? preset.skills;
+
 
   const context = { project_name: projectName, team_members: members };
 

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -33,6 +33,8 @@ program
   .option("--project-name <name>", "Project name")
   .option("--target <dir>", "Target directory", ".")
   .option("--no-interactive", "Disable interactive mode")
+  .option("--ai-personas", "Use Claude API to generate rich personas")
+  .option("--seed <n>", "Seed for reproducible AI persona generation", parseInt)
   .action(async (opts) => {
     await bootstrap({
       preset: opts.preset,
@@ -41,6 +43,8 @@ program
       projectName: opts.projectName,
       target: opts.target,
       interactive: opts.interactive !== false,
+      aiPersonas: opts.aiPersonas ?? false,
+      seed: opts.seed,
     });
   });
 

--- a/node/src/personas.ts
+++ b/node/src/personas.ts
@@ -1,0 +1,149 @@
+/**
+ * AI persona generation via Claude API (optional feature).
+ */
+
+interface PersonaResult {
+  name: string;
+  personality: string;
+  expertise: string;
+}
+
+interface RoleSpec {
+  role: string;
+  level: string;
+}
+
+interface PresetInfo {
+  name: string;
+  description: string;
+}
+
+function buildPrompt(
+  preset: PresetInfo,
+  roles: RoleSpec[],
+  teamSize: number,
+  seed?: number,
+): string {
+  const roleDescriptions = roles
+    .map((r, i) => `  ${i + 1}. ${r.role} (${r.level})`)
+    .join("\n");
+
+  const seedNote = seed !== undefined
+    ? `\nUse seed ${seed} for deterministic generation — always produce the same names and personalities for this seed value.`
+    : "";
+
+  return `Generate ${roles.length} team member personas for a software project team.
+
+Project type: ${preset.name} — ${preset.description}
+Team size: ${teamSize}
+${seedNote}
+
+Roles to fill:
+${roleDescriptions}
+
+For each team member, generate:
+1. A culturally diverse full name (first and last)
+2. A personality/communication style (1-2 sentences describing how they communicate)
+3. Areas of expertise relevant to their role (1 sentence)
+
+IMPORTANT: Names should be culturally diverse — mix of ethnicities, backgrounds, and naming conventions. Avoid common Anglo-Saxon defaults.
+
+Return ONLY a JSON array with objects having these exact keys:
+- "name": full name
+- "personality": communication style description
+- "expertise": areas of expertise
+
+Example format:
+[
+  {"name": "Yuki Tanaka", "personality": "Analytical and precise. Favors data-driven decisions.", "expertise": "Distributed systems and API design."}
+]
+
+Return exactly ${roles.length} objects in the array. No other text.`;
+}
+
+function parseResponse(text: string, expectedCount: number): PersonaResult[] {
+  let cleaned = text.trim();
+
+  // Handle markdown code blocks
+  if (cleaned.startsWith("```")) {
+    const lines = cleaned.split("\n");
+    const filtered = lines.filter((ln) => !ln.trim().startsWith("```"));
+    cleaned = filtered.join("\n");
+  }
+
+  let result: unknown;
+  try {
+    result = JSON.parse(cleaned);
+  } catch {
+    return [];
+  }
+
+  if (!Array.isArray(result)) return [];
+
+  const personas: PersonaResult[] = [];
+  for (const item of result.slice(0, expectedCount)) {
+    if (!item || typeof item !== "object") continue;
+    const persona: PersonaResult = {
+      name: String((item as Record<string, unknown>).name ?? ""),
+      personality: String((item as Record<string, unknown>).personality ?? ""),
+      expertise: String((item as Record<string, unknown>).expertise ?? ""),
+    };
+    if (persona.name && persona.personality) {
+      personas.push(persona);
+    }
+  }
+
+  return personas;
+}
+
+export async function generatePersonas(
+  preset: PresetInfo,
+  roles: RoleSpec[],
+  teamSize: number,
+  seed?: number,
+): Promise<PersonaResult[]> {
+  // Check for API key
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    console.warn(
+      "Warning: ANTHROPIC_API_KEY not set. AI persona generation requires an API key.",
+    );
+    return [];
+  }
+
+  // Try to load anthropic SDK
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let AnthropicClass: any;
+
+  try {
+    const mod = await import("@anthropic-ai/sdk" as string);
+    AnthropicClass = mod.default;
+  } catch {
+    console.warn(
+      "Warning: @anthropic-ai/sdk not installed. Install with: npm install @anthropic-ai/sdk",
+    );
+    return [];
+  }
+
+  const prompt = buildPrompt(preset, roles, teamSize, seed);
+
+  try {
+    const client = new AnthropicClass({ apiKey });
+    const response = await client.messages.create({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 2048,
+      messages: [{ role: "user", content: prompt }],
+    });
+    const text = response.content[0].text;
+    return parseResponse(text, roles.length);
+  } catch (err) {
+    console.warn(
+      `Warning: AI persona generation failed, using local pool: ${err}`,
+    );
+    return [];
+  }
+}
+
+// Export for testing
+export { buildPrompt as _buildPrompt, parseResponse as _parseResponse };
+export type { PersonaResult, RoleSpec, PresetInfo };

--- a/node/tests/personas.test.ts
+++ b/node/tests/personas.test.ts
@@ -2,8 +2,8 @@
  * Tests for AI persona generation module.
  */
 
-import { describe, it, expect } from "vitest";
-import { _buildPrompt, _parseResponse } from "../src/personas.js";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { _buildPrompt, _parseResponse, generatePersonas } from "../src/personas.js";
 
 describe("buildPrompt", () => {
   const preset = { name: "library", description: "Open source library" };
@@ -90,5 +90,91 @@ describe("parseResponse", () => {
     ]);
     const result = _parseResponse(response, 1);
     expect(result).toHaveLength(0);
+  });
+});
+
+describe("generatePersonas", () => {
+  const preset = { name: "library", description: "Open source library" };
+  const roles = [{ role: "Engineer", level: "Senior" }];
+  const originalEnv = process.env.ANTHROPIC_API_KEY;
+
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.ANTHROPIC_API_KEY = originalEnv;
+    } else {
+      delete process.env.ANTHROPIC_API_KEY;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("should return empty array when ANTHROPIC_API_KEY is not set", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    const result = await generatePersonas(preset, roles, 3);
+    expect(result).toEqual([]);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining("ANTHROPIC_API_KEY not set"),
+    );
+  });
+
+  it("should return empty array when SDK is not installed", async () => {
+    process.env.ANTHROPIC_API_KEY = "sk-test-key";
+    // The SDK is not installed in test env, so dynamic import will fail
+    const result = await generatePersonas(preset, roles, 3);
+    expect(result).toEqual([]);
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it("should return empty array on API error", async () => {
+    process.env.ANTHROPIC_API_KEY = "sk-test-key";
+    // Mock the dynamic import to simulate an installed SDK that throws
+    vi.doMock("@anthropic-ai/sdk", () => ({
+      default: class MockAnthropic {
+        messages = {
+          create: () => {
+            throw new Error("API down");
+          },
+        };
+      },
+    }));
+    // Re-import to pick up the mock — but since generatePersonas uses
+    // dynamic import, we need to verify the error path
+    const result = await generatePersonas(preset, roles, 3);
+    expect(result).toEqual([]);
+    expect(console.warn).toHaveBeenCalled();
+    vi.doUnmock("@anthropic-ai/sdk");
+  });
+
+  it("should return personas on successful API call", async () => {
+    process.env.ANTHROPIC_API_KEY = "sk-test-key";
+    const mockPersonas = [
+      {
+        name: "Kenji Sato",
+        personality: "Direct and clear.",
+        expertise: "Backend systems",
+      },
+    ];
+    vi.doMock("@anthropic-ai/sdk", () => ({
+      default: class MockAnthropic {
+        messages = {
+          create: async () => ({
+            content: [{ text: JSON.stringify(mockPersonas) }],
+          }),
+        };
+      },
+    }));
+
+    // Dynamic import inside generatePersonas should pick up the mock
+    const { generatePersonas: freshGenerate } = await import(
+      "../src/personas.js"
+    );
+    const result = await freshGenerate(preset, roles, 3);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Kenji Sato");
+    expect(result[0].personality).toBe("Direct and clear.");
+    vi.doUnmock("@anthropic-ai/sdk");
   });
 });

--- a/node/tests/personas.test.ts
+++ b/node/tests/personas.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for AI persona generation module.
+ */
+
+import { describe, it, expect } from "vitest";
+import { _buildPrompt, _parseResponse } from "../src/personas.js";
+
+describe("buildPrompt", () => {
+  const preset = { name: "library", description: "Open source library" };
+  const roles = [{ role: "Tech Lead", level: "Staff" }];
+
+  it("should include role info", () => {
+    const prompt = _buildPrompt(preset, roles, 3);
+    expect(prompt).toContain("Tech Lead");
+    expect(prompt).toContain("Staff");
+    expect(prompt).toContain("library");
+  });
+
+  it("should include seed when provided", () => {
+    const prompt = _buildPrompt(preset, roles, 3, 42);
+    expect(prompt).toContain("seed 42");
+  });
+
+  it("should request correct number of personas", () => {
+    const multiRoles = [
+      { role: "Manager", level: "Senior VP" },
+      { role: "Engineer", level: "Senior" },
+    ];
+    const prompt = _buildPrompt(preset, multiRoles, 5);
+    expect(prompt).toContain("Generate 2");
+    expect(prompt).toContain("Return exactly 2");
+  });
+});
+
+describe("parseResponse", () => {
+  it("should parse valid JSON array", () => {
+    const response = JSON.stringify([
+      { name: "Yuki Tanaka", personality: "Analytical.", expertise: "APIs" },
+      { name: "Ada Chen", personality: "Direct.", expertise: "Testing" },
+    ]);
+    const result = _parseResponse(response, 2);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("Yuki Tanaka");
+    expect(result[1].name).toBe("Ada Chen");
+  });
+
+  it("should handle markdown code blocks", () => {
+    const response =
+      "```json\n" +
+      JSON.stringify([
+        { name: "Test User", personality: "Friendly.", expertise: "Code" },
+      ]) +
+      "\n```";
+    const result = _parseResponse(response, 1);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Test User");
+  });
+
+  it("should return empty array for invalid JSON", () => {
+    expect(_parseResponse("not json", 1)).toEqual([]);
+  });
+
+  it("should return empty array for non-array JSON", () => {
+    expect(_parseResponse('{"name": "test"}', 1)).toEqual([]);
+  });
+
+  it("should truncate to expected count", () => {
+    const response = JSON.stringify([
+      { name: "A", personality: "X.", expertise: "Y" },
+      { name: "B", personality: "X.", expertise: "Y" },
+      { name: "C", personality: "X.", expertise: "Y" },
+    ]);
+    const result = _parseResponse(response, 2);
+    expect(result).toHaveLength(2);
+  });
+
+  it("should skip items with empty name", () => {
+    const response = JSON.stringify([
+      { name: "", personality: "X.", expertise: "Y" },
+      { name: "Valid", personality: "Good.", expertise: "Z" },
+    ]);
+    const result = _parseResponse(response, 2);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Valid");
+  });
+
+  it("should skip items with empty personality", () => {
+    const response = JSON.stringify([
+      { name: "Test", personality: "", expertise: "Y" },
+    ]);
+    const result = _parseResponse(response, 1);
+    expect(result).toHaveLength(0);
+  });
+});

--- a/python/src/real_team/cli.py
+++ b/python/src/real_team/cli.py
@@ -8,7 +8,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
-from .bootstrap import bootstrap_project, generate_team
+from .bootstrap import bootstrap_project, generate_team, make_email
 from .models import TeamConfig, YamlConfig
 from .presets import get_preset, list_presets
 
@@ -29,6 +29,8 @@ def init(
     git_email_prefix: str = typer.Option(
         "", help="Email prefix (e.g., 'myorg' -> myorg+First.Last@gmail.com)"
     ),
+    ai_personas: bool = typer.Option(False, help="Use Claude API to generate rich personas"),
+    seed: int = typer.Option(None, help="Seed for reproducible AI persona generation"),
 ) -> None:
     """Bootstrap a new project with the team framework."""
     target_path = Path(target).resolve()
@@ -87,8 +89,6 @@ def init(
 
     # Apply per-member overrides from YAML config
     if config and yaml_cfg.members:
-        from .bootstrap import make_email
-
         for i, override in enumerate(yaml_cfg.members):
             if i >= len(members):
                 break
@@ -104,6 +104,26 @@ def init(
                 members[i].level = override.level
             if override.personality:
                 members[i].personality = override.personality
+
+    # Apply AI-generated personas if requested
+    if ai_personas:
+        from .personas import generate_personas
+
+        roles = [{"role": m.role, "level": m.level} for m in members]
+        personas = generate_personas(preset_config, roles, len(members), seed)
+        if personas:
+            for i, persona in enumerate(personas):
+                if i >= len(members):
+                    break
+                members[i].name = persona["name"]
+                parts = persona["name"].split(" ", 1)
+                first = parts[0]
+                last = parts[1] if len(parts) > 1 else ""
+                members[i].email = make_email(first, last, git_email_prefix)
+                members[i].personality = persona["personality"]
+            console.print("[dim]AI personas generated successfully[/dim]")
+        else:
+            console.print("[dim]Using local name pool (AI generation unavailable)[/dim]")
 
     team_config = TeamConfig(
         project_name=project_name,

--- a/python/src/real_team/personas.py
+++ b/python/src/real_team/personas.py
@@ -1,0 +1,171 @@
+"""AI persona generation via Claude API (optional feature)."""
+
+from __future__ import annotations
+
+import json
+import warnings
+from typing import Any
+
+from .models import PresetConfig
+
+
+def _check_anthropic() -> bool:
+    """Check if the anthropic SDK is available."""
+    try:
+        import anthropic  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def _check_api_key() -> str | None:
+    """Return ANTHROPIC_API_KEY from environment, or None."""
+    import os
+
+    return os.environ.get("ANTHROPIC_API_KEY")
+
+
+def generate_personas(
+    preset: PresetConfig,
+    roles: list[dict[str, str]],
+    team_size: int,
+    seed: int | None = None,
+) -> list[dict[str, str]]:
+    """Generate team member personas using the Claude API.
+
+    Each persona dict has keys: name, personality, expertise.
+    Falls back to empty list on any API error (caller uses local pool).
+
+    Parameters
+    ----------
+    preset:
+        The preset config (provides project context).
+    roles:
+        List of {"role": ..., "level": ...} for each member to generate.
+    team_size:
+        Total team size.
+    seed:
+        Optional seed for reproducibility (included in prompt).
+    """
+    if not _check_anthropic():
+        warnings.warn(
+            "anthropic package not installed. Install with: "
+            "pip install '2real-team-framework[ai]'",
+            stacklevel=2,
+        )
+        return []
+
+    api_key = _check_api_key()
+    if not api_key:
+        warnings.warn(
+            "ANTHROPIC_API_KEY not set. AI persona generation requires "
+            "an API key in the environment.",
+            stacklevel=2,
+        )
+        return []
+
+    import anthropic
+
+    prompt = _build_prompt(preset, roles, team_size, seed)
+
+    try:
+        client = anthropic.Anthropic(api_key=api_key)
+        response = client.messages.create(
+            model="claude-sonnet-4-20250514",
+            max_tokens=2048,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        text = response.content[0].text
+        return _parse_response(text, len(roles))
+    except Exception as exc:
+        warnings.warn(
+            f"AI persona generation failed, using local pool: {exc}",
+            stacklevel=2,
+        )
+        return []
+
+
+def _build_prompt(
+    preset: PresetConfig,
+    roles: list[dict[str, str]],
+    team_size: int,
+    seed: int | None = None,
+) -> str:
+    """Build the prompt for Claude API."""
+    role_descriptions = "\n".join(
+        f"  {i + 1}. {r['role']} ({r['level']})" for i, r in enumerate(roles)
+    )
+
+    seed_note = ""
+    if seed is not None:
+        seed_note = (
+            f"\nUse seed {seed} for deterministic generation"
+            " — always produce the same names and personalities"
+            " for this seed value."
+        )
+
+    return f"""Generate {len(roles)} team member personas for a software project team.
+
+Project type: {preset.name} — {preset.description}
+Team size: {team_size}
+{seed_note}
+
+Roles to fill:
+{role_descriptions}
+
+For each team member, generate:
+1. A culturally diverse full name (first and last)
+2. A personality/communication style (1-2 sentences describing how they communicate)
+3. Areas of expertise relevant to their role (1 sentence)
+
+IMPORTANT: Names should be culturally diverse — mix of ethnicities,
+backgrounds, and naming conventions. Avoid common Anglo-Saxon defaults.
+
+Return ONLY a JSON array with objects having these exact keys:
+- "name": full name
+- "personality": communication style description
+- "expertise": areas of expertise
+
+Example format:
+[
+  {{"name": "Yuki Tanaka", "personality": "Analytical and precise.",
+"expertise": "Distributed systems and API design."}}
+]
+
+Return exactly {len(roles)} objects in the array. No other text."""
+
+
+def _parse_response(text: str, expected_count: int) -> list[dict[str, str]]:
+    """Parse the Claude API response into persona dicts."""
+    # Extract JSON array from response
+    text = text.strip()
+
+    # Handle markdown code blocks
+    if text.startswith("```"):
+        lines = text.split("\n")
+        # Remove first and last lines (```json and ```)
+        lines = [ln for ln in lines if not ln.strip().startswith("```")]
+        text = "\n".join(lines)
+
+    try:
+        result: Any = json.loads(text)
+    except json.JSONDecodeError:
+        return []
+
+    if not isinstance(result, list):
+        return []
+
+    personas = []
+    for item in result[:expected_count]:
+        if not isinstance(item, dict):
+            continue
+        persona = {
+            "name": str(item.get("name", "")),
+            "personality": str(item.get("personality", "")),
+            "expertise": str(item.get("expertise", "")),
+        }
+        if persona["name"] and persona["personality"]:
+            personas.append(persona)
+
+    return personas

--- a/python/tests/test_personas.py
+++ b/python/tests/test_personas.py
@@ -41,7 +41,7 @@ class TestBuildPrompt:
     def test_no_seed_note_without_seed(self, library_preset: PresetConfig):
         roles = [{"role": "Engineer", "level": "Senior"}]
         prompt = _build_prompt(library_preset, roles, 3)
-        assert "seed" not in prompt.lower() or "seed" in prompt.lower()  # just runs
+        assert "seed" not in prompt.lower()
 
 
 class TestParseResponse:

--- a/python/tests/test_personas.py
+++ b/python/tests/test_personas.py
@@ -1,0 +1,159 @@
+"""Tests for AI persona generation module."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from real_team.models import PresetConfig, RoleSpec
+from real_team.personas import _build_prompt, _parse_response, generate_personas
+
+
+@pytest.fixture
+def library_preset() -> PresetConfig:
+    return PresetConfig(
+        name="library",
+        description="Open source library",
+        default_team_size=3,
+        roles=[
+            RoleSpec(role="Manager", level="Senior VP", count=1, required=True),
+            RoleSpec(role="Tech Lead", level="Staff", count=1, required=True),
+        ],
+        skills=["retro"],
+    )
+
+
+class TestBuildPrompt:
+    def test_includes_role_info(self, library_preset: PresetConfig):
+        roles = [{"role": "Tech Lead", "level": "Staff"}]
+        prompt = _build_prompt(library_preset, roles, 3)
+        assert "Tech Lead" in prompt
+        assert "Staff" in prompt
+        assert "library" in prompt
+
+    def test_includes_seed(self, library_preset: PresetConfig):
+        roles = [{"role": "Engineer", "level": "Senior"}]
+        prompt = _build_prompt(library_preset, roles, 3, seed=42)
+        assert "seed 42" in prompt
+
+    def test_no_seed_note_without_seed(self, library_preset: PresetConfig):
+        roles = [{"role": "Engineer", "level": "Senior"}]
+        prompt = _build_prompt(library_preset, roles, 3)
+        assert "seed" not in prompt.lower() or "seed" in prompt.lower()  # just runs
+
+
+class TestParseResponse:
+    def test_valid_json_array(self):
+        response = json.dumps([
+            {"name": "Yuki Tanaka", "personality": "Analytical.", "expertise": "APIs"},
+            {"name": "Ada Chen", "personality": "Direct.", "expertise": "Testing"},
+        ])
+        result = _parse_response(response, 2)
+        assert len(result) == 2
+        assert result[0]["name"] == "Yuki Tanaka"
+        assert result[1]["name"] == "Ada Chen"
+
+    def test_code_block_wrapping(self):
+        response = "```json\n" + json.dumps([
+            {"name": "Test User", "personality": "Friendly.", "expertise": "Code"}
+        ]) + "\n```"
+        result = _parse_response(response, 1)
+        assert len(result) == 1
+        assert result[0]["name"] == "Test User"
+
+    def test_invalid_json(self):
+        result = _parse_response("not json at all", 1)
+        assert result == []
+
+    def test_non_array(self):
+        result = _parse_response('{"name": "test"}', 1)
+        assert result == []
+
+    def test_truncates_to_expected_count(self):
+        response = json.dumps([
+            {"name": "A", "personality": "X.", "expertise": "Y"},
+            {"name": "B", "personality": "X.", "expertise": "Y"},
+            {"name": "C", "personality": "X.", "expertise": "Y"},
+        ])
+        result = _parse_response(response, 2)
+        assert len(result) == 2
+
+    def test_skips_items_missing_name(self):
+        response = json.dumps([
+            {"name": "", "personality": "X.", "expertise": "Y"},
+            {"name": "Valid", "personality": "Good.", "expertise": "Z"},
+        ])
+        result = _parse_response(response, 2)
+        assert len(result) == 1
+        assert result[0]["name"] == "Valid"
+
+
+class TestGeneratePersonas:
+    def test_returns_empty_without_anthropic(self, library_preset: PresetConfig):
+        with patch("real_team.personas._check_anthropic", return_value=False):
+            result = generate_personas(
+                library_preset,
+                [{"role": "Engineer", "level": "Senior"}],
+                3,
+            )
+            assert result == []
+
+    def test_returns_empty_without_api_key(self, library_preset: PresetConfig):
+        with (
+            patch("real_team.personas._check_anthropic", return_value=True),
+            patch("real_team.personas._check_api_key", return_value=None),
+        ):
+            result = generate_personas(
+                library_preset,
+                [{"role": "Engineer", "level": "Senior"}],
+                3,
+            )
+            assert result == []
+
+    def test_successful_generation(self, library_preset: PresetConfig):
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock()]
+        mock_response.content[0].text = json.dumps([
+            {
+                "name": "Kenji Sato",
+                "personality": "Direct and clear.",
+                "expertise": "Backend systems",
+            },
+        ])
+
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = mock_response
+
+        mock_anthropic = MagicMock()
+        mock_anthropic.Anthropic.return_value = mock_client
+
+        with (
+            patch("real_team.personas._check_anthropic", return_value=True),
+            patch("real_team.personas._check_api_key", return_value="sk-test"),
+            patch.dict("sys.modules", {"anthropic": mock_anthropic}),
+        ):
+            result = generate_personas(
+                library_preset,
+                [{"role": "Engineer", "level": "Senior"}],
+                3,
+            )
+            assert len(result) == 1
+            assert result[0]["name"] == "Kenji Sato"
+
+    def test_api_error_returns_empty(self, library_preset: PresetConfig):
+        mock_anthropic = MagicMock()
+        mock_anthropic.Anthropic.return_value.messages.create.side_effect = RuntimeError("API down")
+
+        with (
+            patch("real_team.personas._check_anthropic", return_value=True),
+            patch("real_team.personas._check_api_key", return_value="sk-test"),
+            patch.dict("sys.modules", {"anthropic": mock_anthropic}),
+        ):
+            result = generate_personas(
+                library_preset,
+                [{"role": "Engineer", "level": "Senior"}],
+                3,
+            )
+            assert result == []


### PR DESCRIPTION
## Summary

- Add `--ai-personas` flag to `init` command in both Python and Node CLIs
- Integrate Claude API for generating culturally diverse team member personas
- Optional dependencies: `anthropic` (Python) / `@anthropic-ai/sdk` (Node)
- `--seed <int>` flag for reproducible persona generation
- Graceful fallback to local name pool on API errors or missing SDK
- Fix: export `loadPreset` and add `findRosterCards` in Node bootstrap

## Test plan

- [x] 13 new Python tests with mocked API responses (97 total passing)
- [x] 10 new Node tests for prompt building and response parsing (83 total passing)
- [x] Python lint clean (`ruff check`)
- [x] TypeScript compiles (`tsc --noEmit`)
- [ ] Manual test with `ANTHROPIC_API_KEY` set (integration)

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)