### PR TITLE
feat: complete AI persona generation for all commands (#13)

### DIFF
--- a/node/src/bootstrap.ts
+++ b/node/src/bootstrap.ts
@@ -402,9 +402,11 @@ interface AddMemberOptions {
   role: string;
   level: string;
   target: string;
+  aiPersonas?: boolean;
+  seed?: number;
 }
 
-export function addMember(opts: AddMemberOptions): void {
+export async function addMember(opts: AddMemberOptions): Promise<void> {
   const target = resolve(opts.target);
   const rosterDir = join(target, ".claude", "team", "roster");
 
@@ -414,6 +416,29 @@ export function addMember(opts: AddMemberOptions): void {
   }
 
   let name = opts.name;
+  let personality = "To be defined.";
+
+  // Try AI persona generation if requested
+  if (opts.aiPersonas) {
+    try {
+      const { generatePersonas } = await import("./personas.js");
+      const preset = { name: "library", description: "Open source library" };
+      const roles = [{ role: opts.role, level: opts.level }];
+      const personas = await generatePersonas(preset, roles, 1, opts.seed);
+      if (personas.length > 0) {
+        if (!name) {
+          name = personas[0].name;
+        }
+        personality = personas[0].personality;
+        console.log("AI persona generated successfully");
+      } else {
+        console.log("Using local name pool (AI generation unavailable)");
+      }
+    } catch {
+      console.log("Using local name pool (AI generation unavailable)");
+    }
+  }
+
   if (!name) {
     const used = new Set<string>();
     for (const f of readdirSync(rosterDir).filter((f) => f.endsWith(".md"))) {
@@ -433,7 +458,7 @@ export function addMember(opts: AddMemberOptions): void {
     role: opts.role,
     level: opts.level,
     email,
-    personality: "To be defined.",
+    personality,
   };
 
   const card = renderTemplate("roster-card.md.mustache", context);
@@ -536,7 +561,7 @@ export function updateMember(opts: MemberOptions): void {
   console.log(`Updated: ${opts.name}`);
 }
 
-export function randomizeMember(opts: { name: string; target: string }): void {
+export async function randomizeMember(opts: { name: string; target: string; aiPersonas?: boolean; seed?: number }): Promise<void> {
   const target = resolve(opts.target);
   const rosterDir = join(target, ".claude", "team", "roster");
 
@@ -559,13 +584,45 @@ export function randomizeMember(opts: { name: string; target: string }): void {
   // Archive old
   renameSync(oldPath, join(rosterDir, `_departed_${files[0]}`));
 
-  // Generate new identity
-  const used = new Set<string>();
-  for (const f of readdirSync(rosterDir).filter((f) => f.endsWith(".md"))) {
-    used.add(f.replace(/\.md$/, "").replace(/_/g, " "));
+  let newName: string | null = null;
+  let personality: string | null = null;
+
+  // Try AI persona generation if requested
+  if (opts.aiPersonas) {
+    try {
+      const { generatePersonas } = await import("./personas.js");
+      const preset = { name: "library", description: "Open source library" };
+      const roles = [{ role, level }];
+      const personas = await generatePersonas(preset, roles, 1, opts.seed);
+      if (personas.length > 0) {
+        newName = personas[0].name;
+        personality = personas[0].personality;
+        console.log("AI persona generated successfully");
+      } else {
+        console.log("Using local name pool (AI generation unavailable)");
+      }
+    } catch {
+      console.log("Using local name pool (AI generation unavailable)");
+    }
   }
-  const [first, last] = generateName(used);
-  const newName = `${first} ${last}`;
+
+  if (!newName) {
+    // Generate new identity from local pool
+    const used = new Set<string>();
+    for (const f of readdirSync(rosterDir).filter((f) => f.endsWith(".md"))) {
+      used.add(f.replace(/\.md$/, "").replace(/_/g, " "));
+    }
+    const [first, last] = generateName(used);
+    newName = `${first} ${last}`;
+  }
+
+  if (!personality) {
+    personality = randomChoice(COMMUNICATION_STYLES);
+  }
+
+  const parts = newName.split(" ");
+  const first = parts[0];
+  const last = parts.slice(1).join(" ");
   const email = makeEmail(first, last);
 
   const context: Record<string, unknown> = {
@@ -573,7 +630,7 @@ export function randomizeMember(opts: { name: string; target: string }): void {
     role,
     level,
     email,
-    personality: randomChoice(COMMUNICATION_STYLES),
+    personality,
   };
 
   const card = renderTemplate("roster-card.md.mustache", context);

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -54,8 +54,10 @@ program
   .requiredOption("--role <role>", "Role")
   .option("--level <level>", "Level", "Senior")
   .option("--target <dir>", "Target directory", ".")
+  .option("--ai-personas", "Use Claude API to generate rich persona")
+  .option("--seed <n>", "Seed for reproducible AI persona generation", parseInt)
   .action(async (name, opts) => {
-    addMember({ name, role: opts.role, level: opts.level, target: opts.target });
+    await addMember({ name, role: opts.role, level: opts.level, target: opts.target, aiPersonas: opts.aiPersonas ?? false, seed: opts.seed });
   });
 
 program
@@ -80,8 +82,10 @@ program
   .command("randomize-member <name>")
   .description("Regenerate a team member's name, background, and personality")
   .option("--target <dir>", "Target directory", ".")
+  .option("--ai-personas", "Use Claude API to generate rich persona")
+  .option("--seed <n>", "Seed for reproducible AI persona generation", parseInt)
   .action(async (name, opts) => {
-    randomizeMember({ name, target: opts.target });
+    await randomizeMember({ name, target: opts.target, aiPersonas: opts.aiPersonas ?? false, seed: opts.seed });
   });
 
 program

--- a/node/tests/cli.test.ts
+++ b/node/tests/cli.test.ts
@@ -416,8 +416,8 @@ describe("addMember", () => {
     });
   });
 
-  it("should add a named member", () => {
-    addMember({
+  it("should add a named member", async () => {
+    await addMember({
       name: "Jane Doe",
       role: "QA Engineer",
       level: "Senior",
@@ -430,8 +430,8 @@ describe("addMember", () => {
     expect(roster.some((f) => f.includes("jane_doe"))).toBe(true);
   });
 
-  it("should add a member with random name", () => {
-    addMember({
+  it("should add a member with random name", async () => {
+    await addMember({
       role: "DevOps Engineer",
       level: "Mid",
       target: tmp,
@@ -552,8 +552,8 @@ describe("randomizeMember", () => {
     memberName = extractField(content, "Name") ?? "";
   });
 
-  it("should archive old and create new member", () => {
-    randomizeMember({ name: memberName, target: tmp });
+  it("should archive old and create new member", async () => {
+    await randomizeMember({ name: memberName, target: tmp });
     const rosterDir = join(tmp, ".claude", "team", "roster");
     const active = readdirSync(rosterDir).filter(
       (f) => f.endsWith(".md") && !f.startsWith("_departed_"),
@@ -624,7 +624,7 @@ describe("end-to-end lifecycle", () => {
     });
 
     // 2. Add member
-    addMember({
+    await addMember({
       name: "E2E Tester",
       role: "QA Engineer",
       level: "Senior",
@@ -703,11 +703,11 @@ describe("error paths", () => {
     rmSync(tmp, { recursive: true });
   });
 
-  it("addMember should exit(1) when no roster dir", () => {
+  it("addMember should exit(1) when no roster dir", async () => {
     const tmp = mkdtempSync(join(tmpdir(), "test-noroster-"));
-    expect(() =>
+    await expect(
       addMember({ name: "Test", role: "Eng", level: "Sr", target: tmp }),
-    ).toThrow("process.exit(1)");
+    ).rejects.toThrow("process.exit(1)");
     rmSync(tmp, { recursive: true });
   });
 
@@ -758,9 +758,9 @@ describe("error paths", () => {
       target: tmp,
       interactive: false,
     });
-    expect(() =>
+    await expect(
       randomizeMember({ name: "Nobody", target: tmp }),
-    ).toThrow("process.exit(1)");
+    ).rejects.toThrow("process.exit(1)");
     rmSync(tmp, { recursive: true });
   });
 

--- a/python/src/real_team/cli.py
+++ b/python/src/real_team/cli.py
@@ -152,6 +152,8 @@ def add_member(
     role: str = typer.Option(..., help="Role (e.g., 'Software Engineer')"),
     level: str = typer.Option("Senior", help="Level"),
     target: str = typer.Option(".", help="Target directory"),
+    ai_personas: bool = typer.Option(False, help="Use Claude API to generate rich persona"),
+    seed: int = typer.Option(None, help="Seed for reproducible AI persona generation"),
 ) -> None:
     """Add a team member to the roster."""
     from .bootstrap import generate_name, make_email
@@ -163,6 +165,31 @@ def add_member(
     if not roster_dir.exists():
         console.print("[red]Error:[/red] No roster directory found. Run `2real-team init` first.")
         raise typer.Exit(1)
+
+    personality = "To be defined."
+
+    # Try AI persona generation if requested
+    if ai_personas:
+        from .personas import generate_personas
+        from .presets import get_preset
+
+        # Use a minimal preset context for single-member generation
+        try:
+            preset_config = get_preset("library")
+        except ValueError:
+            preset_config = None
+
+        if preset_config:
+            roles = [{"role": role, "level": level}]
+            personas = generate_personas(preset_config, roles, 1, seed)
+            if personas:
+                persona = personas[0]
+                if not name:
+                    name = persona["name"]
+                personality = persona["personality"]
+                console.print("[dim]AI persona generated successfully[/dim]")
+            else:
+                console.print("[dim]Using local name pool (AI generation unavailable)[/dim]")
 
     if not name:
         used = {p.stem.replace("_", " ") for p in roster_dir.glob("*.md")}
@@ -178,7 +205,7 @@ def add_member(
         "role": role,
         "level": level,
         "email": email,
-        "personality": "To be defined.",
+        "personality": personality,
     }
 
     card = render_template("roster-card.md.mustache", context)
@@ -254,6 +281,8 @@ def update_member(
 def randomize_member(
     name: str = typer.Argument(..., help="Member name to regenerate"),
     target: str = typer.Option(".", help="Target directory"),
+    ai_personas: bool = typer.Option(False, help="Use Claude API to generate rich persona"),
+    seed: int = typer.Option(None, help="Seed for reproducible AI persona generation"),
 ) -> None:
     """Regenerate a team member's name, background, and personality."""
     import random
@@ -283,10 +312,41 @@ def randomize_member(
     archived = old_path.parent / f"_departed_{old_path.name}"
     old_path.rename(archived)
 
-    # Generate new identity
-    used = {p.stem.replace("_", " ") for p in roster_dir.glob("*.md")}
-    first, last = generate_name(used)
-    new_name = f"{first} {last}"
+    # Try AI persona generation if requested
+    new_name = None
+    personality = None
+    if ai_personas:
+        from .personas import generate_personas
+        from .presets import get_preset
+
+        try:
+            preset_config = get_preset("library")
+        except ValueError:
+            preset_config = None
+
+        if preset_config:
+            roles = [{"role": role, "level": level}]
+            personas = generate_personas(preset_config, roles, 1, seed)
+            if personas:
+                persona = personas[0]
+                new_name = persona["name"]
+                personality = persona["personality"]
+                console.print("[dim]AI persona generated successfully[/dim]")
+            else:
+                console.print("[dim]Using local name pool (AI generation unavailable)[/dim]")
+
+    if not new_name:
+        # Generate new identity from local pool
+        used = {p.stem.replace("_", " ") for p in roster_dir.glob("*.md")}
+        first, last = generate_name(used)
+        new_name = f"{first} {last}"
+
+    if not personality:
+        personality = random.choice(COMMUNICATION_STYLES)
+
+    parts = new_name.split(" ", 1)
+    first = parts[0]
+    last = parts[1] if len(parts) > 1 else ""
     email = make_email(first, last)
 
     context = {
@@ -294,7 +354,7 @@ def randomize_member(
         "role": role,
         "level": level,
         "email": email,
-        "personality": random.choice(COMMUNICATION_STYLES),
+        "personality": personality,
     }
 
     card = render_template("roster-card.md.mustache", context)


### PR DESCRIPTION
## Summary
- Add `--ai-personas` and `--seed` flags to `add-member` and `randomize-member` commands in both Python and Node CLIs
- When enabled, calls Claude API to generate culturally diverse personas with name, personality, and expertise
- Graceful fallback to local name pool when API is unavailable
- Updated Node tests for now-async addMember/randomizeMember functions

## Related Issues
Closes #13

## Review Checklist
- [ ] Peer reviewed by another engineer
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Nia Rossi <Nia.Rossi@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>