### PR TITLE
chore: PyPI first publish v0.2.0 (#18)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+*.egg
+dist/
+build/
+.eggs/
+.coverage
+.pytest_cache/
+.mypy_cache/
+*.whl
+*.tar.gz
+
+# Node
+node_modules/
+coverage/
+*.tgz
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Build artifacts
+python/dist/
+python/build/
+node/dist/
+node/coverage/
+node/presets/
+node/skills/
+node/templates/


### PR DESCRIPTION
## Summary
- Added `.gitignore` for Python/Node build artifacts
- Built sdist + wheel for `2real-team-framework` v0.2.0
- Published to PyPI: https://pypi.org/project/2real-team-framework/0.2.0/
- Verified install from wheel in clean virtualenv: `2real-team --help` and `init --preset library` both succeed

## Related Issues
Closes #18

## Review Checklist
- [ ] Peer reviewed by another engineer
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Paloma Gupta <Paloma.Gupta@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>