### PR TITLE
fix: npm packaging fixes for first publish (#19)

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/parametrization/2real-team-framework.git"
+    "url": "git+https://github.com/parametrization/2real-team-framework.git"
   },
   "bugs": {
     "url": "https://github.com/parametrization/2real-team-framework/issues"
@@ -30,7 +30,7 @@
     "node": ">=18"
   },
   "bin": {
-    "2real-team": "./dist/index.js"
+    "2real-team": "dist/index.js"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
## Summary
- Fixed bin path in package.json (removed `./` prefix that npm auto-corrects)
- Normalized repository URL per npm standards
- Built tarball and verified: `2real-team --help` and `init --preset library` work from tarball install
- **Blocker**: npm publish returns 403 Forbidden — the configured npm token does not have publish scope. Needs a publish-scoped automation token or manual publish via `npm login`.

## Related Issues
Relates to #19

## Review Checklist
- [ ] Peer reviewed by another engineer
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Ibrahim El-Amin <Ibrahim.El-Amin@gmail.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>