### PR TITLE
fix(ontology): skip committed vendored/build dirs in generator discovery

### DIFF
--- a/framework/assets/lib/ontology_gen/generate.py
+++ b/framework/assets/lib/ontology_gen/generate.py
@@ -5,7 +5,9 @@
 
 1. discover supported source files (git-tracked + untracked-not-ignored when the root
    is a git repo — so generated output reflects the working tree and respects
-   ``.gitignore``; an ``os.walk`` fallback with a default ignore set otherwise),
+   ``.gitignore``; an ``os.walk`` fallback with a default ignore set otherwise).
+   Well-known vendored/build dirs (``node_modules``/``dist``/``build``/``coverage``)
+   are skipped in both modes — even when committed — so they don't flood the index,
 2. dispatch each to its language extractor (a single unparseable file degrades to a
    bare file node instead of aborting the run),
 3. assemble the :class:`CodeGraph` and render ``llms.txt``,
@@ -50,6 +52,10 @@ _IGNORE_DIRS = frozenset(
 )
 # Always skipped even under git discovery (scratch checkouts of other branches).
 _ALWAYS_SKIP_PREFIXES = (".claude/worktrees/",)
+# Vendored deps / build output — skipped in BOTH discovery modes, even when committed.
+# git ls-files trusts tracked files, so repos that commit node_modules/dist/coverage would
+# otherwise flood the index with thousands of vendored/generated files.
+_ALWAYS_SKIP_DIRS = frozenset({"node_modules", "dist", "build", "coverage"})
 
 
 def _git_listed_files(repo_root: Path) -> list[str] | None:
@@ -86,6 +92,9 @@ def discover(repo_root: Path) -> list[str]:
     out: list[str] = []
     for rel in candidates:
         if rel.startswith(_ALWAYS_SKIP_PREFIXES):
+            continue
+        # Exclude vendored/build dirs at any depth, even when git-tracked.
+        if any(part in _ALWAYS_SKIP_DIRS for part in rel.split("/")[:-1]):
             continue
         if rel.endswith(_SUPPORTED):
             out.append(rel)

--- a/framework/tests/test_ontology_gen.py
+++ b/framework/tests/test_ontology_gen.py
@@ -48,6 +48,24 @@ def test_generate_emits_artifacts_and_counts(tmp_path: Path) -> None:
     assert "noorinalabs" not in llms and "#855" not in llms
 
 
+def test_generate_skips_committed_vendored_dirs(tmp_path: Path) -> None:
+    _git_init(tmp_path)
+    (tmp_path / "app.py").write_text("def main():\n    return 0\n")
+    # Vendored deps / build output that the repo commits (git-tracked, not gitignored).
+    for vendored in ("node_modules", "dist", "build", "coverage"):
+        d = tmp_path / "node" / vendored / "pkg"
+        d.mkdir(parents=True)
+        (d / "index.js").write_text("module.exports = 1;\n")
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+
+    counts = generate(tmp_path, tmp_path / "out", "demo")
+
+    assert counts["files"] == 1  # only app.py — every vendored/build file skipped
+    llms = (tmp_path / "out" / "llms.txt").read_text()
+    assert "## app.py [python]" in llms
+    assert "node_modules" not in llms and "/dist/" not in llms
+
+
 def test_generate_import_edge_resolves(tmp_path: Path) -> None:
     _git_init(tmp_path)
     (tmp_path / "a.py").write_text("import b\n")


### PR DESCRIPTION
## Summary
Surfaced while dogfooding the ontology system (PR #42) on this repo: `ontology_gen` produced a **3311-file / 49k-node / 18MB** structural index — ~3092 files were committed `node/node_modules`, `node/dist`, `node/coverage`.

`generate.discover()` uses `git ls-files`, trusting tracked files; the `_IGNORE_DIRS` set only applied to the non-git `os.walk` fallback. So **committed** vendored/build dirs flooded the index.

## Change
- Add `_ALWAYS_SKIP_DIRS = {node_modules, dist, build, coverage}`, filtered in **both** discovery modes at any depth — even when files are git-tracked.
- Update module docstring.
- New test `test_generate_skips_committed_vendored_dirs` (git-tracked vendored files excluded; real source retained).

## Result
Indexing this repo: **228 files / 4.7k nodes / 2.7MB** (was 3311 / 49k / 18MB).

## Tests
`framework/tests/test_ontology_gen.py` — 9 passed; `ruff check` clean.

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)