### PR TITLE
chore(repo): untrack stray top-level node_modules artifact

### DIFF
--- a/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
+++ b/node_modules/.vite/vitest/da39a3ee5e6b4b0d3255bfef95601890afd80709/results.json
@@ -1,1 +1,0 @@
-{"version":"4.1.0","results":[[":node/tests/cli.test.ts",{"duration":43.07388499999999,"failed":false}]]}


### PR DESCRIPTION
Follow-up to #45 / PR #46. That pass untracked `node/node_modules` but missed the **top-level** `node_modules/.vite/vitest/.../results.json` vitest cache file. Removed from the index — now covered by the merged `node_modules/` ignore rule.

Working tree copy kept; pure untracking, no source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)