### PR TITLE
fix(ci): publish to PyPI via API token instead of OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -6,12 +6,10 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: pypi
     steps:
       - uses: actions/checkout@v4
 
@@ -34,3 +32,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: python/dist/
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
The v0.3.0 release publish failed with **`invalid-publisher`** — the workflow used OIDC trusted publishing (`environment: pypi` + `id-token: write`), but PyPI has no matching trusted publisher (0.2.0 was published manually with the token, not via OIDC).

**Fix:** use the existing `PYPI_API_TOKEN` secret — pass it as `password` to `gh-action-pypi-publish`; drop `environment: pypi` and `id-token: write` (not needed for token auth).

> Sequencing: a workflow re-run uses the file **as of the tag**, so this must be in the tagged commit. After merge, `v0.3.0` will be deleted + re-cut from `main` so the corrected workflow runs.

Refs #18
🤖 Generated with [Claude Code](https://claude.com/claude-code)