### PR TITLE
ci: publish to PyPI and npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -18,6 +18,11 @@ jobs:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
 
+      # OIDC trusted publishing requires npm >= 11.5.1, newer than the npm
+      # bundled with Node 20. Upgrade before publishing.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         working-directory: node
         run: npm install
@@ -26,8 +31,9 @@ jobs:
         working-directory: node
         run: npm run build
 
+      # No NODE_AUTH_TOKEN: authentication is via OIDC trusted publishing
+      # (configured on npmjs.com for this repo + workflow). Provenance is
+      # generated automatically from the GitHub Actions OIDC identity.
       - name: Publish
         working-directory: node
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -6,10 +6,12 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: pypi
     steps:
       - uses: actions/checkout@v4
 
@@ -32,4 +34,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: python/dist/
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary

Switches both release-publish workflows to **OIDC trusted publishing**, removing reliance on long-lived tokens — the thing that silently broke the v0.3.0 release (PyPI trusted publisher unconfigured; `NPM_TOKEN` expired end of May).

Trusted publishers are now configured on **both** registries for this repo, so this PR makes the workflows use them.

### Changes
- **`publish-pypi.yml`** — reverts PR #55's API-token workaround back to OIDC: restores `id-token: write` + `environment: pypi`, drops the `password` input.
- **`publish-npm.yml`** — drops `NODE_AUTH_TOKEN`; authenticates via OIDC. Adds an `npm install -g npm@latest` step (OIDC needs npm ≥ 11.5.1, newer than Node 20's bundled npm). `id-token: write` already present; provenance is automatic.

### Status of registries
- **PyPI**: trusted publisher configured; **v0.3.0 already re-published via OIDC** ✅
- **npm**: trusted publisher configured; awaiting this workflow + a v0.3.0 re-cut

## Post-merge steps (need owner sign-off)
1. Re-cut the **v0.3.0** release from updated `main` (delete + recreate tag/release) so the npm publish runs the OIDC workflow — a `release` re-run uses the workflow as of the tag.
2. Verify `2real-team-framework@0.3.0` is live on npm with provenance.
3. Remove the now-unused `NPM_TOKEN` (and optionally `PYPI_API_TOKEN`) repo secrets.

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)