### PR TITLE
chore(release): bump version to 0.3.1

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "2real-team-framework",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "2real-team-framework",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.0.0",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "2real-team-framework",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Drop-in AI agent team framework for Claude Code projects",
   "license": "Apache-2.0",
   "type": "module",

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -22,7 +22,7 @@ const program = new Command();
 program
   .name("2real-team")
   .description("AI agent team framework for Claude Code projects")
-  .version("0.3.0");
+  .version("0.3.1");
 
 program
   .command("init")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "2real-team-framework"
-version = "0.3.0"
+version = "0.3.1"
 description = "Drop-in AI agent team framework for Claude Code projects"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.10"

--- a/python/src/real_team/__init__.py
+++ b/python/src/real_team/__init__.py
@@ -1,3 +1,3 @@
 """2real-team-framework — Drop-in AI agent team framework for Claude Code projects."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"


### PR DESCRIPTION
## Summary

Version bump **0.3.0 → 0.3.1** to cut a fresh release that publishes to both registries via the new **OIDC trusted publishing** workflows (#57).

Why a bump instead of re-cutting v0.3.0: v0.3.0 already published to PyPI but never reached npm (the `NPM_TOKEN` expired end of May). Re-cutting would re-fire the PyPI publish over an existing version (a duplicate error). Bumping to 0.3.1 lets **both** registries publish cleanly and green.

- **PyPI:** 0.3.0 → 0.3.1 (fresh, via OIDC)
- **npm:** 0.2.0 → 0.3.1 (first publish via OIDC; skips 0.3.0)

### Files
- `python/pyproject.toml`, `python/src/real_team/__init__.py`
- `node/package.json`, `node/package-lock.json`, `node/src/index.ts` (`--version` output)

## After merge (needs owner sign-off)
1. Create GitHub Release **v0.3.1** from `main` → fires both publish workflows via OIDC.
2. Verify `2real-team-framework@0.3.1` is live on PyPI and npm (npm with provenance).
3. Remove the now-unused `NPM_TOKEN` / `PYPI_API_TOKEN` repo secrets.

Refs #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)