### PR TITLE
docs(readme): document runtime skills; bump to 0.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ This creates the following in your project:
     review-pr.md         # PR review using charter format
     plan-phase.md        # Phase planning skill
     close-stale-issues.md
+    # with --with-hooks, also: session-start, handoff,
+    # wave-lifecycle, ontology-librarian, ontology-rebuild
   CLAUDE.md              # Team section for your project's CLAUDE.md
 ```
 
@@ -185,7 +187,12 @@ All presets include 6 skills: `retro`, `wave-start`, `wave-end`, `review-pr`, `p
 
 ## Skills
 
-Skills are Claude Code slash commands installed in `.claude/skills/`. After bootstrapping:
+Skills are Claude Code slash commands installed in `.claude/skills/`. The framework ships two
+tiers.
+
+### Team-workflow skills
+
+Templated per project and installed by every preset (the 6 listed in [Presets](#presets)):
 
 - `/retro` — Run a wave retrospective (collect PRs, issues, CI failures, write report)
 - `/wave-start` — Initialize a new deployments branch and clean worktrees
@@ -193,6 +200,23 @@ Skills are Claude Code slash commands installed in `.claude/skills/`. After boot
 - `/review-pr <number>` — Review a PR using the charter's structured format
 - `/plan-phase <number>` — Decompose a phase into issues with acceptance criteria
 - `/close-stale-issues` — Audit and close issues resolved by merged PRs
+
+### Runtime skills
+
+Config-driven and fail-open, installed alongside the hooks/libs runtime with
+`2real-team init --with-hooks`. They read `.claude/framework.config.json` and skip cleanly when
+a subsystem isn't present:
+
+- `/session-start` — Run first in every session: loads memory, confirms the team, reads the
+  last handoff, and reports git/PR/CI + lifecycle + ontology status in one table
+- `/handoff` — Write a session handoff note to project memory (git state, open PRs/issues,
+  lifecycle/wave status, and the context the next session needs to resume)
+- `/wave-lifecycle` — Drive one wave through its full lifecycle (allocate → start → scope →
+  kickoff → work → wrapup → retro) on the deterministic `lifecycle.py` engine
+- `/ontology-librarian [query]` — Read-only ontology reference: checks staleness of both the
+  hand-curated semantic overlay and the generated structural index, and retrieves context
+- `/ontology-rebuild [scope]` — Reconcile the semantic overlay: scan dirty checksums, update
+  ontology files and auto-updatable docs from code, mark resolved
 
 ## How it works with Claude Code
 

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "2real-team-framework",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "2real-team-framework",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.0.0",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "2real-team-framework",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Drop-in AI agent team framework for Claude Code projects",
   "license": "Apache-2.0",
   "type": "module",

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -22,7 +22,7 @@ const program = new Command();
 program
   .name("2real-team")
   .description("AI agent team framework for Claude Code projects")
-  .version("0.3.1");
+  .version("0.3.2");
 
 program
   .command("init")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "2real-team-framework"
-version = "0.3.1"
+version = "0.3.2"
 description = "Drop-in AI agent team framework for Claude Code projects"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.10"

--- a/python/src/real_team/__init__.py
+++ b/python/src/real_team/__init__.py
@@ -1,3 +1,3 @@
 """2real-team-framework — Drop-in AI agent team framework for Claude Code projects."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"


### PR DESCRIPTION
## Why

The PyPI/npm project description is rendered from `README.md`, whose **Skills** section listed
only the 6 preset/templated skills. The 5 config-driven **runtime skills** installed with
`2real-team init --with-hooks` were undocumented, so the published description undersold the
framework.

## What

- **README → Skills:** split into two tiers — *Team-workflow skills* (the 6 preset skills) and
  *Runtime skills* (`session-start`, `handoff`, `wave-lifecycle`, `ontology-librarian`,
  `ontology-rebuild`), each with a one-line description.
- **README → install file-tree:** note the extra skills that land with `--with-hooks`.
- **Version bump 0.3.1 → 0.3.2** across `pyproject.toml`, `__init__.py`, `package.json`,
  `index.ts`, `package-lock.json`.

## Why the bump

A package's long-description metadata is baked per-release — the live PyPI/npm page only
refreshes when a new version publishes. So shipping the doc fix requires a new version.

## Effect

On merge → release `v0.3.2`, the OIDC publish workflows push 0.3.2 to both registries and the
refreshed description goes live. No code/runtime behavior changes.
