### PR TITLE
feat(bootstrap): write CLAUDE.md at project root with backup-on-conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Or specify everything up front:
 This creates the following in your project:
 
 ```
+CLAUDE.md                # Team section, written at the project root
+                         # (an existing CLAUDE.md is preserved as CLAUDE.md.bak
+                         #  for you to reconcile)
 .claude/
   team/
     charter.md           # Team rules, org chart, workflows
@@ -78,7 +81,6 @@ This creates the following in your project:
     close-stale-issues.md
     # with --with-hooks, also: session-start, handoff,
     # wave-lifecycle, ontology-librarian, ontology-rebuild
-  CLAUDE.md              # Team section for your project's CLAUDE.md
 ```
 
 ## Commands

--- a/node/src/bootstrap.ts
+++ b/node/src/bootstrap.ts
@@ -3,7 +3,7 @@
  */
 
 import { readFileSync, mkdirSync, writeFileSync, existsSync, readdirSync, renameSync } from "node:fs";
-import { resolve, join, dirname } from "node:path";
+import { resolve, join, dirname, basename } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 import Mustache from "mustache";
@@ -203,6 +203,21 @@ export function loadYamlConfig(configPath: string): YamlConfig {
   return cfg as unknown as YamlConfig;
 }
 
+/**
+ * Return a non-clobbering backup path for `filePath`. Prefers `<name>.bak`; if
+ * that exists, falls back to `<name>.bak.1`, `<name>.bak.2`, … so an existing
+ * backup is never overwritten.
+ */
+function nextBackupPath(filePath: string): string {
+  let backup = `${filePath}.bak`;
+  let counter = 1;
+  while (existsSync(backup)) {
+    backup = `${filePath}.bak.${counter}`;
+    counter += 1;
+  }
+  return backup;
+}
+
 export async function bootstrap(opts: BootstrapOptions): Promise<void> {
   let target = resolve(opts.target);
   let presetName = opts.preset;
@@ -372,10 +387,23 @@ export async function bootstrap(opts: BootstrapOptions): Promise<void> {
   writeFileSync(join(teamDir, "feedback_log.md"), feedback);
   created.push(".claude/team/feedback_log.md");
 
-  // CLAUDE.md
+  // CLAUDE.md at the PROJECT ROOT. Claude Code loads the root CLAUDE.md by
+  // convention; a copy under .claude/ is easily missed. The framework writes
+  // only the team section, so if the project already has a root CLAUDE.md we
+  // preserve it as a .bak (non-clobbering) and ask the user to reconcile.
   const claudeMd = renderTemplate("CLAUDE.md.mustache", context);
-  writeFileSync(join(target, ".claude", "CLAUDE.md"), claudeMd);
-  created.push(".claude/CLAUDE.md");
+  const claudePath = join(target, "CLAUDE.md");
+  if (existsSync(claudePath)) {
+    const backupPath = nextBackupPath(claudePath);
+    renameSync(claudePath, backupPath);
+    created.push(basename(backupPath));
+    console.warn(
+      `\nExisting CLAUDE.md preserved as ${basename(backupPath)}. The framework wrote its team ` +
+        `section to CLAUDE.md — reconcile your original content from ${basename(backupPath)} into it.`,
+    );
+  }
+  writeFileSync(claudePath, claudeMd);
+  created.push("CLAUDE.md");
 
   // Skills
   for (const skill of skillsList) {

--- a/node/tests/cli.test.ts
+++ b/node/tests/cli.test.ts
@@ -358,12 +358,46 @@ describe("bootstrap", () => {
     expect(existsSync(join(tmp, ".claude", "team", "feedback_log.md"))).toBe(
       true,
     );
-    expect(existsSync(join(tmp, ".claude", "CLAUDE.md"))).toBe(true);
+    // CLAUDE.md lands at the project root, not under .claude/.
+    expect(existsSync(join(tmp, "CLAUDE.md"))).toBe(true);
+    expect(existsSync(join(tmp, ".claude", "CLAUDE.md"))).toBe(false);
 
     const roster = readdirSync(join(tmp, ".claude", "team", "roster")).filter(
       (f) => f.endsWith(".md"),
     );
     expect(roster.length).toBe(3);
+  });
+
+  it("should back up an existing root CLAUDE.md (non-clobbering)", async () => {
+    writeFileSync(join(tmp, "CLAUDE.md"), "ORIGINAL USER CONTENT");
+    await bootstrap({
+      preset: "library",
+      teamSize: 3,
+      projectName: "backup-test",
+      target: tmp,
+      interactive: false,
+    });
+    // Original preserved in .bak; framework content now at root CLAUDE.md.
+    expect(readFileSync(join(tmp, "CLAUDE.md.bak"), "utf8")).toBe(
+      "ORIGINAL USER CONTENT",
+    );
+    expect(readFileSync(join(tmp, "CLAUDE.md"), "utf8")).not.toBe(
+      "ORIGINAL USER CONTENT",
+    );
+  });
+
+  it("should not clobber a pre-existing CLAUDE.md.bak", async () => {
+    writeFileSync(join(tmp, "CLAUDE.md"), "CURRENT");
+    writeFileSync(join(tmp, "CLAUDE.md.bak"), "OLDER BACKUP");
+    await bootstrap({
+      preset: "library",
+      teamSize: 3,
+      projectName: "backup2-test",
+      target: tmp,
+      interactive: false,
+    });
+    expect(readFileSync(join(tmp, "CLAUDE.md.bak"), "utf8")).toBe("OLDER BACKUP");
+    expect(readFileSync(join(tmp, "CLAUDE.md.bak.1"), "utf8")).toBe("CURRENT");
   });
 
   it("should create skills", async () => {

--- a/python/src/real_team/bootstrap.py
+++ b/python/src/real_team/bootstrap.py
@@ -152,6 +152,20 @@ def _assign_reports_to(members: list[TeamMember]) -> None:
             member.reports_to = tech_lead.name if tech_lead else (manager.name if manager else "")
 
 
+def _next_backup_path(path: Path) -> Path:
+    """Return a non-clobbering backup path for ``path``.
+
+    Prefers ``<name>.bak``; if that already exists, falls back to ``<name>.bak.1``,
+    ``<name>.bak.2``, … so an existing backup is never overwritten.
+    """
+    backup = path.with_name(path.name + ".bak")
+    counter = 1
+    while backup.exists():
+        backup = path.with_name(f"{path.name}.bak.{counter}")
+        counter += 1
+    return backup
+
+
 def bootstrap_project(
     target_dir: Path,
     config: TeamConfig,
@@ -201,9 +215,21 @@ def bootstrap_project(
     feedback_path.write_text(feedback)
     created_files.append(str(feedback_path.relative_to(target_dir)))
 
-    # Render CLAUDE.md
+    # Render CLAUDE.md at the PROJECT ROOT. Claude Code loads the root CLAUDE.md
+    # by convention; a copy under .claude/ is easily missed. The framework writes
+    # only the team section, so if the project already has a root CLAUDE.md we
+    # preserve it as a .bak (non-clobbering) and ask the user to reconcile.
     claude_md = render_template("CLAUDE.md.mustache", context)
-    claude_path = target_dir / ".claude" / "CLAUDE.md"
+    claude_path = target_dir / "CLAUDE.md"
+    if claude_path.exists():
+        backup_path = _next_backup_path(claude_path)
+        claude_path.rename(backup_path)
+        created_files.append(str(backup_path.relative_to(target_dir)))
+        console.print(
+            f"\n[yellow]Existing CLAUDE.md preserved as {backup_path.name}.[/yellow] "
+            "The framework wrote its team section to CLAUDE.md — reconcile your original "
+            f"content from {backup_path.name} into it."
+        )
     claude_path.write_text(claude_md)
     created_files.append(str(claude_path.relative_to(target_dir)))
 

--- a/python/src/real_team/cli.py
+++ b/python/src/real_team/cli.py
@@ -178,7 +178,7 @@ def init(
     console.print("Next steps:")
     console.print("  1. Review .claude/team/charter.md")
     console.print("  2. Customize roster cards in .claude/team/roster/")
-    console.print("  3. Add team section to your CLAUDE.md")
+    console.print("  3. Review root CLAUDE.md (any prior CLAUDE.md was kept as .bak)")
     if with_hooks:
         console.print(
             "  4. Review .claude/framework.config.json + restart Claude Code so hooks load."

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1057,7 +1057,55 @@ class TestBootstrapProject:
         assert any("charter.md" in f for f in created)
         assert any("trust_matrix.md" in f for f in created)
         assert any("feedback_log.md" in f for f in created)
-        assert any("CLAUDE.md" in f for f in created)
+        assert "CLAUDE.md" in created
+
+    def test_claude_md_written_at_project_root(self, tmp_path: Path):
+        """CLAUDE.md lands at the project root, not under .claude/."""
+        preset = get_preset("library")
+        config = TeamConfig(
+            project_name="root-test",
+            preset="library",
+            team_members=generate_team(preset, 3),
+            skills=[],
+        )
+        bootstrap_project(tmp_path, config)
+        assert (tmp_path / "CLAUDE.md").is_file()
+        assert not (tmp_path / ".claude" / "CLAUDE.md").exists()
+
+    def test_existing_claude_md_backed_up(self, tmp_path: Path):
+        """An existing root CLAUDE.md is preserved as .bak (non-clobbering)."""
+        preset = get_preset("library")
+        config = TeamConfig(
+            project_name="backup-test",
+            preset="library",
+            team_members=generate_team(preset, 3),
+            skills=[],
+        )
+        (tmp_path / "CLAUDE.md").write_text("ORIGINAL USER CONTENT")
+        created = bootstrap_project(tmp_path, config)
+
+        backup = tmp_path / "CLAUDE.md.bak"
+        assert backup.is_file()
+        assert backup.read_text() == "ORIGINAL USER CONTENT"
+        # Framework content replaced the root file; original is in the backup.
+        assert (tmp_path / "CLAUDE.md").read_text() != "ORIGINAL USER CONTENT"
+        assert "CLAUDE.md.bak" in created
+
+    def test_existing_backup_not_clobbered(self, tmp_path: Path):
+        """A pre-existing .bak is never overwritten; the next free suffix is used."""
+        preset = get_preset("library")
+        config = TeamConfig(
+            project_name="backup2-test",
+            preset="library",
+            team_members=generate_team(preset, 3),
+            skills=[],
+        )
+        (tmp_path / "CLAUDE.md").write_text("CURRENT")
+        (tmp_path / "CLAUDE.md.bak").write_text("OLDER BACKUP")
+        bootstrap_project(tmp_path, config)
+
+        assert (tmp_path / "CLAUDE.md.bak").read_text() == "OLDER BACKUP"
+        assert (tmp_path / "CLAUDE.md.bak.1").read_text() == "CURRENT"
 
     def test_creates_skills(self, tmp_path: Path):
         preset = get_preset("library")


### PR DESCRIPTION
Closes #60.

## Why

`2real-team init` wrote the rendered team-section `CLAUDE.md` to `.claude/CLAUDE.md`. Claude
Code loads the **root** `CLAUDE.md` by convention, so the team section was easily missed.

## What

Both bootstraps now write `CLAUDE.md` to the **project root**:

- If no root `CLAUDE.md` exists → write it there.
- If one already exists → preserve it as `CLAUDE.md.bak` (**non-clobbering**: falls back to
  `.bak.1`, `.bak.2`, … so an existing backup is never overwritten), then write the framework's
  team section and **warn the user to reconcile** (the framework writes only the team section,
  so the user's original content is in the backup).

### Changes
- `python/src/real_team/bootstrap.py` — root path, `_next_backup_path` helper, reconcile warning.
- `node/src/bootstrap.ts` — parity (`nextBackupPath` helper, `console.warn`).
- `python/src/real_team/cli.py` — next-steps message points at root `CLAUDE.md`.
- `python/tests/test_cli.py`, `node/tests/cli.test.ts` — assert root location + non-clobbering
  backup behavior in both languages.
- `README.md` — install file-tree shows `CLAUDE.md` at root.

## Tests
- Python: 106 passed (3 new), `ruff check` clean on `src/` and `framework/`.
- Node: 94 passed (2 new), `tsc` build clean.

## Note (follow-up, not in this PR)
This change is about **install behavior**. This repo's own project instructions still live at
`.claude/CLAUDE.md`; whether to dogfood the new root convention here is a separate decision.
