### PR TITLE
feat(install): ontology setup working on installation (#66)

### DIFF
--- a/framework/install/bootstrap.py
+++ b/framework/install/bootstrap.py
@@ -337,6 +337,48 @@ def install_overlay_template(
     return report
 
 
+def generate_structural(
+    target_root: Path, ontology_rel: str, cfg: dict, *, force: bool, dry_run: bool
+) -> str:
+    """Run the structural generator against the TARGET repo. Fail-open; returns a status line.
+
+    Reuses the same ``ontology_gen.refresh`` path the SessionStart hook uses, so a fresh
+    install ends with ``<ontology>/structural/code-graph.json`` + ``llms.txt`` on disk
+    immediately (not lazily on the next session). Generation runs against ``target_root``
+    (never the framework checkout). Any failure degrades to a warning string — an odd or
+    empty target must never abort the install. Deterministic + staleness-guarded, so
+    re-running is safe (a fresh index is left untouched).
+    """
+    if dry_run:
+        return "would generate (code-graph.json + llms.txt)"
+    lib_dir = _ASSETS / "lib"
+    if str(lib_dir) not in sys.path:
+        sys.path.insert(0, str(lib_dir))
+    try:
+        from ontology_gen.refresh import refresh
+    except ImportError as e:
+        return f"SKIPPED (generator unavailable: {e})"
+    project = cfg.get("project", {}) if isinstance(cfg.get("project"), dict) else {}
+    model = project.get("model") or "single-repo"
+    name = project.get("name") or target_root.name
+    try:
+        result = refresh(
+            target_root, ontology_path=ontology_rel, repo_name=name, model=model, force=force
+        )
+    except Exception as e:  # noqa: BLE001 — fail-open by contract: install must continue.
+        return f"SKIPPED (generation failed: {e}; install continues)"
+    if not result.get("regenerated"):
+        return "fresh (already current)"
+    msg = (
+        f"generated ({result.get('files', 0)} files / "
+        f"{result.get('nodes', 0)} nodes / {result.get('edges', 0)} edges)"
+    )
+    agg = result.get("aggregate")
+    if agg:
+        msg += f"; cross-repo {agg.get('nodes', 0)} nodes across {agg.get('repos', 0)} repo(s)"
+    return msg
+
+
 # ---------------------------------------------------------------- main
 
 
@@ -354,7 +396,7 @@ def main() -> int:
     ap.add_argument("--no-team", action="store_true", help="Skip roster generation (install hooks only)")
     ap.add_argument("--team-size", type=int, help="Target headcount for the generated roster")
     ap.add_argument("--no-enforce-identity", action="store_true", help="Generate the roster but do NOT enable the commit-identity gate")
-    ap.add_argument("--with-ontology", action="store_true", help="Lay down the seed semantic-overlay template (activates the ontology hooks)")
+    ap.add_argument("--with-ontology", action="store_true", help="Lay down the seed semantic-overlay template AND generate the structural index (activates the ontology hooks)")
     ap.add_argument("--force", action="store_true", help="Overwrite existing files")
     ap.add_argument("--dry-run", action="store_true", help="Print the plan; write nothing")
     args = ap.parse_args()
@@ -432,9 +474,13 @@ def main() -> int:
     settings_status = merge_settings(target_claude, dry_run=args.dry_run)
 
     overlay = None
+    structural_status = None
     if args.with_ontology:
         ontology_rel = cfg.get("paths", {}).get("ontology", "ontology")
         overlay = install_overlay_template(target, ontology_rel, force=args.force, dry_run=args.dry_run)
+        structural_status = generate_structural(
+            target, ontology_rel, cfg, force=args.force, dry_run=args.dry_run
+        )
 
     roster_status = "skipped (--no-team)"
     if team_enabled and roster_plan is not None:
@@ -457,6 +503,8 @@ def main() -> int:
     if overlay is not None:
         laid = overlay["would_copy"] if args.dry_run else overlay["copied"]
         print(f"ontology overlay:  {len(laid)} file(s) {'would be laid' if args.dry_run else 'laid'}; {len(overlay['skipped'])} skipped")
+    if structural_status is not None:
+        print(f"structural index:  {structural_status}")
     print(f"team roster:       {roster_status}")
     if team_enabled and roster_plan is not None and not args.no_enforce_identity:
         print("identity gate:     ENABLED (commits must use -c user.name/-c user.email from the roster)")

--- a/framework/tests/test_bootstrap_smoke.py
+++ b/framework/tests/test_bootstrap_smoke.py
@@ -92,6 +92,57 @@ def test_with_ontology_lays_overlay_template(tmp_path: Path) -> None:
     assert "ontology overlay:" in r2.stdout
 
 
+def test_with_ontology_generates_structural_index(tmp_path: Path) -> None:
+    """A fresh install ends with the GENERATED structural layer on disk immediately."""
+    (tmp_path / "app.py").write_text("def hello():\n    return 'world'\n")
+    r = _install(tmp_path, "--with-ontology")
+    assert r.returncode == 0, r.stderr
+    assert "structural index:  generated" in r.stdout
+
+    structural = tmp_path / "ontology" / "structural"
+    assert (structural / "code-graph.json").is_file()
+    assert (structural / "llms.txt").is_file()
+    graph = json.loads((structural / "code-graph.json").read_text())
+    paths = {n.get("path") for n in graph["nodes"]}
+    assert "app.py" in paths  # generation ran against the TARGET repo
+
+    # Idempotent re-run: index is fresh, regeneration safely skipped, files intact.
+    r2 = _install(tmp_path, "--with-ontology")
+    assert r2.returncode == 0
+    assert "structural index:  fresh" in r2.stdout
+    assert (structural / "code-graph.json").is_file()
+
+
+def test_with_ontology_empty_target_still_valid(tmp_path: Path) -> None:
+    """A target with no parseable sources still gets a valid (minimal) structural layer."""
+    r = _install(tmp_path, "--with-ontology")
+    assert r.returncode == 0, r.stderr
+    graph = json.loads((tmp_path / "ontology" / "structural" / "code-graph.json").read_text())
+    assert "nodes" in graph and "edges" in graph
+    assert (tmp_path / "ontology" / "structural" / "llms.txt").is_file()
+
+
+def test_with_ontology_generation_failure_is_fail_open(tmp_path: Path) -> None:
+    """Generation failure warns and continues — the install itself must not abort."""
+    # A regular FILE where the structural dir should go makes generation blow up.
+    (tmp_path / "ontology").mkdir()
+    (tmp_path / "ontology" / "structural").write_text("not a directory")
+    r = _install(tmp_path, "--with-ontology")
+    assert r.returncode == 0, r.stderr
+    assert "structural index:  SKIPPED" in r.stdout
+    assert "install continues" in r.stdout
+    # The overlay + runtime were still laid down.
+    assert (tmp_path / "ontology" / "domain.yaml").is_file()
+    assert (tmp_path / ".claude" / "hooks" / "dispatcher.py").is_file()
+
+
+def test_with_ontology_dry_run_writes_nothing(tmp_path: Path) -> None:
+    r = _install(tmp_path, "--with-ontology", "--dry-run")
+    assert r.returncode == 0, r.stderr
+    assert "structural index:  would generate" in r.stdout
+    assert not (tmp_path / "ontology").exists()
+
+
 def test_no_verify_blocks(tmp_path: Path) -> None:
     _install(tmp_path)
     r = _fire(tmp_path, "git commit --no-verify -m x")

--- a/python/src/real_team/cli.py
+++ b/python/src/real_team/cli.py
@@ -40,6 +40,14 @@ def init(
     merge_model: str = typer.Option(
         None, help="Default merge model: wave-branch | direct-to-main"
     ),
+    with_ontology: bool = typer.Option(
+        True,
+        "--with-ontology/--no-ontology",
+        help=(
+            "Seed the ontology semantic-overlay template and generate the structural index "
+            "(ontology/structural/) at install time (requires --with-hooks)"
+        ),
+    ),
 ) -> None:
     """Bootstrap a new project with the team framework."""
     target_path = Path(target).resolve()
@@ -157,6 +165,7 @@ def init(
             target_path,
             owner=owner or git_email_prefix or None,
             merge_model=merge_model,
+            with_ontology=with_ontology,
         )
         if proc is None:
             console.print(

--- a/python/src/real_team/framework_install.py
+++ b/python/src/real_team/framework_install.py
@@ -53,6 +53,7 @@ def install_framework(
     shell: str = "bash",
     reviewers: int | None = None,
     merge_model: str | None = None,
+    with_ontology: bool = True,
     dry_run: bool = False,
 ) -> subprocess.CompletedProcess | None:
     """Install the framework runtime into ``target`` via its own bootstrapper.
@@ -79,6 +80,8 @@ def install_framework(
         cmd += ["--reviewers", str(reviewers)]
     if merge_model:
         cmd += ["--merge-model", merge_model]
+    if with_ontology:
+        cmd += ["--with-ontology"]
     if dry_run:
         cmd += ["--dry-run"]
 

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -478,6 +478,55 @@ class TestInitCommand:
         assert not (tmp_path / ".claude" / "framework.config.json").exists()
         assert not (tmp_path / ".claude" / "hooks").exists()
 
+    def test_init_ontology_installed_by_default(self, tmp_path: Path):
+        """Default-ON: init lays the overlay AND the generated structural index."""
+        result = runner.invoke(app, [
+            "init",
+            "--preset", "library",
+            "--team-size", "2",
+            "--project-name", "onto-default",
+            "--target", str(tmp_path),
+            "--no-interactive",
+            "--owner", "acme",
+        ])
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "ontology" / "domain.yaml").is_file()
+        structural = tmp_path / "ontology" / "structural"
+        assert (structural / "code-graph.json").is_file()
+        assert (structural / "llms.txt").is_file()
+        graph = json.loads((structural / "code-graph.json").read_text())
+        assert "nodes" in graph and "edges" in graph
+
+    def test_init_no_ontology_skips_ontology(self, tmp_path: Path):
+        result = runner.invoke(app, [
+            "init",
+            "--preset", "library",
+            "--team-size", "2",
+            "--project-name", "onto-off",
+            "--target", str(tmp_path),
+            "--no-interactive",
+            "--owner", "acme",
+            "--no-ontology",
+        ])
+        assert result.exit_code == 0, result.output
+        # Runtime installed, ontology not.
+        assert (tmp_path / ".claude" / "hooks" / "dispatcher.py").is_file()
+        assert not (tmp_path / "ontology").exists()
+
+    def test_init_no_hooks_skips_ontology_too(self, tmp_path: Path):
+        """Ontology install rides the framework runtime — --no-hooks disables both."""
+        result = runner.invoke(app, [
+            "init",
+            "--preset", "library",
+            "--team-size", "2",
+            "--project-name", "onto-nohooks",
+            "--target", str(tmp_path),
+            "--no-interactive",
+            "--no-hooks",
+        ])
+        assert result.exit_code == 0, result.output
+        assert not (tmp_path / "ontology").exists()
+
     def test_init_missing_preset_noninteractive(self, tmp_path: Path):
         result = runner.invoke(app, [
             "init",
@@ -656,6 +705,41 @@ class TestInitCommand:
             "--no-interactive",
         ])
         assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# framework_install bridge — flag threading
+# ---------------------------------------------------------------------------
+
+
+class TestFrameworkInstallBridge:
+    def _capture_cmd(self, monkeypatch) -> dict:
+        import subprocess
+
+        import real_team.framework_install as fi
+
+        captured: dict = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr(fi.subprocess, "run", fake_run)
+        return captured
+
+    def test_with_ontology_default_passes_flag(self, monkeypatch, tmp_path: Path):
+        from real_team.framework_install import install_framework
+
+        captured = self._capture_cmd(monkeypatch)
+        install_framework(tmp_path)
+        assert "--with-ontology" in captured["cmd"]
+
+    def test_no_ontology_omits_flag(self, monkeypatch, tmp_path: Path):
+        from real_team.framework_install import install_framework
+
+        captured = self._capture_cmd(monkeypatch)
+        install_framework(tmp_path, with_ontology=False)
+        assert "--with-ontology" not in captured["cmd"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #66

## Summary

Makes ontology setup actually work at installation: the structural index is generated during install (not lazily on the next SessionStart), and the Python CLI can finally turn the ontology on/off — default ON.

## Design

**`framework/install/bootstrap.py`** — new `generate_structural()` runs right after `install_overlay_template()` under the existing `--with-ontology` flag. It reuses the exact code path the SessionStart hook uses (`ontology_gen.refresh.refresh()` imported from `framework/assets/lib/`, run against the **target** repo with `project.model`/`project.name` from the built config), so there is zero duplicated generation logic and install-time output is byte-identical to what the refresh hook would later produce. Changes to `main()` are two localized lines (call + report line) to stay out of the way of #64's config work.

- **Fail-open:** any generation failure prints `structural index:  SKIPPED (...; install continues)` and the install exits 0 with overlay + runtime intact.
- **Idempotent:** `refresh()` is staleness-guarded — re-runs report `fresh (already current)`; regen when actually stale is deterministic and safe. `--dry-run` writes nothing (`would generate`). `--force` forces regeneration.
- **Empty targets** still get a valid minimal `code-graph.json` + `llms.txt`.
- **Meta-aware (light touch per #65):** `project.model` is passed through, so a `meta-and-children` root gets the same best-effort cross-repo aggregation the refresh hook does; nothing hardcoded against meta roots.

**`python/src/real_team/cli.py` + `framework_install.py`** — `2real-team init` gains `--with-ontology/--no-ontology` (default **ON**), threaded through `install_framework(with_ontology=...)` which appends `--with-ontology` to the bootstrap subprocess. It rides the runtime bridge, so `--no-hooks` skips it too.

## Test evidence

- `ENVIRONMENT=test python3 -m pytest framework/tests/ -q` → **63 passed** (was 59; +4: generated-index presence & target-source indexing, empty-target minimal layer, fail-open failure path, dry-run)
- `cd python && python -m pytest -q` → **111 passed** (was 106; +5: CLI default-ON e2e, `--no-ontology`, `--no-hooks` skips ontology, bridge flag threading x2)
- `ruff check framework/` and `ruff check python/` → clean
- Manual e2e: bootstrap against a scratch repo → `structural index:  generated (36 files / 313 nodes / 573 edges)`; re-run → `fresh (already current)`; `2real-team init` (module invocation) → `ontology/structural/{code-graph.json,llms.txt}` present immediately.

## Coordination notes

- Kept `bootstrap.py --with-ontology` opt-in at the bootstrap layer (default-ON lives at the CLI layer) so #64's `install.config.yaml` `ontology.enabled` key can take over the default cleanly; `main()` changes are minimal/localized. Base branch had not moved at push time — no rebase needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1sHWTyKtu8DAExDn9DgLS
