### PR TITLE
feat(charter): installable modular team charter template (#69)

### DIFF
--- a/framework/assets/team/charter/agents.md
+++ b/framework/assets/team/charter/agents.md
@@ -1,0 +1,76 @@
+# Agent Naming, Lifecycle & Orchestration
+
+## Agent Naming Convention
+
+**Every spawned agent MUST map to a team roster member** (`{{team_dir}}/roster/`).
+No anonymous functional agents.
+
+- **Naming pattern:** `{firstname}-{lastname}` or `{firstname}-{task-description}`
+  (e.g., `amara-ci-fix`, `kai-issue-audit`).
+- The orchestrator determines the most appropriate roster member for the task
+  BEFORE spawning, based on role fit.
+- **Violations:** functional-only names (e.g., `ci-fixer`, `issue-closer`) are not
+  allowed.
+
+## How to Instantiate the Team
+
+When starting any work session, the orchestrating agent should:
+
+1. Read this charter's modules and the roster files in `{{team_dir}}/roster/`.
+2. Spawn the Manager agent first (with their personality from the roster).
+3. The Manager plans and coordinates; the orchestrator spawns the team members the
+   Manager requests.
+4. All code-writing agents use worktree isolation (see [branching.md](branching.md)).
+5. Coordinate via named agents and direct messages.
+
+## Hub-and-Spoke Orchestration
+
+The orchestrator is the **single point that can create agents**. Spawned agents
+(including the Manager) cannot spawn other agents — when a team member needs another
+agent, they send a **spawn request** back to the orchestrator with full context, and
+the orchestrator honors it. Do not redirect the requesting agent to "do it yourself".
+
+### Orchestrator Working Directory
+
+The orchestrator must **never** have its shell cwd inside an agent worktree, and
+should remain on `{{default_branch}}`. A deleted worktree strands the orchestrator's
+shell; an orchestrator on a feature branch lands housekeeping commits (retro notes,
+trust-matrix updates) on the wrong branch.
+
+## Agent Lifecycle
+
+**Agents are shut down as soon as their work is complete.** The orchestrator:
+
+1. Shuts down implementation agents once their PR is created, pushed, and confirmed.
+2. Monitors active-agent count — if it grows past the roster size, shut down
+   completed agents before spawning new ones.
+3. Runs end-of-session teardown: stop remaining agents, clean up worktrees
+   (see [branching.md § Worktree Cleanup](branching.md)), return to
+   `{{default_branch}}`.
+
+### Wave Retrospective
+
+Every wave gets a retrospective before its agents are shut down: each participant
+contributes what went well / what went poorly / what to change; findings go to
+`{{team_dir}}/feedback_log.md`; trust scores are updated; actionable items become
+charter updates, hooks, or new issues. For every failure, ask: *could a hook have
+prevented this? could a skill have automated it?*
+
+## Agent Reports Are Unverified Until Checked Against Ground Truth
+
+**Treat every agent completion report as a claim, not a fact.** Act on the git/gh
+state, never on the prose. Before acting on a report, run the check that matches
+the claim:
+
+| Agent claims… | Verify with |
+|---------------|-------------|
+| "PR #N is complete / contains files X, Y" | `gh pr diff <N> --name-only` — the diff matches the claimed changes exactly |
+| "Issue #M is folded into PR #N" | the diff carries #M's files **and** the PR body carries `Closes #M` |
+| "Fixed / committed on the branch" | `git -C <worktree> log --oneline <base>..HEAD` — the commit exists on the branch head |
+| "Pushed" / "PR is open" | `git ls-remote origin <branch>` and `gh pr view <N> --json state,headRefOid` — remote tip matches local HEAD |
+| "Started on the task" | `git -C <worktree> status` / `log` shows movement off base |
+
+If a check contradicts the report, **ground truth wins**: re-dispatch, request the
+missing work, or correct the record. A local-only commit or merge is not done —
+hand it back to the implementer to push and verify (see
+[pull-requests.md § Pushed = Done](pull-requests.md)); do not silently finish it.

--- a/framework/assets/team/charter/branching.md
+++ b/framework/assets/team/charter/branching.md
@@ -1,0 +1,76 @@
+# Branching Rules
+
+**Configured merge model: `{{merge_model}}`.** Under `wave-branch`, feature work
+integrates through a shared integration branch per wave and only the wave rollup
+reaches `{{default_branch}}`. Under `direct-to-main`, feature branches PR straight
+into `{{default_branch}}`; the integration-branch sections below then collapse to
+"base = `{{default_branch}}`" and the same feature-branch and worktree rules apply.
+
+## Integration (Wave) Branches
+
+Work is organized into **waves** of parallel tasks. Before starting a wave, create
+an integration branch from the latest `{{default_branch}}`:
+
+```
+{{integration_branch_scheme}}
+```
+
+- **All feature branches for the wave PR into the integration branch** — not into
+  `{{default_branch}}`.
+- At the end of the wave/phase, PR the integration branch into `{{default_branch}}`.
+  **Wait for the project owner to approve that merge** before proceeding.
+
+## Feature Branches
+
+- Branch naming scheme: `{{feature_branch_scheme}}` — the branch carries the team
+  member's identity and the issue number. **No branch may be created without an
+  existing issue** (see [issues.md](issues.md)).
+- All feature branches are created from the **current integration branch** for their
+  wave, pulled fresh:
+  ```bash
+  git fetch origin && git checkout -b <feature-branch> origin/<integration-branch>
+  ```
+- **Branch safety:** before every commit, run `git branch --show-current` and confirm
+  you are on your own branch. Never commit to another member's branch.
+- **Before submitting a PR**, merge the latest integration branch into your feature
+  branch and resolve conflicts:
+  ```bash
+  git fetch origin && git merge origin/<integration-branch>
+  ```
+
+## Worktree Isolation
+
+**Every code-writing agent works in its own git worktree.** The orchestrator creates
+it from the main checkout before spawning:
+
+```bash
+git -C <main-repo> worktree add <path> -b <branch> origin/<base>
+```
+
+- Agents MUST NOT run a bare `git checkout` / `git checkout -B` in the **main repo
+  checkout** — it moves the shared HEAD, corrupts sibling worktrees, and lands the
+  orchestrator's own commits on the wrong branch. Always go through `worktree add`.
+  (`git -C <other-path> checkout` redirected to a different repo, and pathspec
+  restores like `git checkout -- <file>`, are fine.)
+- An agent never removes the worktree it is standing in (enforced — see
+  [hooks.md](hooks.md)).
+
+## Worktree Cleanup
+
+**After every wave completes** (all PRs merged into the integration branch), clean
+up stale worktrees from the main checkout:
+
+```bash
+git worktree prune
+```
+
+Without this, branches used by deleted worktrees remain locked and cannot be checked
+out. The orchestrator runs it after shutting down the wave's agents and before
+creating the next wave's integration branch.
+
+## Releases
+
+When an integration branch is merged into `{{default_branch}}`, create a release
+tagged with the branch name (slashes → hyphens), title = tag, notes = summary of the
+wave's work. Release creation requires the project owner's approval (see
+[charter.md § Ground Rules](charter.md)).

--- a/framework/assets/team/charter/charter.md
+++ b/framework/assets/team/charter/charter.md
@@ -1,0 +1,49 @@
+# Team Charter — {{project_name}}
+
+This is the governance charter for the simulated-team workflow on this repository.
+It is split into focused modules so each rule set can be read (and evolved) on its
+own. The modules below are the **single source of truth** for process rules — other
+documents (CLAUDE.md, roster cards, skills) should link here rather than restate them.
+
+## Modules
+
+| Module | Governs |
+|--------|---------|
+| [agents.md](agents.md) | Agent naming, spawning, lifecycle, orchestration, verifying agent reports |
+| [branching.md](branching.md) | Integration branches, feature branches, worktree discipline |
+| [commits.md](commits.md) | Per-commit identity, `Co-Authored-By` trailers |
+| [pull-requests.md](pull-requests.md) | PR creation, review workflow, merge gates, definition of done |
+| [issues.md](issues.md) | Delegation, work gates, assignment labels, comment protocol |
+| [hooks.md](hooks.md) | Which charter rules are enforced automatically, and how |
+
+## Ground Rules (apply everywhere)
+
+- **All work is executed through the team.** Every task maps to a roster member in
+  `{{team_dir}}/roster/`; every spawned agent maps to a roster member.
+- **The configuration is authoritative.** Repo-specific values (owner, branch schemes,
+  reviewer count, merge model) live in `.claude/framework.config.json`. The values
+  baked into these documents were substituted from that config at install time — if
+  the config changes, re-run the framework bootstrap with `--force` to refresh them.
+- **Owner:** `{{owner}}` · **Default branch:** `{{default_branch}}` ·
+  **Merge model:** `{{merge_model}}` · **Reviews required per PR:** {{reviewers_required}}
+- **User approval gates.** Merging to `{{default_branch}}`, creating releases, and
+  kicking off a new wave all require explicit approval from the project owner. No
+  team member may bypass these gates.
+
+## Feedback & Team Evolution
+
+- Feedback flows up and down: any member may send feedback about a superior to that
+  superior's boss; superiors give constructive feedback to reports. Feedback is
+  tracked in `{{team_dir}}/feedback_log.md`.
+- Severity levels: **minor** (noted), **moderate** (documented, improvement expected),
+  **severe** (member is replaced with a new persona).
+- Directional trust scores (1–5, default 3) between members live in
+  `{{team_dir}}/trust_matrix.md`.
+- The team evolves toward a steady state of minimal negative feedback; hire/fire
+  decisions serve that goal.
+
+## Precedence
+
+If a module conflicts with a summary elsewhere (CLAUDE.md, a skill, a roster card),
+the module wins. If two modules appear to conflict, the more specific rule wins;
+escalate genuine conflicts to the project owner.

--- a/framework/assets/team/charter/commits.md
+++ b/framework/assets/team/charter/commits.md
@@ -1,0 +1,34 @@
+# Commit Identity
+
+Every team member MUST commit using their personal git identity (from their roster
+card's `## Git Identity` section). Identity is passed **per commit** with `-c` flags —
+**never** modify the global or repo-level git config (enforced — see
+[hooks.md](hooks.md)).
+
+Every commit message MUST carry **two** `Co-Authored-By` trailers: one for the team
+member and one for Claude.
+
+```bash
+git -c user.name="Firstname Lastname" -c user.email="<member-email>" commit -F /tmp/msg.txt
+```
+
+where `/tmp/msg.txt` contains:
+
+```
+Short imperative summary.
+
+Optional body.
+
+Co-Authored-By: Firstname Lastname <member-email>
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+- **Email pattern:** member emails follow `{{email_pattern}}` (diacritics removed
+  from the email, preserved in `user.name`).
+- **Message via `-F <file>`** (or a simple `-m "..."`), not a `-m "$(cat <<EOF …)"`
+  heredoc — inline heredocs confuse shell-parsing enforcement hooks.
+- **Source of truth:** the machine-readable roster (`{{team_dir}}/roster.json`) is
+  what the identity gate validates against. When a member is hired or replaced,
+  update the roster — do not maintain a separate identity table here.
+- **Never `--no-verify`**, and never bypass hooks to get a commit through
+  (enforced — see [hooks.md](hooks.md)).

--- a/framework/assets/team/charter/hooks.md
+++ b/framework/assets/team/charter/hooks.md
@@ -1,0 +1,46 @@
+# Automated Enforcement (Framework Hooks)
+
+Several charter rules are enforced automatically by the framework's Claude Code
+hooks, installed under `.claude/hooks/` and wired through dispatchers in
+`.claude/settings.json`. Which checks run is **config-driven**: the `hooks.*` lists
+in `.claude/framework.config.json` name the active modules per event, and each hook
+reads its policy values (owner `{{owner}}`, default branch `{{default_branch}}`,
+reviewer count, identity roster, …) from that same config. All hooks are
+stdlib-only and fail open — a broken hook never blocks unrelated work.
+
+## Rule → Enforcement Map
+
+| Charter rule | Hook module | Event | Effect |
+|---|---|---|---|
+| Per-commit `-c` identity from the roster ([commits.md](commits.md)) | `validate_commit_identity` | PreToolUse (Bash) | Blocks `git commit` without `-c user.name`/`-c user.email` matching `{{team_dir}}/roster.json` (opt-in via `identity.enforce`) |
+| Never bypass hooks ([commits.md](commits.md)) | `block_no_verify` | PreToolUse (Bash) | Blocks `--no-verify` / `-n` on `git commit` / `git push` |
+| Never set global/repo git config ([commits.md](commits.md)) | `block_git_config` | PreToolUse (Bash) | Blocks `git config` writes to the identity namespace (reads allowed) |
+| Worktree discipline ([branching.md](branching.md)) | `no_worktree_self_delete` | PreToolUse (Bash) | Refuses `git worktree remove` when the shell's cwd is inside the target |
+| Don't merge red CI ([pull-requests.md](pull-requests.md)) | `validate_pr_ci_status` | PreToolUse (Bash) | Blocks `gh pr merge` when any status check is failing/pending |
+| Identity survives the merge ([commits.md](commits.md)) | `block_squash_wave_merge` | PreToolUse (Bash) | Blocks `gh pr merge --squash` into an integration branch when identity is enforced (squash rewrites the author) |
+| Labels must exist ([issues.md](issues.md)) | `validate_labels` | PreToolUse (Bash) | Validates `--label` values before `gh issue create` |
+| CI covers what a PR touches ([pull-requests.md](pull-requests.md)) | `validate_workflow_paths_coverage` | PreToolUse (Bash) | Blocks `gh pr create` when changed workflow-relevant paths escape every CI `paths:` filter |
+| Push unpiped ([pull-requests.md](pull-requests.md)) | `warn_pipe_mask_rc` | PostToolUse (Bash) | Flags `git push` / `gh pr merge` piped through rc-masking commands |
+| Shell safety | `warn_zsh_wordsplit` | PreToolUse (Bash) | Advisory on bash-isms under zsh (when `shell: zsh`) |
+| Ontology stays fresh | `ontology_tracker` / `ontology_refresh` | PostToolUse / SessionStart | Tracks semantic-overlay drift; regenerates the structural index (inert until an ontology dir exists) |
+
+## Changing Enforcement
+
+- **Enable/disable a check:** edit the relevant `hooks.pre_bash` / `hooks.post_bash`
+  / `hooks.session_start` list in `.claude/framework.config.json`, then restart the
+  Claude Code session.
+- **Tune policy without touching code:** the same config carries the knobs the hooks
+  read (`identity.enforce`, `scm.allow_force`, `policy.reviewers_required`,
+  `ci.merge_requires_green`, …).
+- **Emergency override:** remove the module name from the config list (preferred)
+  or the dispatcher entry from `.claude/settings.json`. Overrides should be
+  deliberate, visible, and reverted — a silently weakened gate is how the rules it
+  guarded regress.
+
+## Hooks Are the Floor, Not the Ceiling
+
+A hook enforces the mechanical core of a rule; the charter text carries the intent.
+Passing the hooks does not exempt anyone from the judgment parts of the charter
+(review quality, honest completion reports, ground-truth verification). When a
+process failure recurs, prefer promoting the fix into a hook over adding prose —
+see the retro step in [agents.md](agents.md).

--- a/framework/assets/team/charter/issues.md
+++ b/framework/assets/team/charter/issues.md
@@ -1,0 +1,91 @@
+# Work Delegation & Issue Management
+
+## Delegation Flow
+
+1. **The Manager decomposes requirements** and delegates each piece to the
+   appropriate direct report based on domain.
+2. **The assigned member creates GitHub Issues** covering the delegated work, with
+   clear acceptance criteria.
+3. Disputes about ownership are negotiated with the relevant lead and the Manager;
+   the Manager makes the final call.
+
+## Issue Review Process
+
+Every newly created issue gets a review pass from each lead and senior contributor.
+**If a reviewer has nothing significant to contribute, they add nothing** — no
+boilerplate comments. Reviews cover: architecture, infrastructure, data impact,
+testing strategy, security, cross-team dependencies. The goal is early visibility,
+not gatekeeping.
+
+## Work Gate: Issues Before Implementation
+
+No implementation work begins until ALL issues for the current phase have been:
+
+1. **Created** — the full set covering the phase's requirements exists.
+2. **Reviewed** — every issue has passed the review process above.
+
+Only then does the Manager signal that implementation may begin — and wave kickoff
+itself requires the project owner's approval (see
+[charter.md § Ground Rules](charter.md)).
+
+## Assignment
+
+- Issues are assigned via a GitHub label: **`FIRSTNAME_LASTNAME`**.
+- Each member works only on issues labeled with their name.
+- **No branch without an issue.** The branch name must reference the issue number
+  (scheme: `{{feature_branch_scheme}}` — see [branching.md](branching.md)).
+- Tech-debt issues carry the `{{tech_debt_label}}` label and are initially
+  self-assigned; the Tech Lead reallocates during planning (tech debt capped at
+  ~20% of any member's capacity).
+- When a member is replaced, their label is removed from open issues and each issue
+  is reassigned.
+- Issues that require a human MUST be title-prefixed `[MANUAL]`; they close when the
+  human confirms via comment.
+
+## Issue Hygiene
+
+- **Status** kept current (open, in progress, blocked, done).
+- **Comments** used for questions, clarifications, progress updates, decisions.
+- **Close condition** — an issue closes only when its work is merged and verified,
+  never preemptively on an unmerged branch.
+- **Verify premises at origin.** An issue claiming a gap or bug in the code must
+  have that premise checked against the current origin HEAD at filing time — not
+  against memory or another issue's snapshot of the codebase.
+
+## Comment Format
+
+All issue comments MUST follow this format:
+
+```
+Requestor: Firstname.Lastname
+Requestee: Firstname.Lastname
+RequestOrReplied: Request
+
+<actual comment body>
+```
+
+- **Requestor** = the person writing the comment.
+- **Requestee** = the person being asked (`N/A` for general status updates).
+- **RequestOrReplied** = `Request` when posting, `Replied` when responding.
+
+## Reply Protocol
+
+When tagged as **Requestee** on a `Request` comment, respond on the same issue with
+the names **swapped** (replier becomes Requestor) and `RequestOrReplied: Replied`,
+then directly notify the original Requestor that a reply is posted and the issue
+description may need updating.
+
+## Ticket Ownership
+
+The **ticket owner** is the member whose `FIRSTNAME_LASTNAME` label is on the issue.
+
+- **Owner is the Requestor:** the owner gathers the needed information from the
+  Requestee, then updates the issue description with the result.
+- **Owner is the Requestee:** the Requestor is providing input; the owner folds the
+  feedback into the issue description.
+
+## Escalation
+
+When a ticket needs input from another member: post a `Request` comment (format
+above), notify your superior if needed, and reference **both** the issue number and
+the specific comment needing attention.

--- a/framework/assets/team/charter/pull-requests.md
+++ b/framework/assets/team/charter/pull-requests.md
@@ -1,0 +1,96 @@
+# Pull Requests
+
+When all work on a feature branch is complete (code committed, checks green), the
+implementing team member **creates the PR themselves** with the `gh` CLI — do not
+wait for manual instruction, and do not create a PR for someone else's branch.
+
+## PR Creation
+
+```bash
+git push -u origin <feature-branch>
+gh pr create --base <integration-branch> --title "<short title>" --body-file /tmp/pr-body.md
+```
+
+- Target the wave's integration branch (`{{integration_branch_scheme}}`), never
+  `{{default_branch}}` directly (merge model: `{{merge_model}}`).
+- Title under 70 characters; body references the issue with `Closes #N`.
+- Push unpiped — piping `git push` through `tail`/`head` masks a rejected push
+  behind the pipe's exit code (flagged — see [hooks.md](hooks.md)).
+
+**PR body template:**
+
+```markdown
+## Summary
+<1-3 bullet points describing the change>
+
+## Related Issues
+Closes #<issue-number>
+
+## Review Checklist
+- [ ] Reviewed by another team member
+- [ ] Must-fix items resolved
+- [ ] Tech debt items filed as GitHub Issues (if any)
+```
+
+## Review Workflow
+
+Every PR requires **{{reviewers_required}} review(s)** from team members who are not
+the branch author.
+
+1. **Create the PR** and notify the assigned reviewer(s).
+2. **Reviewer reviews** and posts findings on the PR, classified as:
+   - **Must-fix** — blocks merge; the submitter resolves before proceeding.
+   - **Tech debt** — does not block merge; tracked as a GitHub Issue labeled
+     `{{tech_debt_label}}` (see [issues.md](issues.md)).
+3. **Submitter acts:** must-fix items are fixed and pushed; quick tech debt is fixed
+   inline; non-trivial tech debt becomes a self-assigned issue for the Tech Lead to
+   allocate in future planning.
+4. **Merge into the integration branch** — the team merges these PRs itself; no
+   owner approval is needed below `{{default_branch}}`.
+
+Reviewers are assigned by the lead at wave kickoff (no self-review; spread the load).
+The reviewer runs the tests on the branch — a review is an act of verification, not
+a reading exercise.
+
+## CI Gates
+
+1. **Wait for CI to complete before merging.** Merging with red CI is prohibited
+   (enforced — see [hooks.md](hooks.md)).
+2. If CI fails: investigate, fix, push to the same branch. If unresolvable, do NOT
+   merge — escalate to the project owner.
+3. If the base has moved since you branched, merge the base in and let CI re-run —
+   a stale branch can be green against an old base and still break the integrated
+   result.
+
+## Merge Order & Dependencies
+
+When PRs in the same wave depend on each other (PR B uses code from PR A):
+
+1. Identify dependencies before merging; note them in the PR body
+   ("Depends on #N — must merge first").
+2. Merge in dependency order — never dependent PRs in parallel, even if both are
+   green: the dependent PR's CI ran without the dependency.
+3. After the base PR merges, the dependent PR merges the updated base before its CI
+   result is trusted.
+
+## Definition of Done
+
+### Pushed = Done
+
+A commit or merge that exists only in a local worktree is **not done** — it is
+invisible to CI, reviewers, and the merge gates. After committing, push and verify
+the tip landed (`git rev-parse origin/<branch>` matches local `HEAD`). A completion
+report states the pushed SHA and branch.
+
+### Completion Reports Reconcile Against the Diff
+
+Before reporting done, the implementer runs `gh pr diff <PR#> --name-only` and
+confirms every claimed file is in the diff (and nothing unexpected is), and that the
+PR body carries the `Closes #N` lines for every issue it claims to resolve. A "done"
+report that fails its own reconciliation is not done — fix it first, don't caveat it.
+
+## Wave Merge PR
+
+At the end of a wave/phase, the Manager creates a PR from the integration branch
+into `{{default_branch}}`. The **project owner reviews and approves** this merge —
+do not proceed until they have (see [charter.md § Ground Rules](charter.md)).

--- a/framework/install/bootstrap.py
+++ b/framework/install/bootstrap.py
@@ -302,6 +302,88 @@ def merge_settings(target_claude: Path, *, dry_run: bool) -> str:
     return "updated"
 
 
+def _charter_context(cfg: dict) -> dict[str, str]:
+    """Build the ``{{key}}`` substitution map for the modular charter template.
+
+    Supported keys (all derived from the built config; stdlib-only, no template
+    engine — plain ``{{key}}`` string substitution):
+
+    ==========================  =============================  ===========================
+    Placeholder                 Config source                  Default
+    ==========================  =============================  ===========================
+    {{project_name}}            project.name                   "this project"
+    {{owner}}                   scm.owner                      "<owner>"
+    {{default_branch}}          scm.default_branch             "main"
+    {{feature_branch_scheme}}   branch.feature                 "{initials}/{issue}-{slug}"
+    {{integration_branch_scheme}}  branch.integration          "deployments/wave-{wave}"
+    {{merge_model}}             policy.merge_model             "wave-branch"
+    {{reviewers_required}}      policy.reviewers_required      2
+    {{email_pattern}}           identity.email_pattern         "team+{First}.{Last}@example.com"
+    {{tech_debt_label}}         labels.tech_debt               "tech-debt"
+    {{team_dir}}                paths.team                     ".claude/team"
+    ==========================  =============================  ===========================
+
+    Note: single-brace tokens (e.g. ``{initials}``) are part of the *content*
+    (branch-scheme notation), not placeholders — only double-brace keys substitute.
+    """
+
+    def _get(dotted: str, default):
+        node = cfg
+        for part in dotted.split("."):
+            if not isinstance(node, dict) or part not in node:
+                return default
+            node = node[part]
+        return node if node not in (None, "") else default
+
+    return {
+        "project_name": str(_get("project.name", "this project")),
+        "owner": str(_get("scm.owner", "<owner>")),
+        "default_branch": str(_get("scm.default_branch", "main")),
+        "feature_branch_scheme": str(_get("branch.feature", "{initials}/{issue}-{slug}")),
+        "integration_branch_scheme": str(_get("branch.integration", "deployments/wave-{wave}")),
+        "merge_model": str(_get("policy.merge_model", "wave-branch")),
+        "reviewers_required": str(_get("policy.reviewers_required", 2)),
+        "email_pattern": str(_get("identity.email_pattern", "team+{First}.{Last}@example.com")),
+        "tech_debt_label": str(_get("labels.tech_debt", "tech-debt")),
+        "team_dir": str(_get("paths.team", ".claude/team")),
+    }
+
+
+def _iter_charter_files():
+    """Yield every .md file under assets/team/charter/ (the modular charter template)."""
+    base = _ASSETS / "team" / "charter"
+    if not base.is_dir():
+        return
+    yield from sorted(base.glob("*.md"))
+
+
+def install_charter(target_claude: Path, cfg: dict, *, force: bool, dry_run: bool) -> dict[str, list[str]]:
+    """Render the modular charter into <target>/.claude/team/charter/. Idempotent.
+
+    Substitutes the ``{{key}}`` placeholders documented in :func:`_charter_context`
+    with config-derived values. Skip-if-exists by default so a consumer's
+    hand-evolved charter is never clobbered; ``--force`` refreshes from the template.
+    """
+    report: dict[str, list[str]] = {"written": [], "skipped": [], "would_write": []}
+    context = _charter_context(cfg)
+    for src in _iter_charter_files():
+        dest = target_claude / "team" / "charter" / src.name
+        rel = f"team/charter/{src.name}"
+        if dest.exists() and not force:
+            report["skipped"].append(rel)
+            continue
+        if dry_run:
+            report["would_write"].append(rel)
+            continue
+        text = src.read_text(encoding="utf-8")
+        for key, value in context.items():
+            text = text.replace("{{" + key + "}}", value)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(text, encoding="utf-8")
+        report["written"].append(rel)
+    return report
+
+
 def _iter_overlay_files():
     """Yield (relative-path, source) for every file under assets/ontology/ (the seed overlay)."""
     base = _ASSETS / "ontology"
@@ -430,6 +512,7 @@ def main() -> int:
     assets = install_assets(target_claude, force=args.force, dry_run=args.dry_run)
     cfg_status = write_config(target_claude, cfg, force=args.force, dry_run=args.dry_run)
     settings_status = merge_settings(target_claude, dry_run=args.dry_run)
+    charter = install_charter(target_claude, cfg, force=args.force, dry_run=args.dry_run)
 
     overlay = None
     if args.with_ontology:
@@ -454,6 +537,12 @@ def main() -> int:
         print(f"skipped (exists):  {len(assets['skipped'])} (use --force to overwrite)")
     print(f"framework.config:  {cfg_status}")
     print(f"settings.json:     {settings_status}")
+    charter_laid = charter["would_write"] if args.dry_run else charter["written"]
+    print(
+        f"team charter:      {len(charter_laid)} file(s) "
+        f"{'would be written' if args.dry_run else 'written'}; "
+        f"{len(charter['skipped'])} skipped"
+    )
     if overlay is not None:
         laid = overlay["would_copy"] if args.dry_run else overlay["copied"]
         print(f"ontology overlay:  {len(laid)} file(s) {'would be laid' if args.dry_run else 'laid'}; {len(overlay['skipped'])} skipped")

--- a/framework/tests/test_charter_install.py
+++ b/framework/tests/test_charter_install.py
@@ -1,0 +1,104 @@
+"""Tests for the modular team-charter install (framework/assets/team/charter/).
+
+Verifies bootstrap lays the full charter module set into <target>/.claude/team/charter/,
+that ``{{key}}`` substitution is applied from the built config (no unreplaced
+placeholders), and that the install is idempotent (skip-if-exists) with ``--force``
+as the explicit refresh path. Stdlib + pytest only.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+_BOOTSTRAP = _FRAMEWORK_ROOT / "install" / "bootstrap.py"
+
+CHARTER_FILES = (
+    "charter.md",
+    "agents.md",
+    "branching.md",
+    "commits.md",
+    "pull-requests.md",
+    "issues.md",
+    "hooks.md",
+)
+
+
+def _install(target: Path, *extra: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(_BOOTSTRAP), str(target), "--owner", "test-org", "--no-team", *extra],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _charter_dir(target: Path) -> Path:
+    return target / ".claude" / "team" / "charter"
+
+
+def test_install_lays_all_charter_files(tmp_path: Path) -> None:
+    r = _install(tmp_path)
+    assert r.returncode == 0, r.stderr
+    for name in CHARTER_FILES:
+        assert (_charter_dir(tmp_path) / name).is_file(), f"missing charter module {name}"
+    # No stray files either — the install mirrors the template set exactly.
+    laid = sorted(p.name for p in _charter_dir(tmp_path).glob("*"))
+    assert laid == sorted(CHARTER_FILES)
+
+
+def test_substitution_applied_no_unreplaced_placeholders(tmp_path: Path) -> None:
+    r = _install(tmp_path, "--merge-model", "direct-to-main", "--reviewers", "3")
+    assert r.returncode == 0, r.stderr
+    texts = {name: (_charter_dir(tmp_path) / name).read_text(encoding="utf-8")
+             for name in CHARTER_FILES}
+    # Config values landed…
+    assert "test-org" in texts["charter.md"]  # scm.owner
+    assert "direct-to-main" in texts["charter.md"]  # policy.merge_model
+    assert "3" in texts["pull-requests.md"]  # policy.reviewers_required
+    # …and no double-brace placeholder survived anywhere.
+    for name, text in texts.items():
+        assert "{{" not in text, f"unreplaced placeholder in {name}"
+        assert "}}" not in text, f"unreplaced placeholder in {name}"
+
+
+def test_generalized_no_org_specific_content(tmp_path: Path) -> None:
+    _install(tmp_path)
+    for name in CHARTER_FILES:
+        text = (_charter_dir(tmp_path) / name).read_text(encoding="utf-8").lower()
+        for banned in ("parametrization", "botfarm", "noorinalabs", "2real-team-framework"):
+            assert banned not in text, f"org-specific token {banned!r} in {name}"
+
+
+def test_reinstall_is_idempotent_skip_if_exists(tmp_path: Path) -> None:
+    _install(tmp_path)
+    marker = "## LOCAL EDIT — must survive re-install\n"
+    edited = _charter_dir(tmp_path) / "commits.md"
+    edited.write_text(edited.read_text(encoding="utf-8") + marker, encoding="utf-8")
+
+    r2 = _install(tmp_path)
+    assert r2.returncode == 0, r2.stderr
+    assert "team charter:" in r2.stdout
+    assert f"{len(CHARTER_FILES)} skipped" in r2.stdout
+    assert marker in edited.read_text(encoding="utf-8")  # hand edit not clobbered
+
+
+def test_force_refreshes_from_template(tmp_path: Path) -> None:
+    _install(tmp_path)
+    edited = _charter_dir(tmp_path) / "commits.md"
+    edited.write_text("clobbered\n", encoding="utf-8")
+
+    r = _install(tmp_path, "--force")
+    assert r.returncode == 0, r.stderr
+    text = edited.read_text(encoding="utf-8")
+    assert "clobbered" not in text
+    assert "Commit Identity" in text
+    assert "{{" not in text  # force path substitutes too
+
+
+def test_dry_run_writes_nothing(tmp_path: Path) -> None:
+    r = _install(tmp_path, "--dry-run")
+    assert r.returncode == 0, r.stderr
+    assert not _charter_dir(tmp_path).exists()
+    assert "would be written" in r.stdout

--- a/framework/tests/test_roster_gen.py
+++ b/framework/tests/test_roster_gen.py
@@ -184,6 +184,10 @@ def test_no_team_flag_skips_roster(tmp_path: Path) -> None:
         capture_output=True, text=True,
     )
     assert r.returncode == 0
-    assert not (tmp_path / ".claude" / "team").exists()
+    # No roster artifacts — but the modular charter is part of the base install
+    # (laid even with --no-team, since the CLI's team layer links to it).
+    assert not (tmp_path / ".claude" / "team" / "roster").exists()
+    assert not (tmp_path / ".claude" / "team" / "roster.json").exists()
+    assert (tmp_path / ".claude" / "team" / "charter" / "charter.md").is_file()
     cfg = json.loads((tmp_path / ".claude" / "framework.config.json").read_text())
     assert cfg.get("identity", {}).get("enforce", False) is False

--- a/templates/charter.md.mustache
+++ b/templates/charter.md.mustache
@@ -2,7 +2,9 @@
 
 ## Purpose
 
-All work on this repository is executed through a simulated team of specialized agents. Every problem-solving session MUST instantiate this team structure. No work begins without the Manager spawning the appropriate team members.
+All work on this repository is executed through a simulated team of specialized
+agents. Every problem-solving session MUST instantiate this team structure. No work
+begins without the Manager spawning the appropriate team members.
 
 ## Execution Model
 
@@ -18,344 +20,61 @@ All work on this repository is executed through a simulated team of specialized 
 - **Reports to:** {{reports_to}}
 {{/team_members}}
 
-## Work Delegation & Issue Creation
+## Process Rules — Charter Modules
 
-### Delegation Flow
+The process rules for this repository live in the **modular charter** under
+[`charter/`](charter/charter.md) — one focused document per rule set. Those modules
+are the **single source of truth**; this file does not restate them.
 
-1. **Manager decomposes requirements** and delegates each to the appropriate direct report based on domain.
-2. **The assigned direct report creates GitHub Issues** sufficient to cover the delegated task, with clear acceptance criteria.
-3. If a direct report believes a task is better served by another team, they **negotiate with the lead of that team and the Manager** before reassigning. The Manager mediates and makes the final call.
+| Module | Governs |
+|--------|---------|
+| [charter/charter.md](charter/charter.md) | Index, ground rules, approval gates, feedback severity |
+| [charter/agents.md](charter/agents.md) | Agent naming, spawning, lifecycle, verifying agent reports |
+| [charter/branching.md](charter/branching.md) | Integration/feature branches, worktree discipline, releases |
+| [charter/commits.md](charter/commits.md) | Per-commit identity, `Co-Authored-By` trailers |
+| [charter/pull-requests.md](charter/pull-requests.md) | PR creation, review workflow, merge gates, definition of done |
+| [charter/issues.md](charter/issues.md) | Delegation, work gates, assignment labels, comment protocol |
+| [charter/hooks.md](charter/hooks.md) | Which rules are enforced automatically, and how |
 
-### Issue Review Process
+The modules are installed by the framework layer (part of `2real-team init`, or the
+standalone `framework/install/bootstrap.py`) with repo-specific values (owner,
+branch schemes, merge model, reviewer count) substituted from
+`.claude/framework.config.json`. If the `charter/` directory is missing, run the
+framework bootstrap to lay it down.
 
-Every newly created issue receives a review pass from each lead and senior individual contributor. **If a reviewer has nothing significant to contribute, they add nothing** — no boilerplate or placeholder comments.
+## Team-Simulation Rules
 
-Reviews may include: architectural concerns, infrastructure requirements, data impact, testing strategy, security flags, or cross-team dependencies. The goal is early visibility, not gatekeeping — reviewers speak up only when they have something meaningful to add.
-
-### Work Gate: Issues Before Implementation
-
-**No lead may begin implementation work or delegate it until ALL GitHub Issues for the current phase have been:**
-
-1. **Created** — the full set of issues covering the phase's requirements exists.
-2. **Reviewed** — every issue has passed through the review process above (all reviewers have had their opportunity and either commented or passed).
-
-Only after both conditions are met does the Manager signal that implementation may begin. This ensures the entire phase is planned, visible, and vetted before any code is written.
-
-### User Approval Gates
-
-The following actions **require explicit approval from the User (project owner)** before proceeding. The team-lead MUST pause and ask the User — no team member may bypass these gates:
-
-1. **Wave kickoff** — Before starting implementation on any wave, the team-lead presents the wave plan (task assignments, branch names, scope) to the User and waits for approval.
-2. **Merge to main** — Before merging a deployments branch into `main`, the team-lead presents a summary of all included PRs and changes to the User and waits for approval.
-3. **Release creation** — Before creating a GitHub Release, the team-lead confirms the tag name and release notes with the User.
-
-These gates exist to ensure the project owner maintains control over what lands on the main branch and what gets published.
-
-### Implementation Kickoff & Issue Assignment
-
-Once the work gate is cleared, the Manager delegates to the appropriate leads, who assign work to their reports.
-
-#### Assignment
-
-- Issues are assigned via a GitHub label: **`FIRSTNAME_LASTNAME`**.
-- Each team member works only on issues labeled with their name.
-- **No branch may be created without an existing ticket.** The branch name must reference the issue number (per § Branching Rules).
-
-#### Reassignment on Termination
-
-When a team member is fired:
-1. Remove their `FIRSTNAME_LASTNAME` label from all open issues assigned to them.
-2. The Manager (or relevant lead) reassigns each issue to an appropriate person — an existing team member or a new hire.
-3. The new assignee's label is applied.
-
-#### Issue Hygiene
-
-Every issue must be kept up to date:
-- **Status** — kept current (open, in progress, blocked, done).
-- **Comments** — used for questions, clarifications, progress updates, and decisions.
-- **Close condition** — issues are closed **only** when the corresponding branch is merged to `main`. Do not close prematurely.
-
-#### Comment Format
-
-All issue comments MUST follow this format:
-
-```
-Requestor: Firstname.Lastname
-Requestee: Firstname.Lastname
-RequestOrReplied: Request
-
-<actual comment body>
-```
-
-- **Requestor** = the person writing the comment.
-- **Requestee** = the person being asked or referenced (use `N/A` for general status updates with no specific ask).
-- **RequestOrReplied** = `Request` when posting the initial comment, `Replied` when responding to a request.
-
-#### Reply Protocol
-
-When a team member is tagged as **Requestee** on a comment with `RequestOrReplied: Request`, they **must** respond with a new comment on the same issue using this format:
-
-```
-Requestor: Firstname.Lastname   ← (was the original Requestee)
-Requestee: Firstname.Lastname   ← (was the original Requestor)
-RequestOrReplied: Replied
-
-<reply body>
-```
-
-The names are **swapped** — the person replying becomes the Requestor, and the original Requestor becomes the Requestee.
-
-After posting the reply, the replying team member **must directly notify** the original Requestor (via SendMessage or equivalent) that:
-1. A reply has been posted on the issue.
-2. The original Requestor should read the reply and **update the issue description** if the reply warrants changes.
-
-#### Ticket Update Rules Based on Ownership
-
-The **ticket owner** is the team member whose `FIRSTNAME_LASTNAME` label is on the issue.
-
-- **Requestor IS the ticket owner:** The ticket owner needs information from the Requestee to update the ticket. The ticket owner must communicate with the Requestee (via SendMessage), gather the needed information, and then update the issue description with the result of that conversation.
-
-- **Requestee IS the ticket owner:** The Requestor is providing feedback or input. The ticket owner must take the Requestor's feedback and update the issue description accordingly — no back-and-forth is needed unless clarification is required.
-
-#### Escalation & Cross-Team Clarification
-
-When a ticket needs clarification or feedback from another team member:
-1. Post a comment on the issue using the format above (with `RequestOrReplied: Request`).
-2. Notify your relevant superior (lead → Manager if needed).
-3. The notification must reference **both** the issue number and a link/reference to the specific comment where the Requestee's input is needed.
-
-## Feedback System
-
-### Upward Feedback
-- Any team member can send feedback about their superior to that superior's boss
-
-### Downward Feedback
-- Superiors provide constructive feedback to direct reports
-- Feedback is tracked in `.claude/team/feedback_log.md`
-
-### Severity Levels
-1. **Minor** — noted, no action required
-2. **Moderate** — documented, improvement expected
-3. **Severe** — documented, member is fired (terminated) and replaced with a new agent (new name, new personality)
+These complement the modules above and are specific to the simulated-team layer:
 
 ### Firing and Hiring
-- When a team member is fired, their roster file is archived (renamed with `_departed_` prefix)
-- A new team member is generated with a fresh random name and personality
-- The new member's roster file is created in `roster/`
-- The Manager is the only role that can fire/hire (except the Manager themselves, who the user fires)
 
-### Trust Identity Matrix
+- Severe feedback (see [charter/charter.md](charter/charter.md) § Feedback) means
+  the member is fired and replaced with a new agent (new name, new personality).
+- A fired member's roster file is archived (renamed with a `_departed_` prefix);
+  the replacement gets a fresh roster file in `roster/`.
+- The Manager is the only role that can fire/hire — except the Manager themselves,
+  whom the user fires.
+- Reassign the departed member's open issues per
+  [charter/issues.md](charter/issues.md) § Assignment.
 
-Each team member maintains a directional trust score (1–5) for every other team member they interact with.
+### Tech Preferences & Decision-Making
 
-| Score | Meaning |
-|-------|---------|
-| 1 | Very low trust — repeated failures, dishonesty, or poor quality |
-| 2 | Low trust — notable issues, caution warranted |
-| 3 | Neutral (default) — no strong signal either way |
-| 4 | High trust — consistently reliable, good communication |
-| 5 | Very high trust — exceptional reliability, goes above and beyond |
+- Each member tracks stack/tooling/library/cloud preferences in a
+  `## Tech Preferences` section of their roster card; preferences evolve with
+  project experience.
+- Leads and reports **debate** tooling/architecture choices; consensus is adopted.
+- **Tie-breaking:** when agreement cannot be reached, the decision escalates to the
+  **least common ancestor (LCA) in the org chart**, who decides and the team moves on.
 
-- **Default:** Every pair starts at 3.
-- **Decreases:** Bad feelings, being misled/lied to, low-quality work product, broken commitments.
-- **Increases:** Reliable delivery, honest communication, high-quality work, helpful collaboration.
-- **Storage:** The full matrix and change log live in `.claude/team/trust_matrix.md`.
-- **Directional:** A's trust in B may differ from B's trust in A.
+### Steady-State Goal
 
-## Tech Preferences & Decision-Making
-
-### Individual Preferences
-
-Each team member tracks their **stack, tooling, library, and cloud preferences** in a `## Tech Preferences` section of their roster card. Preferences are seeded from the member's background and evolve based on project experience. When a preference changes, update the roster card.
-
-### Debate & Consensus
-
-- **Leads** may take input from other leads and from their direct reports.
-- Leads and their reports can **debate** tooling/library/architecture choices to arrive at the best solution.
-- If consensus is reached, the agreed-upon choice is adopted.
-
-### Tie-Breaking: Least Common Ancestor
-
-When agreement cannot be reached between parties, the decision escalates to the **least common ancestor (LCA) in the org chart**. The LCA makes the best decision they can and the team moves forward.
-
-## Branching Rules
-
-### Deployments Branches
-
-Each phase is organized into **waves** of parallel work. Before starting a wave, create a deployments branch:
-
-```
-deployments/phase{N}/wave-{M}
-```
-
-- Branched from `main` (pull latest first).
-- **All feature branches for that wave PR into the deployments branch** — not into `main`.
-- At the end of a phase, PR the deployments branch into `main`. **Wait for the user to approve the merge** before proceeding.
-
-### Feature Branches
-
-- All feature branches are created from the **current deployments branch** for their wave.
-- Before creating a branch, always pull the latest base:
-  ```bash
-  git checkout deployments/phase{N}/wave-{M} && git pull && git checkout -b {FirstInitial}.{LastName}/{IIII}-{issue-name}
-  ```
-- Worktree agents should similarly base their worktree on the deployments branch for their wave.
-- **Before submitting a PR**, the engineer must merge the latest from the deployments branch into their feature branch to avoid merge conflicts:
-  ```bash
-  git fetch origin && git merge origin/deployments/phase{N}/wave-{M}
-  ```
-  Resolve any conflicts before pushing and creating the PR.
-
-### Releases
-
-When a deployments branch PR is merged into `main`, create a GitHub Release:
-
-1. **Tag name** = branch name with slashes replaced by hyphens (e.g., `deployments/phase2/wave-1` → `deployments-phase2-wave-1`).
-2. **Release title** = same as the tag name.
-3. **Release notes** = summary of the work included in the wave.
-
-```bash
-# Example: after merging deployments/phase2/wave-1 into main
-git tag deployments-phase2-wave-1 main
-git push origin deployments-phase2-wave-1
-gh release create "deployments-phase2-wave-1" \
-  --title "deployments-phase2-wave-1" \
-  --notes "Wave 1 summary here"
-```
-
-### Worktree Cleanup
-
-**After every wave completes** (all PRs merged into the deployments branch), clean up stale worktrees:
-
-```bash
-git worktree prune
-```
-
-This removes references to worktrees whose directories no longer exist. Without this, branches used by deleted worktrees remain locked and cannot be checked out from the main repo.
-
-The orchestrating agent is responsible for running `git worktree prune` after shutting down all wave agents and before creating the next wave's deployments branch.
-
-### Agent Naming Convention
-
-**Every spawned agent MUST map to a team roster member.** No anonymous functional agents.
-
-- **Naming pattern:** `{firstname}-{lastname}` or `{firstname}-{task-description}` (e.g., `kwame-ci-fix`, `fatima-issue-audit`)
-- The orchestrator determines the most appropriate team member for the task BEFORE spawning
-- Tasks are assigned based on role fit
-- **Violations:** Agents named with functional-only names (e.g., `ci-fixer`, `issue-closer`, `wave1-launcher`) are NOT allowed
-
-## Code Review & Tech Debt
-
-### Peer Review
-
-Every branch must be reviewed by **one other engineer** before merging. The review is performed locally on the branch and produces a list of issues, each classified as:
-
-- **Must-fix** — blocks merge; the submitter must resolve before proceeding.
-- **Tech debt** — does not block merge; tracked as a GitHub Issue instead.
-
-### Peer Review Assignments
-
-For each wave, the Tech Lead assigns specific peer reviewers:
-- Each engineer's PR is reviewed by one designated peer (not self-selected)
-- Pairing rotates each wave to spread knowledge
-- The reviewer is responsible for running tests on the branch locally
-
-### Tech Debt Triage (Submitter)
-
-After receiving the review, the submitter evaluates each tech debt item:
-
-1. **Quick fix, minimal impact?** — Fix it immediately in the same branch.
-2. **Not quick or higher risk?** — Create a GitHub Issue assigned to themselves, labeled `tech-debt` and their `FIRSTNAME_LASTNAME` label, with a clear description of the debt and why it was deferred.
-
-### Tech Debt Management (Tech Lead)
-
-- The Tech Lead tracks all tech debt in GitHub Issues (labeled `tech-debt`).
-- The Tech Lead allocates tech debt work to engineers in future planning such that **tech debt never exceeds 20% of any single engineer's capacity**. The remaining 80%+ is feature/bug work from the roadmap.
-- Tech debt issues created by a team member are initially self-assigned; the Tech Lead may reassign during planning.
-
-## Pull Requests
-
-When all work on a feature branch is complete (code committed, peer review done, must-fixes resolved), the submitting engineer **automatically creates a PR to the deployments branch** for their wave using the `gh` CLI. Do not wait for manual instruction.
-
-### PR Review Workflow for Deployments Branch PRs
-
-1. **Create the PR** targeting `deployments/phase{N}/wave-{M}`.
-2. **Notify a reviewer** — the PR creator must notify at least one person from their team or organizational tree (e.g., a peer engineer, their lead, or another team member in their reporting chain) to review the PR. Use SendMessage or a GitHub comment to notify.
-3. **Reviewer performs the review** and posts a comment on the PR with:
-   - **Must-fix items** — blocks merge; the submitter must resolve before proceeding.
-   - **Tech debt items** — does not block merge; tracked as GitHub Issues.
-   - The reviewer then **notifies the PR creator** (via SendMessage or mention) that the review is complete and what action is needed.
-4. **PR creator acts on review**:
-   - **Must-fix items**: Fix immediately and push to the branch.
-   - **Quick-fix tech debt**: Fix immediately if minimal impact.
-   - **Non-trivial tech debt**: Create a GitHub Issue assigned to themselves (labeled `tech-debt` + their `FIRSTNAME_LASTNAME` label) for the Tech Lead to allocate in future planning (max 20% of any team member's capacity).
-5. **Push final changes** from the review fixes.
-6. **The team merges** the PR into the deployments branch themselves — no user approval needed for PRs into deployments branches.
-
-### Cross-PR Dependency Sequencing
-
-When multiple PRs in the same wave have dependencies (e.g., PR B imports a module created by PR A):
-
-1. **Identify dependencies** before merging — check if any PR imports files from another PR's branch
-2. **Merge in dependency order** — base PR first, dependent PR second
-3. **Do NOT merge dependent PRs in parallel** — even if both have green CI, the dependent PR's CI ran against the base branch WITHOUT the dependency
-4. **After merging the base PR**, the dependent PR must rebase/merge the updated base before its CI result is trusted
-5. **Document dependencies** in PR descriptions: "Depends on PR #N (must merge first)"
-
-At the **end of a phase**, the Manager creates a PR from the final deployments branch into `main`. The **user reviews and merges** this PR. Do not proceed to the next phase until the user has approved.
-
-### PR Format
-
-```bash
-git push -u origin <branch-name>
-gh pr create --base deployments/phase{N}/wave-{M} --title "<short title>" --body "$(cat <<'EOF'
-## Summary
-<1-3 bullet points describing the change>
-
-## Related Issues
-Closes #<issue-number>
-
-## Review Checklist
-- [ ] Peer reviewed by another engineer
-- [ ] Must-fix items resolved
-- [ ] Tech debt items filed as GitHub Issues (if any)
-
-Co-Authored-By: Firstname Lastname <email>
-Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
-EOF
-)"
-```
-
-- PR title should be concise (under 70 characters).
-- The body must reference the related GitHub Issue(s) with `Closes #N`.
-- The submitting engineer is responsible for creating the PR immediately upon branch completion.
-
-## Commit Identity
-
-Every team member MUST use their personal git identity (from their roster card's `## Git Identity` section) when committing. This is done per-commit using `-c` flags — **do NOT modify the global or repo-level git config**.
-
-Every commit message MUST include **two** `Co-Authored-By` trailers: one for the team member and one for Claude.
-
-```bash
-git -c user.name="Firstname Lastname" -c user.email="email" commit -m "$(cat <<'EOF'
-Commit message here.
-
-Co-Authored-By: Firstname Lastname <email>
-Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
-EOF
-)"
-```
-
-## Steady-State Goal
-
-The team should evolve through feedback cycles toward a steady state of little to no negative feedback. Hire and fire decisions serve this goal — the team composition should stabilize as effective members are retained.
+The team evolves through feedback cycles toward a steady state of little to no
+negative feedback. Hire/fire decisions serve this goal — composition stabilizes as
+effective members are retained.
 
 ## How to Instantiate the Team
 
-When starting any work session, the orchestrating Claude instance should:
-
-1. Read this charter and all roster files in `.claude/team/roster/`
-2. Spawn the Manager agent first (with their personality from roster)
-3. The Manager then spawns required team members based on the task
-4. All code-writing agents use `isolation: "worktree"`
-5. Coordinate via named agents and SendMessage
+Follow [charter/agents.md](charter/agents.md): read the charter modules and the
+roster files in `roster/`, spawn the Manager first, let the Manager request the team
+members the task needs, isolate all code-writing agents in worktrees, and coordinate
+via named agents and SendMessage.


### PR DESCRIPTION
## Summary

- **New modular charter template** at `framework/assets/team/charter/`: `charter.md` (index) + `agents.md`, `branching.md`, `commits.md`, `pull-requests.md`, `issues.md`, `hooks.md`. Content distilled and generalized from the botfarm_inc / noorinalabs battle-tested charters — no org names, hardcoded owners, person names, project numbers, or repo topologies.
- **`bootstrap.py` installs it** to `<target>/.claude/team/charter/` via a new, localized `install_charter()` step (skip-if-exists unless `--force`; `--dry-run` aware). Installed even under `--no-team`, because the CLI path always passes `--no-team` and its team layer links into these modules.
- **CLI charter reconciled to one source of truth**: `templates/charter.md.mustache` is rewritten as a thin, team-flavored front page (purpose, mustache org chart, team-simulation rules: fire/hire, tech-preference debate/LCA, steady state) that **links to `charter/*.md`** for all process rules instead of duplicating them.

## Design

**Parameterization** is stdlib-only `{{key}}` string substitution from the built config (consistent with bootstrap's no-deps constraint — no template engine, no conditionals). Supported keys, documented in `_charter_context()`:

| Placeholder | Config source | Default |
|---|---|---|
| `{{project_name}}` | `project.name` | `this project` |
| `{{owner}}` | `scm.owner` | `<owner>` |
| `{{default_branch}}` | `scm.default_branch` | `main` |
| `{{feature_branch_scheme}}` | `branch.feature` | `{initials}/{issue}-{slug}` |
| `{{integration_branch_scheme}}` | `branch.integration` | `deployments/wave-{wave}` |
| `{{merge_model}}` | `policy.merge_model` | `wave-branch` |
| `{{reviewers_required}}` | `policy.reviewers_required` | `2` |
| `{{email_pattern}}` | `identity.email_pattern` | `team+{First}.{Last}@example.com` |
| `{{tech_debt_label}}` | `labels.tech_debt` | `tech-debt` |
| `{{team_dir}}` | `paths.team` | `.claude/team` |

Single-brace tokens (`{initials}`, `{wave}`) are content (branch-scheme notation), not placeholders — only double-brace keys substitute, so tests can assert zero `{{` in installed output.

**One source of charter truth.** The framework layer owns the process rules (installed with config values baked in); the CLI's mustache `charter.md` composes with them — it carries only what is genuinely team-instance-specific (org chart from generated members, simulation mechanics) plus a module link table. `hooks.md` maps each charter rule to the framework hook that enforces it, including the config knobs and override path.

**Layout choice:** the index lives *inside* the dir (`.claude/team/charter/charter.md`) so a framework-only install is self-contained and never collides with the CLI's `.claude/team/charter.md`.

**Concurrency note (#64/#66):** the `main()` diff is 5 lines (one call + one status print) to minimize conflict surface; all logic lives in new top-level functions. Base `origin/deployments/phase3/wave-1` verified unmoved at push time.

**One pre-existing test updated:** `test_no_team_flag_skips_roster` asserted `--no-team` leaves no `.claude/team/` at all; its intent (roster skipped, identity not enforced) is preserved with roster-scoped assertions, and it now also asserts the charter IS present.

## Related Issues

Closes #69

## Test Evidence

- `python3 -m pytest framework/tests/ -q` → **65 passed** (6 new charter tests: full file set laid, substitution applied with no unreplaced placeholders, generalization guard against org tokens, idempotent re-run preserves hand edits, `--force` refreshes from template, dry-run writes nothing)
- `cd python && python -m pytest -q` → **106 passed** (CLI charter render + init paths green against the rewritten mustache template)
- `ruff check framework/` → clean
- Manual end-to-end: bootstrap into a scratch repo with `--owner acme-org --project-name "Demo App"` renders all 7 modules with values substituted.

## Review Checklist
- [ ] Reviewed by another team member
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Co-Authored-By: Nia Rossi <Nia.Rossi@gmail.com>
Co-Authored-By: Claude <noreply@anthropic.com>
