### PR TITLE
ci: run CI on PRs into deployments/** wave branches (#73)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - "deployments/**"
 
 jobs:
   python:


### PR DESCRIPTION
Closes #73

## Summary

`.github/workflows/ci.yml` triggered `pull_request` only for `main`, so PRs into `deployments/**` wave branches ran zero checks — every Phase 3 wave PR was verification-blind (confirmed live on PR #71, which shows no check runs).

## Change

One trigger edit: add `deployments/**` to the `pull_request` branches list. All three jobs (python / framework / node) now gate wave-branch PRs.

- Push triggers untouched (`push: branches: [main]` unchanged).
- Publish/release workflows untouched (only `ci.yml` modified).

## Verification

- YAML parses; trigger map is now `{push: {branches: [main]}, pull_request: {branches: [main, deployments/**]}}` with all three jobs intact.
- `deployments/**` uses the recursive glob so nested wave branches (`deployments/phase3/wave-1`) match (single `*` does not cross `/`).

Requestor: Tariq Morales (QA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1sHWTyKtu8DAExDn9DgLS
