### PR TITLE
feat(bootstrap): pre-push git hook installer, no-op by default (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,27 @@ a subsystem isn't present:
 - `/ontology-rebuild [scope]` — Reconcile the semantic overlay: scan dirty checksums, update
   ontology files and auto-updatable docs from code, mark resolved
 
+## Pre-push hook
+
+The framework bootstrapper (`framework/install/bootstrap.py`, also run by
+`2real-team init --with-hooks`) installs a `pre-push` git hook into the target repo's
+effective hooks directory (it respects `core.hooksPath`). Three modes, driven by the unified
+install config key `pre_push.mode` or the `--pre-push {noop,enforce,none}` flag (precedence:
+flag > user YAML > shipped default `noop`):
+
+- **`noop`** (default) — an executable, clearly-commented script that always exits 0. It never
+  blocks a push; it just makes the enforcement seam visible and documents how to turn it on.
+- **`enforce`** — runs every command in `hooks.pre_push_commands` from
+  `.claude/framework.config.json` (in order, from the repo root) and blocks the push on the
+  first failure. The list is read at push time, so editing the config changes the checks
+  without reinstalling. Fail-open: a missing config or an empty list allows the push.
+- **`none`** — installs nothing (and never deletes an existing hook).
+
+To switch modes, re-run the bootstrapper with the new `--pre-push` value. An existing
+`pre-push` hook is never clobbered: a non-framework hook is preserved as `pre-push.bak`
+(`.bak.1`, `.bak.2`, … — never overwriting an earlier backup) with a warning. Targets without
+a `.git` directory are skipped with a notice.
+
 ## How it works with Claude Code
 
 1. **Bootstrap:** Run `2real-team init` in your project

--- a/framework/assets/hooks/_framework_config.py
+++ b/framework/assets/hooks/_framework_config.py
@@ -91,6 +91,7 @@ _DEFAULTS: dict[str, Any] = {
         "post_bash": ["warn_pipe_mask_rc"],
         "post_file": ["ontology_tracker"],
         "session_start": ["ontology_refresh"],
+        "pre_push_commands": [],
     },
 }
 

--- a/framework/config/README.md
+++ b/framework/config/README.md
@@ -32,6 +32,7 @@ capability but do not error.
 | `ci.neutral_pending_check_prefixes` | Services whose `NEUTRAL` means "review pending" (e.g. `["chromatic"]`). |
 | `ci.tooling` | The full CI check-set the local⇄CI parity gate expects mirrored. |
 | `hooks.pre_bash` / `hooks.post_bash` | Which checks run, in what order (the dispatcher seam). |
+| `hooks.pre_push_commands` | Checks the enforce-mode pre-push git hook runs (read at push time; empty = pass). |
 
 ## How reads work
 

--- a/framework/config/framework.config.example.json
+++ b/framework/config/framework.config.example.json
@@ -62,6 +62,7 @@
       "validate_workflow_paths_coverage",
       "validate_pr_ci_status"
     ],
-    "post_bash": ["warn_pipe_mask_rc"]
+    "post_bash": ["warn_pipe_mask_rc"],
+    "pre_push_commands": ["ruff check .", "pytest -q"]
   }
 }

--- a/framework/config/framework.config.schema.json
+++ b/framework/config/framework.config.schema.json
@@ -157,6 +157,12 @@
           "items": { "type": "string" },
           "default": ["ontology_refresh"],
           "description": "Ordered SessionStart checks (run via start_dispatcher.py). Advisory only — never block; INERT unless the subsystem they target exists (e.g. ontology_refresh acts only when an ontology dir is present)."
+        },
+        "pre_push_commands": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Shell commands the ENFORCE-mode pre-push git hook runs (in order, from the repo root) before every push; the first nonzero exit blocks the push. Read at push time, so editing this list needs no reinstall. Empty = the enforce hook allows the push (fail-open). Ignored by the default noop hook. Installed via bootstrap.py --pre-push {noop,enforce,none}."
         }
       }
     }

--- a/framework/install/bootstrap.py
+++ b/framework/install/bootstrap.py
@@ -47,6 +47,13 @@ Flags
   --reviewers N          policy.reviewers_required.
   --merge-model {wave-branch,direct-to-main}
   --no-permissions       Skip installing the curated permissions.allow allowlist.
+  --pre-push {noop,enforce,none}
+                         Pre-push git hook to install; overrides the
+                         install-config key ``pre_push.mode`` (flag > user
+                         YAML > shipped default noop). noop = an executable,
+                         clearly-commented script that exits 0; enforce runs
+                         hooks.pre_push_commands from framework.config.json
+                         and blocks push on failure; none installs nothing.
   --interactive          Prompt for missing required fields (scm.owner) if a TTY.
   --with-ontology / --no-ontology   Override ontology.enabled from the config.
   --force                Overwrite existing hook/lib files and framework.config.json.
@@ -60,6 +67,7 @@ from __future__ import annotations
 import argparse
 import json
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -99,6 +107,7 @@ def _schema_defaults() -> dict:
             "post_bash": ["warn_pipe_mask_rc"],
             "post_file": ["ontology_tracker"],
             "session_start": ["ontology_refresh"],
+            "pre_push_commands": [],
         },
     }
 
@@ -147,6 +156,8 @@ def resolve_install_config(args: argparse.Namespace) -> tuple[dict, set[str]]:
         flag_map["ontology.enabled"] = False
     elif args.with_ontology:
         flag_map["ontology.enabled"] = True
+    if args.pre_push:  # default=None -> only an EXPLICIT flag beats the YAML
+        flag_map["pre_push.mode"] = args.pre_push
     for dotted, value in flag_map.items():
         if value is not None:
             install_config.set_key(inst, dotted, value)
@@ -569,6 +580,184 @@ def generate_structural(
     return msg
 
 
+# ---------------------------------------------------------------- pre-push hook
+
+_NOOP_PRE_PUSH = """\
+#!/bin/sh
+# pre-push -- installed by the 2real team framework (framework/install/bootstrap.py).
+#
+# MODE: noop. This hook does nothing and never blocks a push (it exits 0).
+# It exists so the enforcement seam is visible: one config edit + reinstall
+# turns on real pre-push checks with no further wiring.
+#
+# To enable enforcement:
+#   1. List the checks to run in .claude/framework.config.json:
+#        "hooks": { "pre_push_commands": ["ruff check .", "pytest -q"] }
+#   2. Re-run the bootstrapper with --pre-push enforce
+#      (this hook is replaced; a non-framework hook would be kept as pre-push.bak).
+#
+# To remove: delete this file. Re-running bootstrap with --pre-push none
+# installs nothing (it never deletes an existing hook).
+exit 0
+"""
+
+_ENFORCE_PRE_PUSH = """\
+#!/bin/sh
+# pre-push -- installed by the 2real team framework (framework/install/bootstrap.py).
+#
+# MODE: enforce. Runs every command in hooks.pre_push_commands from
+# .claude/framework.config.json (in order, from the repo root) and BLOCKS the
+# push on the first nonzero exit. The list is read at push time, so editing the
+# config changes the checks with no reinstall.
+#
+# Fail-open by design: a missing config, missing python3, or an empty command
+# list allows the push (with a note) rather than stranding you.
+#
+# To go back to a do-nothing hook: re-run the bootstrapper with --pre-push noop.
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+cfg="$repo_root/.claude/framework.config.json"
+[ -f "$cfg" ] || { echo "pre-push: no framework.config.json - allowing push." >&2; exit 0; }
+command -v python3 >/dev/null 2>&1 || { echo "pre-push: python3 not found - allowing push." >&2; exit 0; }
+cd "$repo_root" || exit 0
+exec python3 - "$cfg" <<'PY'
+import json, subprocess, sys
+
+try:
+    with open(sys.argv[1], encoding="utf-8") as fh:
+        cmds = (json.load(fh).get("hooks") or {}).get("pre_push_commands") or []
+except (OSError, ValueError):
+    sys.exit(0)  # fail-open: an unreadable config never blocks a push
+if not cmds:
+    print("pre-push: hooks.pre_push_commands is empty - allowing push.", file=sys.stderr)
+    sys.exit(0)
+for cmd in cmds:
+    print(f"pre-push: running: {cmd}", file=sys.stderr)
+    rc = subprocess.run(cmd, shell=True).returncode
+    if rc != 0:
+        print(f"pre-push: BLOCKED - '{cmd}' failed (exit {rc}).", file=sys.stderr)
+        print(
+            "pre-push: fix the failure, or edit hooks.pre_push_commands in"
+            " .claude/framework.config.json.",
+            file=sys.stderr,
+        )
+        sys.exit(rc)
+print("pre-push: all checks passed.", file=sys.stderr)
+PY
+"""
+
+
+def _next_backup_path(path: Path) -> Path:
+    """Return a non-clobbering backup path for ``path``.
+
+    Prefers ``<name>.bak``; if that already exists, falls back to ``<name>.bak.1``,
+    ``<name>.bak.2``, … so an existing backup is never overwritten. (Mirrors the
+    CLAUDE.md backup pattern in python/src/real_team/bootstrap.py.)
+    """
+    backup = path.with_name(path.name + ".bak")
+    counter = 1
+    while backup.exists():
+        backup = path.with_name(f"{path.name}.bak.{counter}")
+        counter += 1
+    return backup
+
+
+def _git_hooks_dir(target: Path) -> tuple[Path | None, str | None]:
+    """Resolve the EFFECTIVE git hooks dir for ``target``. Returns (dir, note).
+
+    Asks git itself first (``rev-parse --git-path hooks``), which honours
+    ``core.hooksPath`` and worktree/submodule ``.git``-file layouts; the note
+    reports a non-default ``core.hooksPath`` so the operator knows where the
+    hook went. Falls back to a manual ``.git`` walk when the git binary is
+    unavailable. Returns ``(None, reason)`` when there is nowhere sane to write
+    (fail-open: the caller skips with a notice, never errors).
+    """
+    git_entry = target / ".git"
+    if not git_entry.exists():
+        return None, "no .git"
+    try:
+        r = subprocess.run(
+            ["git", "-C", str(target), "rev-parse", "--git-path", "hooks"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if r.returncode == 0 and r.stdout.strip():
+            hooks_dir = Path(r.stdout.strip())
+            if not hooks_dir.is_absolute():
+                hooks_dir = (target / hooks_dir).resolve()
+            note = None
+            c = subprocess.run(
+                ["git", "-C", str(target), "config", "--get", "core.hooksPath"],
+                capture_output=True, text=True, timeout=10,
+            )
+            if c.returncode == 0 and c.stdout.strip():
+                note = f"core.hooksPath is set ({c.stdout.strip()})"
+            return hooks_dir, note
+    except (OSError, subprocess.SubprocessError):
+        pass  # git missing/broken -> manual fallback below
+    if git_entry.is_dir():
+        return git_entry / "hooks", None
+    try:  # worktree/submodule: .git is a file containing "gitdir: <path>"
+        for line in git_entry.read_text(encoding="utf-8").splitlines():
+            if line.startswith("gitdir:"):
+                gitdir = Path(line.split(":", 1)[1].strip())
+                if not gitdir.is_absolute():
+                    gitdir = (target / gitdir).resolve()
+                return gitdir / "hooks", None
+    except OSError:
+        pass
+    return None, "unrecognised .git layout"
+
+
+def install_pre_push(target: Path, mode: str, cfg: dict | None = None, *, dry_run: bool) -> str:
+    """Install ``<hooks-dir>/pre-push`` in ``target`` per ``mode``. Idempotent.
+
+    Self-contained (only reads ``cfg`` for an advisory); ``mode`` is the
+    RESOLVED install-config ``pre_push.mode`` (--pre-push flag > user YAML >
+    shipped default noop). ``noop`` writes an executable, clearly-commented
+    exit-0 script; ``enforce`` writes a script that runs
+    ``hooks.pre_push_commands`` from framework.config.json and blocks the push
+    on failure; ``none`` installs nothing. A pre-existing pre-push with
+    different content is never clobbered — it is preserved via the
+    non-clobbering ``.bak`` pattern with a warning. No ``.git`` -> skip with a
+    notice (fail-open). Returns a one-line status for the report.
+    """
+    if mode == "none":
+        return "skipped (pre_push.mode=none)"
+    hooks_dir, note = _git_hooks_dir(target)
+    if hooks_dir is None:
+        return f"skipped ({note} — nothing to hook; re-run after `git init`)"
+    if note:
+        print(f"note:          {note} — writing pre-push there")
+    if mode == "enforce" and cfg is not None:
+        if not (cfg.get("hooks") or {}).get("pre_push_commands"):
+            print(
+                "warn:          hooks.pre_push_commands is empty — the enforce hook will"
+                " allow pushes until you set it in .claude/framework.config.json"
+            )
+    content = _ENFORCE_PRE_PUSH if mode == "enforce" else _NOOP_PRE_PUSH
+    dest = hooks_dir / "pre-push"
+    if dest.exists():
+        try:
+            existing = dest.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            existing = None
+        if existing == content:
+            return f"already installed ({mode}; unchanged)"
+        if dry_run:
+            return f"would back up existing pre-push (.bak) and write the {mode} hook"
+        backup = _next_backup_path(dest)
+        dest.rename(backup)
+        print(
+            f"warn:          existing pre-push preserved as {backup.name} —"
+            " reconcile any custom logic it carried"
+        )
+    if dry_run:
+        return f"would write the {mode} hook"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    dest.write_text(content, encoding="utf-8")
+    dest.chmod(0o755)
+    return f"installed ({mode}) at {dest}"
+
+
 # ---------------------------------------------------------------- main
 
 
@@ -589,6 +778,10 @@ def main() -> int:
     ap.add_argument("--shell", choices=["bash", "zsh"])
     ap.add_argument("--reviewers", type=int)
     ap.add_argument("--merge-model", choices=["wave-branch", "direct-to-main"])
+    ap.add_argument("--pre-push", choices=["noop", "enforce", "none"], default=None,
+                    help="Pre-push git hook to install (install-config key pre_push.mode; "
+                         "precedence: this flag > user YAML > shipped default noop). "
+                         "enforce runs hooks.pre_push_commands; none installs nothing.")
     mode_group = ap.add_mutually_exclusive_group()
     mode_group.add_argument("--interactive", action="store_true",
                             help="Prompt for missing fields + review the proposed team (TTY only)")
@@ -706,6 +899,10 @@ def main() -> int:
         target_claude, dry_run=args.dry_run, install_permissions=not args.no_permissions
     )
     charter = install_charter(target_claude, cfg, force=args.force, dry_run=args.dry_run)
+    # Pre-push hook mode is config-driven: the RESOLVED pre_push.mode
+    # (flag > user YAML > shipped default noop).
+    pre_push_mode = install_config.get_key(inst, "pre_push.mode", "noop")
+    pre_push_status = install_pre_push(target, pre_push_mode, cfg, dry_run=args.dry_run)
 
     # Ontology (seed overlay + generated structural index) is config-driven:
     # the RESOLVED ontology.enabled (flags > user YAML > shipped default ON).
@@ -743,7 +940,7 @@ def main() -> int:
         f"{'would be written' if args.dry_run else 'written'}; "
         f"{len(charter['skipped'])} skipped"
     )
-    print(f"pre-push mode:     {install_config.get_key(inst, 'pre_push.mode', 'noop')} (recorded; hook installer is a separate tranche)")
+    print(f"pre-push hook:     {pre_push_status}")
     children = inst.get("children") or []
     if children:
         print(f"children:          {len(children)} recorded ({', '.join(c.get('path', '?') for c in children[:4])}{' …' if len(children) > 4 else ''})")

--- a/framework/install/install_config.py
+++ b/framework/install/install_config.py
@@ -25,11 +25,11 @@ Schema (v1) — every key, with the shipped default:
     team.size:           int | null                      (null)
     children:            list of {path: str, flavor: product|infra}   ([])
 
-Keys whose behaviour lands in later issues (``repo.expect`` enforcement,
-``project.model`` meta/child modes, ``children``, ``pre_push``) are parsed,
-validated, and carried — the resolved config is written to
-``.claude/install.config.json`` so downstream consumers read one canonical
-record of the install-time decisions.
+``pre_push.mode`` drives the bootstrapper's pre-push hook installer. Keys
+whose behaviour lands in later issues (``repo.expect`` enforcement,
+``project.model`` meta/child modes, ``children``) are parsed, validated, and
+carried — the resolved config is written to ``.claude/install.config.json`` so
+downstream consumers read one canonical record of the install-time decisions.
 
 Stdlib only (uses the sibling ``miniyaml`` parser).
 """

--- a/framework/tests/test_pre_push.py
+++ b/framework/tests/test_pre_push.py
@@ -1,0 +1,215 @@
+"""Tests for the pre-push git hook installer (bootstrap.py --pre-push).
+
+Covers the issue's AC: noop install (executable, exits 0), enforce blocks the
+push on a failing configured command and passes on success, backup-on-conflict
+via the non-clobbering .bak pattern, no-.git skip (fail-open), idempotent
+re-run, `none` installs nothing, and core.hooksPath is respected. The enforce
+semantics are asserted by executing the installed hook script directly (what
+git itself would exec on push). Stdlib + pytest only.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+_BOOTSTRAP = _FRAMEWORK_ROOT / "install" / "bootstrap.py"
+
+
+def _install(target: Path, *extra: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(_BOOTSTRAP), str(target), "--owner", "test-org", "--no-team", *extra],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _git_init(target: Path) -> None:
+    subprocess.run(["git", "init", "-q", str(target)], check=True, capture_output=True)
+
+
+def _set_pre_push_commands(target: Path, cmds: list[str]) -> None:
+    p = target / ".claude" / "framework.config.json"
+    cfg = json.loads(p.read_text())
+    cfg.setdefault("hooks", {})["pre_push_commands"] = cmds
+    p.write_text(json.dumps(cfg))
+
+
+def _run_hook(target: Path, hook: Path | None = None) -> subprocess.CompletedProcess:
+    """Execute the installed pre-push hook the way git would (from the repo)."""
+    hook = hook or (target / ".git" / "hooks" / "pre-push")
+    return subprocess.run([str(hook)], cwd=str(target), capture_output=True, text=True)
+
+
+def test_noop_install_is_executable_and_exits_zero(tmp_path: Path) -> None:
+    _git_init(tmp_path)
+    r = _install(tmp_path)  # noop is the default mode
+    assert r.returncode == 0, r.stderr
+    assert "pre-push hook:" in r.stdout and "installed (noop)" in r.stdout
+
+    hook = tmp_path / ".git" / "hooks" / "pre-push"
+    assert hook.is_file()
+    assert os.access(hook, os.X_OK), "hook must be executable"
+    text = hook.read_text()
+    assert "2real team framework" in text  # says who installed it
+    assert "noop" in text and "enforce" in text  # explains itself + how to enable enforcement
+
+    assert _run_hook(tmp_path).returncode == 0  # never blocks a push
+
+
+def test_enforce_blocks_on_failing_command(tmp_path: Path) -> None:
+    _git_init(tmp_path)
+    r = _install(tmp_path, "--pre-push", "enforce")
+    assert r.returncode == 0, r.stderr
+    assert "installed (enforce)" in r.stdout
+    # Empty command list at install time earns an advisory.
+    assert "pre_push_commands is empty" in r.stdout
+
+    _set_pre_push_commands(tmp_path, ["true", "exit 7"])
+    run = _run_hook(tmp_path)
+    assert run.returncode == 7, run.stderr
+    assert "BLOCKED" in run.stderr
+
+
+def test_enforce_passes_on_success(tmp_path: Path) -> None:
+    _git_init(tmp_path)
+    _install(tmp_path, "--pre-push", "enforce")
+    _set_pre_push_commands(tmp_path, ["true", "echo ok"])
+    run = _run_hook(tmp_path)
+    assert run.returncode == 0, run.stderr
+    assert "all checks passed" in run.stderr
+
+
+def test_enforce_fails_open_on_empty_or_missing_config(tmp_path: Path) -> None:
+    _git_init(tmp_path)
+    _install(tmp_path, "--pre-push", "enforce")
+    # Empty command list -> allow the push.
+    assert _run_hook(tmp_path).returncode == 0
+    # Missing config entirely -> still allow the push.
+    (tmp_path / ".claude" / "framework.config.json").unlink()
+    run = _run_hook(tmp_path)
+    assert run.returncode == 0
+    assert "allowing push" in run.stderr
+
+
+def test_existing_hook_is_backed_up_not_clobbered(tmp_path: Path) -> None:
+    _git_init(tmp_path)
+    hooks = tmp_path / ".git" / "hooks"
+    hooks.mkdir(parents=True, exist_ok=True)
+    custom = "#!/bin/sh\necho my custom hook\n"
+    (hooks / "pre-push").write_text(custom)
+
+    r = _install(tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert "preserved as pre-push.bak" in r.stdout  # warned
+    assert (hooks / "pre-push.bak").read_text() == custom  # original kept
+    assert "2real team framework" in (hooks / "pre-push").read_text()  # ours installed
+
+    # A second conflicting hook backs up to .bak.1 (never overwrites .bak).
+    (hooks / "pre-push").write_text(custom + "# v2\n")
+    r2 = _install(tmp_path)
+    assert r2.returncode == 0
+    assert (hooks / "pre-push.bak.1").is_file()
+    assert (hooks / "pre-push.bak").read_text() == custom  # first backup untouched
+
+
+def test_no_git_target_skips_with_notice(tmp_path: Path) -> None:
+    r = _install(tmp_path)  # no git init
+    assert r.returncode == 0, r.stderr  # fail-open: the install itself succeeds
+    assert "pre-push hook:     skipped" in r.stdout
+    assert not (tmp_path / ".git").exists()
+
+
+def test_rerun_is_idempotent(tmp_path: Path) -> None:
+    _git_init(tmp_path)
+    _install(tmp_path)
+    r2 = _install(tmp_path)
+    assert r2.returncode == 0
+    assert "already installed (noop; unchanged)" in r2.stdout
+    hooks = tmp_path / ".git" / "hooks"
+    assert not (hooks / "pre-push.bak").exists()  # our own hook is never "backed up"
+
+
+def test_mode_switch_replaces_framework_hook_with_backup(tmp_path: Path) -> None:
+    _git_init(tmp_path)
+    _install(tmp_path)  # noop
+    r = _install(tmp_path, "--pre-push", "enforce")
+    assert r.returncode == 0
+    assert "installed (enforce)" in r.stdout
+    assert "enforce. Runs every command" in (tmp_path / ".git" / "hooks" / "pre-push").read_text()
+
+
+def test_none_installs_nothing(tmp_path: Path) -> None:
+    _git_init(tmp_path)
+    r = _install(tmp_path, "--pre-push", "none")
+    assert r.returncode == 0, r.stderr
+    assert "skipped (pre_push.mode=none)" in r.stdout
+    assert not (tmp_path / ".git" / "hooks" / "pre-push").exists()
+
+
+def test_install_config_yaml_drives_mode_without_flag(tmp_path: Path) -> None:
+    """pre_push.mode from a user install-config YAML drives install_pre_push (no flag)."""
+    yaml = tmp_path / "install.yaml"
+    yaml.write_text("pre_push:\n  mode: enforce\n", encoding="utf-8")
+    target = tmp_path / "repo"
+    target.mkdir()
+    _git_init(target)
+    r = _install(target, "--install-config", str(yaml))
+    assert r.returncode == 0, r.stderr
+    assert "installed (enforce)" in r.stdout
+    hook = target / ".git" / "hooks" / "pre-push"
+    assert "MODE: enforce" in hook.read_text()
+    # The resolved decision is recorded in the install snapshot.
+    snapshot = json.loads((target / ".claude" / "install.config.json").read_text())
+    assert snapshot["pre_push"]["mode"] == "enforce"
+
+
+def test_flag_beats_install_config_yaml(tmp_path: Path) -> None:
+    """Precedence: --pre-push flag > user YAML (> shipped default noop)."""
+    yaml = tmp_path / "install.yaml"
+    yaml.write_text("pre_push:\n  mode: enforce\n", encoding="utf-8")
+    target = tmp_path / "repo"
+    target.mkdir()
+    _git_init(target)
+    r = _install(target, "--install-config", str(yaml), "--pre-push", "none")
+    assert r.returncode == 0, r.stderr
+    assert "skipped (pre_push.mode=none)" in r.stdout
+    assert not (target / ".git" / "hooks" / "pre-push").exists()
+    # The flag decision (not the YAML's) is what the snapshot records.
+    snapshot = json.loads((target / ".claude" / "install.config.json").read_text())
+    assert snapshot["pre_push"]["mode"] == "none"
+
+
+def test_shipped_default_is_noop_without_flag_or_yaml(tmp_path: Path) -> None:
+    _git_init(tmp_path)
+    r = _install(tmp_path)  # no --pre-push flag, no --install-config
+    assert r.returncode == 0, r.stderr
+    assert "installed (noop)" in r.stdout
+    assert "MODE: noop" in (tmp_path / ".git" / "hooks" / "pre-push").read_text()
+
+
+def test_core_hookspath_is_respected(tmp_path: Path) -> None:
+    _git_init(tmp_path)
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "core.hooksPath", ".githooks"],
+        check=True, capture_output=True,
+    )
+    r = _install(tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert "core.hooksPath is set" in r.stdout
+    hook = tmp_path / ".githooks" / "pre-push"
+    assert hook.is_file(), "hook must land in the EFFECTIVE hooks dir, not .git/hooks"
+    assert not (tmp_path / ".git" / "hooks" / "pre-push").exists()
+    assert _run_hook(tmp_path, hook).returncode == 0
+
+
+def test_dry_run_writes_nothing(tmp_path: Path) -> None:
+    _git_init(tmp_path)
+    r = _install(tmp_path, "--dry-run")
+    assert r.returncode == 0, r.stderr
+    assert "would write the noop hook" in r.stdout
+    assert not (tmp_path / ".git" / "hooks" / "pre-push").exists()


### PR DESCRIPTION
Closes #67

## Summary

Adds a pre-push git hook installer to `framework/install/bootstrap.py`, no-op by default, as a self-contained `install_pre_push()` + a `--pre-push {noop,enforce,none}` CLI flag (default `noop`). `main()` changes are three localized lines (flag, call, report line) so #64's `install.config.yaml` layer can later drive the same flag without conflict.

## Design

**Modes**
- `noop` (default): executable, clearly-commented `#!/bin/sh` script that exits 0 — says the framework installed it, what it is, and exactly how to enable enforcement.
- `enforce`: script that runs `hooks.pre_push_commands` from `.claude/framework.config.json` in order from the repo root and blocks the push on the first nonzero exit. The list is read **at push time**, so editing the config changes the checks with no reinstall. Fail-open: missing config, missing python3, or an empty list allows the push with a note.
- `none`: installs nothing (never deletes an existing hook).

**Safety rails (framework philosophy: fail-open, config-driven, idempotent)**
- Never clobbers an existing `pre-push`: differing content is preserved via the non-clobbering `.bak`/`.bak.N` pattern (mirrors `_next_backup_path` in `python/src/real_team/bootstrap.py`) with a warning; identical content → "already installed (unchanged)", so re-runs create no backups.
- Respects `core.hooksPath`: the effective hooks dir is resolved via `git rev-parse --git-path hooks` (also handles worktree/submodule `.git`-files), with a manual `.git`-walk fallback when the git binary is absent; a non-default `core.hooksPath` is reported.
- Target without `.git` → skip with a notice, exit 0.
- `--dry-run` reports the plan and writes nothing.

**New config key** `hooks.pre_push_commands` (default `[]`) added to all three synced copies — `framework/config/framework.config.schema.json`, `_framework_config._DEFAULTS`, `bootstrap._schema_defaults()` — plus the example config and the config README table. Root README gains a "Pre-push hook" section (what's installed, modes, how to switch).

Since `noop` is the default, `2real-team init --with-hooks` (which subprocesses the bundled bootstrap with default flags) picks this up automatically — dual-deploy requirement satisfied with no CLI change.

## Test evidence

New `framework/tests/test_pre_push.py` (11 tests): noop executable + exits 0; enforce blocks on failing command (propagates its exit code) / passes on success / fails open on empty or missing config; backup-on-conflict (`.bak` then `.bak.1`, first backup untouched); no-git skip; idempotent re-run; mode switch; `none` installs nothing; `core.hooksPath` respected; dry-run writes nothing.

```
python3 -m pytest framework/tests/ -q      -> 70 passed
cd python && PYTHONPATH=src python -m pytest -q -> 106 passed, 3 warnings
ruff check framework/                      -> All checks passed!
```

Also verified end-to-end with a real `git push` to a local bare remote: enforce hook with `["exit 3"]` blocks the push (`rc=1`, "BLOCKED" on stderr); with `["true"]` the push succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1sHWTyKtu8DAExDn9DgLS
