### PR TITLE
feat(install): unified YAML install config + noninteractive install mode (#64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,10 @@ CLAUDE.md                # Team section, written at the project root
 | `--preset <name>` | Project preset: `fullstack-monorepo`, `data-pipeline`, `library` |
 | `--team-size <n>` | Override the preset's default team size |
 | `--project-name <name>` | Project name (defaults to directory name) |
-| `--config <path>` | Path to a YAML config file (see below) |
+| `--config <path>` | Path to a YAML config file — unified install config or legacy team config (see below) |
 | `--target <dir>` | Target directory (defaults to `.`) |
 | `--no-interactive` | Disable interactive prompts |
+| `--non-interactive` | Guarantee zero prompts; the config (flags > YAML > shipped defaults) answers everything |
 | `--git-email-prefix <prefix>` | Email prefix (e.g., `myorg` produces `myorg+First.Last@gmail.com`) |
 | `--ai-personas` | Use Claude API to generate rich, diverse personas |
 | `--seed <n>` | Seed for reproducible AI persona generation |
@@ -149,6 +150,55 @@ Config file fields:
 | `members` | list | Per-member overrides (name, role, level, personality) |
 
 See `examples/` for sample configs for each preset.
+
+## Install configuration
+
+A single unified `install.config.yaml` schema covers **every** interactive decision point
+across both installers — the stdlib-only `framework/install/bootstrap.py` and `2real-team init`
+(which auto-detects it via `--config`). It drives fully non-interactive installs:
+
+```bash
+# Standalone framework installer (stdlib-only, zero prompts):
+python3 framework/install/bootstrap.py /path/to/repo --install-config my.install.yaml --non-interactive
+
+# Python CLI (same file, auto-detected):
+2real-team init --config my.install.yaml --non-interactive
+```
+
+**Precedence:** CLI flags > user YAML > shipped defaults
+(`framework/config/install.config.default.yaml` — a fully commented reference copy).
+The resolved config is recorded at `<target>/.claude/install.config.json` so downstream
+tooling reads one canonical record of the install-time decisions. This is the
+*install-time* config; the *runtime* config the hooks read remains
+`.claude/framework.config.json` (overlapping keys — `scm.owner`, `project.name`,
+`project.model` — flow into it).
+
+### Key reference
+
+| Key | Type | Default | Effect |
+|-----|------|---------|--------|
+| `version` | integer | `1` | Config schema version (must be `1`) |
+| `repo.expect` | `fresh` \| `existing` \| `any` | `fresh` | Expectation about the target repo. Recorded today (a mismatch prints a note); detection/enforcement ships with the meta/child install modes |
+| `project.name` | string \| null | `null` | Display name; `null` falls back to the target directory name |
+| `project.model` | `standalone` \| `meta` \| `child` | `standalone` | Project shape. Maps into the runtime config (`standalone`/`child` → `single-repo`, `meta` → `meta-and-children`) |
+| `scm.provider` | `github` | `github` | SCM host (only GitHub is implemented) |
+| `scm.owner` | string \| null | `null` | GitHub org/user. Replaces the interactive owner prompt; flows into `framework.config.json` |
+| `ci.provider` | `github-actions` | `github-actions` | CI system (only GitHub Actions is implemented) |
+| `ticketing.provider` | `github-issues` | `github-issues` | Story/task tracker (only GitHub Issues is implemented) |
+| `pre_push.mode` | `noop` \| `enforce` \| `none` | `noop` | Git pre-push hook mode. Validated and recorded; the hook installer is a separate tranche |
+| `ontology.enabled` | bool | `true` | Lay the two-layer ontology seed and activate the ontology hooks (`--with-ontology`/`--no-ontology` override) |
+| `team.enabled` | bool | `true` | Generate the team layer (roster, identity gate); `false` installs the runtime only |
+| `team.preset` | string \| null | `null` | Team preset for `2real-team init` (`fullstack-monorepo`, `data-pipeline`, `library`). Replaces the preset prompt |
+| `team.size` | integer \| null | `null` | Target headcount. Replaces the team-size and roster-proceed prompts; `null` lets the preset/introspection decide |
+| `children` | list | `[]` | Child repos for meta/child models: `- path: <rel-path>` with optional `flavor: product\|infra` (default `product`). Parsed, validated, and recorded for the meta/child install modes |
+
+Unknown keys are warned about and **carried** into the recorded snapshot (forward
+compatibility). Invalid values (bad enums/types) are fatal — the install refuses to proceed.
+
+With `--non-interactive` there are **zero prompts on any path**: `scm.owner` left `null`
+produces a warning (not a prompt), and the team is generated exactly as configured.
+`bootstrap.py` stays stdlib-only — it reads the YAML with a bundled minimal parser
+(`framework/install/miniyaml.py`); the Python CLI uses PyYAML.
 
 ## AI Persona Generation
 

--- a/framework/config/install.config.default.yaml
+++ b/framework/config/install.config.default.yaml
@@ -1,0 +1,77 @@
+# 2real framework — install-time configuration (the unified install config).
+#
+# This file is the SHIPPED DEFAULT layer. It covers every interactive decision
+# point of both installers (framework/install/bootstrap.py and `2real-team init`)
+# so that a `--non-interactive` install needs zero prompts.
+#
+# Precedence (highest wins):   CLI flags  >  user YAML (--install-config)  >  this file
+#
+# Copy it, edit, and pass via:
+#   python3 framework/install/bootstrap.py <target> --install-config my.install.yaml --non-interactive
+#   2real-team init --config my.install.yaml --non-interactive
+#
+# NOTE: this is the INSTALL-time config. The RUNTIME config the hooks read is
+# still `.claude/framework.config.json` — install keys that overlap (scm.owner,
+# project name/model) flow into the generated runtime config.
+
+version: 1
+
+repo:
+  # What the installer should expect at the target:
+  #   fresh    — a brand-new project (no established repo yet)
+  #   existing — an already-established repository
+  #   any      — no expectation; install either way
+  # (Fresh-vs-existing detection/enforcement ships with the meta/child install modes.)
+  expect: fresh
+
+project:
+  # Display name. null -> defaults to the target directory's name.
+  name: null
+  # Project shape:
+  #   standalone — a single self-contained repository
+  #   meta       — a parent meta-repo orchestrating N child repos
+  #   child      — one child repo inside a meta-repo project
+  model: standalone
+
+scm:
+  # Source-control host. Only `github` is implemented today.
+  provider: github
+  # GitHub org or user that owns the repo(s). null -> prompted in interactive
+  # mode, warned about (and left unset) in non-interactive mode.
+  owner: null
+
+ci:
+  # CI/CD system. Only `github-actions` is implemented today.
+  provider: github-actions
+
+ticketing:
+  # Story/task/bug tracker. Only `github-issues` is implemented today.
+  provider: github-issues
+
+pre_push:
+  # Git pre-push hook installation mode:
+  #   noop    — install the pre-push hook as a no-op placeholder (recommended)
+  #   enforce — install the pre-push hook with checks enabled
+  #   none    — do not install a pre-push hook
+  mode: noop
+
+ontology:
+  # Lay down the two-layer ontology seed (semantic overlay template) and
+  # activate the ontology_refresh / ontology_tracker hooks.
+  enabled: true
+
+team:
+  # Generate the simulated-team layer (charter/roster/identity gate).
+  enabled: true
+  # Team preset (used by `2real-team init`): fullstack-monorepo | data-pipeline
+  # | library. null -> prompted in interactive mode, required for a
+  # non-interactive `2real-team init` (bootstrap.py introspects instead).
+  preset: null
+  # Target headcount. null -> the preset default / repo introspection decides.
+  size: null
+
+# Child repositories (meta/child project models only). Each entry:
+#   - path: relative path (or bare repo name) of the child
+#     flavor: product | infra        (defaults to product)
+# Consumed by the meta/child install modes; parsed and carried today.
+children: []

--- a/framework/install/bootstrap.py
+++ b/framework/install/bootstrap.py
@@ -9,13 +9,23 @@ changes nothing. Interactive prompts are an opt-in convenience, never required.
 
 Stdlib only (no deps), so it runs anywhere ``python3`` does.
 
+Install-time decisions are driven by the unified YAML install config
+(``--install-config``; shipped defaults at ``config/install.config.default.yaml``)
+with precedence CLI flags > user YAML > shipped defaults. ``--non-interactive``
+guarantees zero prompts on every path. The resolved install config is recorded
+at ``<target>/.claude/install.config.json``; the RUNTIME config the hooks read
+remains ``<target>/.claude/framework.config.json``.
+
 Usage
 =====
 
   # Deterministic (no prompts) — minimal:
   python3 bootstrap.py /path/to/repo --owner my-org
 
-  # From a prepared config file (recommended for reproducible installs):
+  # Fully declarative, zero prompts (recommended for automation):
+  python3 bootstrap.py /path/to/repo --install-config my.install.yaml --non-interactive
+
+  # From a prepared RUNTIME config seed (JSON, framework.config.json shape):
   python3 bootstrap.py /path/to/repo --config my.framework.config.json
 
   # Preview without writing anything:
@@ -27,8 +37,10 @@ Usage
 Flags
 =====
   target                 Target repo root (default: current directory).
-  --config PATH          JSON config to seed from (overlaid on schema defaults).
-  --owner NAME           scm.owner (GitHub org/user). Overlays --config.
+  --install-config PATH  Unified YAML install config (see --help for the keys).
+  --non-interactive      Never prompt; the install config answers everything.
+  --config PATH          JSON RUNTIME-config seed (framework.config.json shape).
+  --owner NAME           scm.owner (GitHub org/user). Overlays the configs.
   --project-name NAME    project.name.
   --model {single-repo,meta-and-children}
   --shell {bash,zsh}
@@ -36,10 +48,11 @@ Flags
   --merge-model {wave-branch,direct-to-main}
   --no-permissions       Skip installing the curated permissions.allow allowlist.
   --interactive          Prompt for missing required fields (scm.owner) if a TTY.
+  --with-ontology / --no-ontology   Override ontology.enabled from the config.
   --force                Overwrite existing hook/lib files and framework.config.json.
   --dry-run              Print the plan; write nothing.
 
-Exit codes: 0 ok / dry-run, 1 on a hard error (e.g. assets missing).
+Exit codes: 0 ok / dry-run, 1 on a hard error (e.g. assets missing, invalid config).
 """
 
 from __future__ import annotations
@@ -51,6 +64,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+import install_config  # noqa: E402  (sibling module in install/)
 import roster_gen  # noqa: E402  (sibling module in install/)
 
 # framework/install/bootstrap.py  ->  framework/
@@ -107,7 +121,53 @@ def _set_path(cfg: dict, dotted: str, value) -> None:
     node[parts[-1]] = value
 
 
-def build_config(args: argparse.Namespace) -> dict:
+def resolve_install_config(args: argparse.Namespace) -> tuple[dict, set[str]]:
+    """Resolve the unified install config: flags > user YAML > shipped defaults.
+
+    Returns ``(install_cfg, user_keys)``; ``user_keys`` are the dotted paths the
+    operator explicitly decided (via YAML or flag) — used for precedence into the
+    runtime config and for prompt-skipping. Raises SystemExit on invalid input.
+    """
+    try:
+        inst, user_keys = install_config.load(args.install_config)
+    except install_config.InstallConfigError as e:
+        raise SystemExit(f"ERROR: {e}")
+
+    # CLI flags are the highest-precedence layer of the install config.
+    flag_map = {
+        "scm.owner": args.owner,
+        "project.name": args.project_name,
+        "team.size": args.team_size,
+    }
+    if args.model:  # runtime enum -> install enum
+        flag_map["project.model"] = install_config.INSTALL_MODEL_MAP[args.model]
+    if args.no_team:
+        flag_map["team.enabled"] = False
+    if args.no_ontology:
+        flag_map["ontology.enabled"] = False
+    elif args.with_ontology:
+        flag_map["ontology.enabled"] = True
+    for dotted, value in flag_map.items():
+        if value is not None:
+            install_config.set_key(inst, dotted, value)
+            user_keys.add(dotted)
+
+    problems, warnings = install_config.validate(inst)
+    for w in warnings:
+        print(f"install-config warn: {w}")
+    if problems:
+        for p in problems:
+            print(f"install-config problem: {p}", file=sys.stderr)
+        raise SystemExit("ERROR: refusing to install with an invalid install config.")
+    return inst, user_keys
+
+
+def build_config(args: argparse.Namespace, inst: dict, user_keys: set[str]) -> dict:
+    """Build the RUNTIME config (framework.config.json shape).
+
+    Layering: schema defaults < ``--config`` JSON seed < install-config overlay
+    (which already has the CLI flags folded in, so flags beat both files).
+    """
     cfg = _schema_defaults()
     if args.config:
         try:
@@ -118,13 +178,9 @@ def build_config(args: argparse.Namespace) -> dict:
             raise SystemExit("ERROR: --config must be a JSON object")
         cfg = _deep_merge(cfg, loaded)
 
-    # Individual flags overlay the config file.
-    if args.owner:
-        _set_path(cfg, "scm.owner", args.owner)
-    if args.project_name:
-        _set_path(cfg, "project.name", args.project_name)
-    if args.model:
-        _set_path(cfg, "project.model", args.model)
+    cfg = _deep_merge(cfg, install_config.runtime_overlay(inst, user_keys))
+
+    # Runtime-only flags (no install-config equivalent) overlay everything.
     if args.shell:
         _set_path(cfg, "shell", args.shell)
     if args.reviewers is not None:
@@ -132,12 +188,14 @@ def build_config(args: argparse.Namespace) -> dict:
     if args.merge_model:
         _set_path(cfg, "policy.merge_model", args.merge_model)
 
-    # Interactive fill of still-missing required-ish fields (TTY only).
+    # Interactive fill of still-missing required-ish fields (TTY only; the
+    # config is always consulted first, --non-interactive never reaches here).
     if args.interactive and sys.stdin.isatty():
         if not cfg.get("scm", {}).get("owner"):
             ans = input("GitHub owner (org or user) [leave blank to skip]: ").strip()
             if ans:
                 _set_path(cfg, "scm.owner", ans)
+                install_config.set_key(inst, "scm.owner", ans)
 
     return cfg
 
@@ -243,6 +301,23 @@ def write_config(target_claude: Path, cfg: dict, *, force: bool, dry_run: bool) 
         return "would write"
     target_claude.mkdir(parents=True, exist_ok=True)
     dest.write_text(json.dumps(cfg, indent=2) + "\n", encoding="utf-8")
+    return "written"
+
+
+def write_install_snapshot(target_claude: Path, inst: dict, *, force: bool, dry_run: bool) -> str:
+    """Record the RESOLVED install config at .claude/install.config.json.
+
+    This is the carry-point for install-time decisions whose behaviour lands in
+    later tranches (repo.expect, meta/child models, children, pre_push): one
+    canonical, machine-readable record every downstream consumer reads.
+    """
+    dest = target_claude / install_config.SNAPSHOT_REL
+    if dest.exists() and not force:
+        return "skipped (exists; use --force to overwrite)"
+    if dry_run:
+        return "would write"
+    target_claude.mkdir(parents=True, exist_ok=True)
+    dest.write_text(json.dumps(inst, indent=2) + "\n", encoding="utf-8")
     return "written"
 
 
@@ -498,20 +573,37 @@ def generate_structural(
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(description="Install the 2real framework hooks into a repo.")
+    ap = argparse.ArgumentParser(
+        description="Install the 2real framework hooks into a repo.",
+        epilog=install_config.HELP_EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     ap.add_argument("target", nargs="?", default=".", help="Target repo root (default: cwd)")
-    ap.add_argument("--config", help="JSON config to seed from")
+    ap.add_argument("--install-config", metavar="YAML",
+                    help="Unified YAML install config (see the key reference below). "
+                         "Precedence: CLI flags > this file > shipped defaults.")
+    ap.add_argument("--config", help="JSON RUNTIME-config seed (framework.config.json shape)")
     ap.add_argument("--owner", help="scm.owner (GitHub org/user)")
     ap.add_argument("--project-name", help="project.name")
     ap.add_argument("--model", choices=["single-repo", "meta-and-children"])
     ap.add_argument("--shell", choices=["bash", "zsh"])
     ap.add_argument("--reviewers", type=int)
     ap.add_argument("--merge-model", choices=["wave-branch", "direct-to-main"])
-    ap.add_argument("--interactive", action="store_true", help="Prompt for missing fields + review the proposed team (TTY only)")
+    mode_group = ap.add_mutually_exclusive_group()
+    mode_group.add_argument("--interactive", action="store_true",
+                            help="Prompt for missing fields + review the proposed team (TTY only)")
+    mode_group.add_argument("--non-interactive", action="store_true",
+                            help="Guarantee zero prompts on every path; the install config "
+                                 "(flags > YAML > shipped defaults) answers everything")
     ap.add_argument("--no-team", action="store_true", help="Skip roster generation (install hooks only)")
     ap.add_argument("--team-size", type=int, help="Target headcount for the generated roster")
     ap.add_argument("--no-enforce-identity", action="store_true", help="Generate the roster but do NOT enable the commit-identity gate")
-    ap.add_argument("--with-ontology", action="store_true", help="Lay down the seed semantic-overlay template AND generate the structural index (activates the ontology hooks)")
+    ontology_group = ap.add_mutually_exclusive_group()
+    ontology_group.add_argument("--with-ontology", action="store_true",
+                                help="Lay down the seed semantic-overlay template AND generate the "
+                                     "structural index (ontology.enabled=true; activates the ontology hooks)")
+    ontology_group.add_argument("--no-ontology", action="store_true",
+                                help="Skip the ontology seed + structural index (ontology.enabled=false)")
     ap.add_argument("--no-permissions", action="store_true", help="Do NOT install the curated permissions.allow allowlist into settings.json (hook wiring still merges)")
     ap.add_argument("--force", action="store_true", help="Overwrite existing files")
     ap.add_argument("--dry-run", action="store_true", help="Print the plan; write nothing")
@@ -526,13 +618,25 @@ def main() -> int:
     mode = "DRY-RUN" if args.dry_run else "INSTALL"
     print(f"== 2real framework bootstrap ({mode}) ==")
     print(f"target repo:   {target}")
-    if not (target / ".git").exists():
-        print("note:          no .git here — installing anyway (new repo / pre-init).")
 
-    cfg = build_config(args)
+    inst, user_keys = resolve_install_config(args)
+
+    # repo.expect: informational today — detection/enforcement lands with the
+    # meta/child install modes. Mismatches are noted, never fatal.
+    expect = install_config.get_key(inst, "repo.expect", "fresh")
+    has_git = (target / ".git").exists()
+    if not has_git:
+        print("note:          no .git here — installing anyway (new repo / pre-init).")
+    if expect == "existing" and not has_git:
+        print("note:          repo.expect=existing but no .git found — proceeding.")
+    elif expect == "fresh" and has_git:
+        print("note:          repo.expect=fresh but a .git already exists — proceeding.")
+
+    cfg = build_config(args, inst, user_keys)
 
     # --- introspect the repo + plan the roster (the team layer) ---
-    team_enabled = not args.no_team
+    team_enabled = bool(install_config.get_key(inst, "team.enabled", True))
+    team_size = install_config.get_key(inst, "team.size")
     roster_plan = None
     if team_enabled:
         email_pattern = cfg.get("identity", {}).get("email_pattern") or "team+{First}.{Last}@example.com"
@@ -541,21 +645,30 @@ def main() -> int:
             email_pattern=email_pattern,
             declared_model=cfg.get("project", {}).get("model"),
             declared_repos=cfg.get("project", {}).get("repos"),
-            team_size=args.team_size,
+            team_size=team_size,
         )
-        # Record what introspection found back into the config.
+        # Record what introspection found back into the configs.
         cfg.setdefault("project", {})["model"] = roster_plan.intro.model
         if roster_plan.intro.model == "meta-and-children":
             cfg["project"]["repos"] = [r.name for r in roster_plan.intro.repos]
+        if "project.model" not in user_keys:
+            install_config.set_key(
+                inst, "project.model",
+                install_config.INSTALL_MODEL_MAP.get(roster_plan.intro.model, "standalone"),
+            )
 
         print("\n-- repo introspection + proposed team --")
         print(roster_plan.summary())
 
-        if args.interactive and sys.stdin.isatty():
+        # The config is consulted first: an explicit team decision (team.size /
+        # team.enabled via YAML or flag) answers the proceed-prompt.
+        team_answered = bool({"team.size", "team.enabled"} & user_keys)
+        if args.interactive and sys.stdin.isatty() and not team_answered:
             ans = input("\nProceed with this team? [Y]es / [s]ize N / [n]o team: ").strip().lower()
             if ans.startswith("n"):
                 team_enabled = False
                 roster_plan = None
+                install_config.set_key(inst, "team.enabled", False)
             elif ans.startswith("s"):
                 try:
                     size = int(ans.split()[-1])
@@ -564,6 +677,7 @@ def main() -> int:
                                                   declared_repos=cfg.get("project", {}).get("repos"),
                                                   team_size=size)
                     print(roster_plan.summary())
+                    install_config.set_key(inst, "team.size", size)
                 except (ValueError, IndexError):
                     print("  (could not parse size; keeping the proposed team)")
 
@@ -587,21 +701,24 @@ def main() -> int:
 
     assets = install_assets(target_claude, force=args.force, dry_run=args.dry_run)
     cfg_status = write_config(target_claude, cfg, force=args.force, dry_run=args.dry_run)
+    snapshot_status = write_install_snapshot(target_claude, inst, force=args.force, dry_run=args.dry_run)
     settings_status = merge_settings(
         target_claude, dry_run=args.dry_run, install_permissions=not args.no_permissions
     )
     charter = install_charter(target_claude, cfg, force=args.force, dry_run=args.dry_run)
 
+    # Ontology (seed overlay + generated structural index) is config-driven:
+    # the RESOLVED ontology.enabled (flags > user YAML > shipped default ON).
     overlay = None
     structural_status = None
-    if args.with_ontology:
+    if install_config.get_key(inst, "ontology.enabled", True):
         ontology_rel = cfg.get("paths", {}).get("ontology", "ontology")
         overlay = install_overlay_template(target, ontology_rel, force=args.force, dry_run=args.dry_run)
         structural_status = generate_structural(
             target, ontology_rel, cfg, force=args.force, dry_run=args.dry_run
         )
 
-    roster_status = "skipped (--no-team)"
+    roster_status = "skipped (team disabled)"
     if team_enabled and roster_plan is not None:
         rep = roster_gen.write_roster(target_claude / "team", roster_plan, force=args.force, dry_run=args.dry_run)
         n_children = max(0, len(roster_plan.intro.repos) - 1) if roster_plan.intro.model == "meta-and-children" else 0
@@ -618,6 +735,7 @@ def main() -> int:
     if assets["skipped"]:
         print(f"skipped (exists):  {len(assets['skipped'])} (use --force to overwrite)")
     print(f"framework.config:  {cfg_status}")
+    print(f"install snapshot:  {snapshot_status}")
     print(f"settings.json:     {settings_status}")
     charter_laid = charter["would_write"] if args.dry_run else charter["written"]
     print(
@@ -625,6 +743,10 @@ def main() -> int:
         f"{'would be written' if args.dry_run else 'written'}; "
         f"{len(charter['skipped'])} skipped"
     )
+    print(f"pre-push mode:     {install_config.get_key(inst, 'pre_push.mode', 'noop')} (recorded; hook installer is a separate tranche)")
+    children = inst.get("children") or []
+    if children:
+        print(f"children:          {len(children)} recorded ({', '.join(c.get('path', '?') for c in children[:4])}{' …' if len(children) > 4 else ''})")
     if overlay is not None:
         laid = overlay["would_copy"] if args.dry_run else overlay["copied"]
         print(f"ontology overlay:  {len(laid)} file(s) {'would be laid' if args.dry_run else 'laid'}; {len(overlay['skipped'])} skipped")

--- a/framework/install/install_config.py
+++ b/framework/install/install_config.py
@@ -1,0 +1,259 @@
+"""Unified install-time configuration: load / merge / validate.
+
+The single ``install.config.yaml`` schema covers every interactive decision
+point of both installers (``framework/install/bootstrap.py`` and the
+``2real-team`` CLI). This module owns the stdlib-only loading pipeline:
+
+    built-in fallback  <  shipped defaults (framework/config/install.config.default.yaml)
+                       <  user YAML (--install-config)
+                       <  CLI flags (applied by the caller via :func:`set_key`)
+
+Schema (v1) — every key, with the shipped default:
+
+    version: 1
+    repo.expect:         fresh | existing | any          (fresh)
+    project.name:        str | null                      (null -> target dir name)
+    project.model:       standalone | meta | child       (standalone)
+    scm.provider:        github                          (github)
+    scm.owner:           str | null                      (null)
+    ci.provider:         github-actions                  (github-actions)
+    ticketing.provider:  github-issues                   (github-issues)
+    pre_push.mode:       noop | enforce | none           (noop)
+    ontology.enabled:    bool                            (true)
+    team.enabled:        bool                            (true)
+    team.preset:         str | null                      (null)
+    team.size:           int | null                      (null)
+    children:            list of {path: str, flavor: product|infra}   ([])
+
+Keys whose behaviour lands in later issues (``repo.expect`` enforcement,
+``project.model`` meta/child modes, ``children``, ``pre_push``) are parsed,
+validated, and carried — the resolved config is written to
+``.claude/install.config.json`` so downstream consumers read one canonical
+record of the install-time decisions.
+
+Stdlib only (uses the sibling ``miniyaml`` parser).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import miniyaml  # noqa: E402  (sibling module in install/)
+
+# framework/install/install_config.py -> framework/
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+DEFAULTS_PATH = _FRAMEWORK_ROOT / "config" / "install.config.default.yaml"
+
+#: Where the resolved install config is recorded inside the target repo.
+SNAPSHOT_REL = "install.config.json"
+
+ENUMS: dict[str, tuple[str, ...]] = {
+    "repo.expect": ("fresh", "existing", "any"),
+    "project.model": ("standalone", "meta", "child"),
+    "scm.provider": ("github",),
+    "ci.provider": ("github-actions",),
+    "ticketing.provider": ("github-issues",),
+    "pre_push.mode": ("noop", "enforce", "none"),
+}
+CHILD_FLAVORS = ("product", "infra")
+
+#: install-config project.model -> runtime framework.config.json project.model
+RUNTIME_MODEL_MAP = {"standalone": "single-repo", "meta": "meta-and-children", "child": "single-repo"}
+#: runtime project.model -> install-config project.model (for flag reverse-mapping)
+INSTALL_MODEL_MAP = {"single-repo": "standalone", "meta-and-children": "meta"}
+
+
+class InstallConfigError(ValueError):
+    """A fatal problem loading/validating the install config."""
+
+
+def builtin_defaults() -> dict:
+    """In-code mirror of the shipped default file (safety net if it is missing)."""
+    return {
+        "version": 1,
+        "repo": {"expect": "fresh"},
+        "project": {"name": None, "model": "standalone"},
+        "scm": {"provider": "github", "owner": None},
+        "ci": {"provider": "github-actions"},
+        "ticketing": {"provider": "github-issues"},
+        "pre_push": {"mode": "noop"},
+        "ontology": {"enabled": True},
+        "team": {"enabled": True, "preset": None, "size": None},
+        "children": [],
+    }
+
+
+def deep_merge(base: dict, over: dict) -> dict:
+    out = dict(base)
+    for k, v in over.items():
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = deep_merge(out[k], v)
+        else:
+            out[k] = v
+    return out
+
+
+def dotted_keys(node: Any, prefix: str = "") -> set[str]:
+    """All leaf key-paths of a nested dict (lists count as leaves)."""
+    if not isinstance(node, dict):
+        return {prefix} if prefix else set()
+    keys: set[str] = set()
+    for k, v in node.items():
+        path = f"{prefix}.{k}" if prefix else str(k)
+        keys |= dotted_keys(v, path)
+    return keys
+
+
+def get_key(cfg: dict, dotted: str, default: Any = None) -> Any:
+    node: Any = cfg
+    for part in dotted.split("."):
+        if not isinstance(node, dict) or part not in node:
+            return default
+        node = node[part]
+    return node
+
+
+def set_key(cfg: dict, dotted: str, value: Any) -> None:
+    node = cfg
+    parts = dotted.split(".")
+    for p in parts[:-1]:
+        node = node.setdefault(p, {})
+    node[parts[-1]] = value
+
+
+def load(user_path: str | Path | None = None) -> tuple[dict, set[str]]:
+    """Resolve the install config: builtin < shipped defaults < user YAML.
+
+    Returns ``(config, user_keys)`` where ``user_keys`` is the set of dotted
+    key-paths the USER explicitly provided (used for precedence decisions and
+    for prompt-skipping). Raises :class:`InstallConfigError` on unreadable or
+    structurally invalid input.
+    """
+    cfg = builtin_defaults()
+    if DEFAULTS_PATH.is_file():
+        try:
+            shipped = miniyaml.load(DEFAULTS_PATH)
+        except (OSError, miniyaml.MiniYamlError) as e:
+            raise InstallConfigError(f"shipped default install config is unreadable: {e}")
+        if isinstance(shipped, dict):
+            cfg = deep_merge(cfg, shipped)
+
+    user_keys: set[str] = set()
+    if user_path is not None:
+        p = Path(user_path)
+        try:
+            data = miniyaml.load(p)
+        except OSError as e:
+            raise InstallConfigError(f"install config could not be read: {e}")
+        except miniyaml.MiniYamlError as e:
+            raise InstallConfigError(f"install config is not valid YAML ({p}): {e}")
+        if not isinstance(data, dict):
+            raise InstallConfigError(f"install config must be a YAML mapping ({p})")
+        cfg = deep_merge(cfg, data)
+        user_keys = dotted_keys(data)
+    return cfg, user_keys
+
+
+def validate(cfg: dict) -> tuple[list[str], list[str]]:
+    """Validate the resolved config. Returns ``(problems, warnings)``.
+
+    Problems are fatal (bad enum values / types); warnings are advisory
+    (unknown keys — kept for forward compatibility, they are carried as-is).
+    """
+    problems: list[str] = []
+    warnings: list[str] = []
+
+    if cfg.get("version") != 1:
+        problems.append("version: must be 1")
+
+    for dotted, allowed in ENUMS.items():
+        value = get_key(cfg, dotted)
+        if value is not None and value not in allowed:
+            problems.append(f"{dotted}: {value!r} is not one of {list(allowed)}")
+
+    for dotted in ("ontology.enabled", "team.enabled"):
+        value = get_key(cfg, dotted)
+        if not isinstance(value, bool):
+            problems.append(f"{dotted}: must be true or false (got {value!r})")
+
+    size = get_key(cfg, "team.size")
+    if size is not None and (not isinstance(size, int) or isinstance(size, bool) or size < 1):
+        problems.append(f"team.size: must be a positive integer or null (got {size!r})")
+
+    for dotted in ("project.name", "scm.owner", "team.preset"):
+        value = get_key(cfg, dotted)
+        if value is not None and not isinstance(value, str):
+            problems.append(f"{dotted}: must be a string or null (got {value!r})")
+
+    children = cfg.get("children")
+    if children is None:
+        cfg["children"] = []
+    elif not isinstance(children, list):
+        problems.append(f"children: must be a list (got {type(children).__name__})")
+    else:
+        for idx, child in enumerate(children):
+            loc = f"children[{idx}]"
+            if not isinstance(child, dict):
+                problems.append(f"{loc}: must be a mapping with a `path` key")
+                continue
+            path = child.get("path")
+            if not isinstance(path, str) or not path.strip():
+                problems.append(f"{loc}.path: required non-empty string")
+            flavor = child.setdefault("flavor", "product")
+            if flavor not in CHILD_FLAVORS:
+                problems.append(f"{loc}.flavor: {flavor!r} is not one of {list(CHILD_FLAVORS)}")
+            for extra in sorted(set(child) - {"path", "flavor"}):
+                warnings.append(f"{loc}: unknown key {extra!r} (carried as-is)")
+
+    known_top = set(builtin_defaults())
+    for extra in sorted(set(cfg) - known_top):
+        warnings.append(f"unknown top-level key {extra!r} (carried as-is)")
+
+    return problems, warnings
+
+
+def runtime_overlay(cfg: dict, user_keys: set[str]) -> dict:
+    """The slice of the install config that flows into framework.config.json.
+
+    Only keys the user explicitly decided (or that carry a real value) are
+    overlaid, so an untouched install default never clobbers a ``--config``
+    JSON runtime seed.
+    """
+    overlay: dict = {}
+    owner = get_key(cfg, "scm.owner")
+    if owner:
+        overlay.setdefault("scm", {})["owner"] = owner
+    name = get_key(cfg, "project.name")
+    if name:
+        overlay.setdefault("project", {})["name"] = name
+    if "project.model" in user_keys:
+        model = get_key(cfg, "project.model")
+        if model in RUNTIME_MODEL_MAP:
+            overlay.setdefault("project", {})["model"] = RUNTIME_MODEL_MAP[model]
+    return overlay
+
+
+HELP_EPILOG = """\
+install config keys (--install-config YAML; precedence: flags > user YAML > shipped defaults):
+  version              config schema version (must be 1)
+  repo.expect          fresh | existing | any        target-repo expectation (default: fresh)
+  project.name         str | null                    display name (default: target dir name)
+  project.model        standalone | meta | child     project shape (default: standalone)
+  scm.provider         github                        SCM host (default: github)
+  scm.owner            str | null                    GitHub org/user (replaces the owner prompt)
+  ci.provider          github-actions                CI system (default: github-actions)
+  ticketing.provider   github-issues                 tracker (default: github-issues)
+  pre_push.mode        noop | enforce | none         pre-push hook mode (default: noop)
+  ontology.enabled     bool                          lay the ontology seed (default: true)
+  team.enabled         bool                          generate the team layer (default: true)
+  team.preset          str | null                    team preset (used by `2real-team init`)
+  team.size            int | null                    target headcount (replaces the roster prompt)
+  children             [{path, flavor: product|infra}]  child repos (meta/child models)
+
+Shipped defaults: framework/config/install.config.default.yaml. The resolved
+config is recorded at <target>/.claude/install.config.json. With
+--non-interactive the install is fully prompt-free on every path.
+"""

--- a/framework/install/miniyaml.py
+++ b/framework/install/miniyaml.py
@@ -1,0 +1,369 @@
+"""Minimal stdlib-only YAML-subset parser for install-time configuration.
+
+``framework/install`` must stay stdlib-only (it runs anywhere ``python3`` does,
+before any dependency is installed), so this module implements just enough of
+YAML to read ``install.config.yaml`` files:
+
+Supported
+=========
+- nested mappings (indentation-based)
+- block sequences (``- item``), including sequences of mappings
+  (``- path: x`` + continuation lines) and sequences at the same indent
+  as their parent key
+- flow sequences/mappings on one line: ``[a, b]``, ``{path: x, flavor: y}``,
+  ``[]``, ``{}``
+- scalars: booleans (``true/false``, YAML 1.2 core casings), null
+  (``null``/``~``/empty), integers, floats, single/double-quoted strings,
+  plain strings
+- comments: full-line and trailing (`` # ...``), quote-aware
+- a leading ``---`` document-start marker
+
+Deliberately NOT supported (raises :class:`MiniYamlError` with a line number):
+anchors/aliases (``&``, ``*``), block scalars (``|``, ``>``), multi-document
+streams, tags (``!``), tabs in indentation, multi-line flow collections.
+
+The module is self-contained (no sibling imports) so it can also be copied
+verbatim as an asset if a later issue needs it at runtime.
+
+API: :func:`loads`, :func:`load`, :class:`MiniYamlError`.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+__all__ = ["MiniYamlError", "load", "loads"]
+
+
+class MiniYamlError(ValueError):
+    """Parse error carrying a 1-based source line number."""
+
+    def __init__(self, message: str, line: int | None = None) -> None:
+        self.line = line
+        super().__init__(f"line {line}: {message}" if line is not None else message)
+
+
+_INT_RE = re.compile(r"^[+-]?\d+$")
+_FLOAT_RE = re.compile(r"^[+-]?(\d+\.\d*|\.\d+|\d+)([eE][+-]?\d+)?$")
+_BOOL_TRUE = frozenset({"true", "True", "TRUE"})
+_BOOL_FALSE = frozenset({"false", "False", "FALSE"})
+_NULLS = frozenset({"null", "Null", "NULL", "~"})
+_DQ_ESCAPES = {"\\": "\\", '"': '"', "n": "\n", "t": "\t", "r": "\r", "0": "\0"}
+
+
+def load(path: str | Path) -> Any:
+    """Parse the YAML-subset file at ``path``."""
+    return loads(Path(path).read_text(encoding="utf-8"))
+
+
+def loads(text: str) -> Any:
+    """Parse a YAML-subset document from a string. Empty document -> None."""
+    lines = _prepare(text)
+    if not lines:
+        return None
+    value, idx = _parse_block(lines, 0, lines[0][1])
+    if idx != len(lines):
+        raise MiniYamlError("unexpected content (bad indentation?)", lines[idx][0])
+    return value
+
+
+# ---------------------------------------------------------------- line prep
+
+
+def _prepare(text: str) -> list[list]:
+    """Return significant lines as mutable ``[lineno, indent, content]`` triples."""
+    out: list[list] = []
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        body = _strip_comment(raw.rstrip(), lineno)
+        if not body.strip():
+            continue
+        indent = len(body) - len(body.lstrip(" "))
+        if "\t" in body[:indent] or body.lstrip(" ").startswith("\t"):
+            raise MiniYamlError("tabs are not allowed in indentation", lineno)
+        content = body.strip()
+        if not out and content == "---":
+            continue  # document-start marker
+        if content in ("---", "..."):
+            raise MiniYamlError("multi-document streams are not supported", lineno)
+        out.append([lineno, indent, content])
+    return out
+
+
+def _strip_comment(line: str, lineno: int) -> str:
+    """Remove a trailing `` # comment`` (quote-aware). Full-line comments -> ''."""
+    in_single = in_double = False
+    i = 0
+    while i < len(line):
+        ch = line[i]
+        if in_single:
+            if ch == "'":
+                if i + 1 < len(line) and line[i + 1] == "'":
+                    i += 1  # escaped '' inside single quotes
+                else:
+                    in_single = False
+        elif in_double:
+            if ch == "\\":
+                i += 1
+            elif ch == '"':
+                in_double = False
+        elif ch == "'":
+            in_single = True
+        elif ch == '"':
+            in_double = True
+        elif ch == "#" and (i == 0 or line[i - 1] in " \t"):
+            return line[:i].rstrip()
+        i += 1
+    if in_single or in_double:
+        raise MiniYamlError("unterminated quoted string", lineno)
+    return line
+
+
+# ---------------------------------------------------------------- block parse
+
+
+def _is_seq_item(content: str) -> bool:
+    return content == "-" or content.startswith("- ")
+
+
+def _parse_block(lines: list[list], i: int, indent: int) -> tuple[Any, int]:
+    lineno, ind, content = lines[i]
+    if ind != indent:
+        raise MiniYamlError("unexpected indentation", lineno)
+    if _is_seq_item(content):
+        return _parse_sequence(lines, i, indent)
+    return _parse_mapping(lines, i, indent)
+
+
+def _parse_sequence(lines: list[list], i: int, indent: int) -> tuple[list, int]:
+    items: list[Any] = []
+    while i < len(lines):
+        lineno, ind, content = lines[i]
+        if ind != indent or not _is_seq_item(content):
+            break
+        rest = content[1:].lstrip()
+        if not rest:
+            # A bare `-`: the item is the following deeper block (or null).
+            if i + 1 < len(lines) and lines[i + 1][1] > indent:
+                value, i = _parse_block(lines, i + 1, lines[i + 1][1])
+                items.append(value)
+            else:
+                items.append(None)
+                i += 1
+            continue
+        rest_col = ind + (len(content) - len(rest))
+        if rest[0] in "[{":
+            # Flow collection item: `- {path: x}` / `- [a, b]`.
+            items.append(_parse_scalar(rest, lineno))
+            i += 1
+        elif _looks_like_mapping_entry(rest) or _is_seq_item(rest):
+            # Compact form: `- key: value` (or `- - x`). Reparse the remainder
+            # as a block starting at the column where it begins.
+            lines[i] = [lineno, rest_col, rest]
+            value, i = _parse_block(lines, i, rest_col)
+            items.append(value)
+        else:
+            items.append(_parse_scalar(rest, lineno))
+            i += 1
+    return items, i
+
+
+def _parse_mapping(lines: list[list], i: int, indent: int) -> tuple[dict, int]:
+    out: dict[str, Any] = {}
+    while i < len(lines):
+        lineno, ind, content = lines[i]
+        if ind != indent or _is_seq_item(content):
+            break
+        key, rest = _split_key(content, lineno)
+        if key in out:
+            raise MiniYamlError(f"duplicate key {key!r}", lineno)
+        if rest:
+            out[key] = _parse_scalar(rest, lineno)
+            i += 1
+            continue
+        i += 1
+        if i < len(lines) and lines[i][1] > indent:
+            out[key], i = _parse_block(lines, i, lines[i][1])
+        elif i < len(lines) and lines[i][1] == indent and _is_seq_item(lines[i][2]):
+            # Sequence at the same indent as its key (common YAML style).
+            out[key], i = _parse_sequence(lines, i, indent)
+        else:
+            out[key] = None
+    return out, i
+
+
+def _looks_like_mapping_entry(s: str) -> bool:
+    try:
+        _split_key(s, 0)
+        return True
+    except MiniYamlError:
+        return False
+
+
+def _split_key(content: str, lineno: int) -> tuple[str, str]:
+    """Split ``key: rest`` (colon must be outside quotes, followed by space/EOL)."""
+    in_single = in_double = False
+    i = 0
+    while i < len(content):
+        ch = content[i]
+        if in_single:
+            if ch == "'":
+                if i + 1 < len(content) and content[i + 1] == "'":
+                    i += 1
+                else:
+                    in_single = False
+        elif in_double:
+            if ch == "\\":
+                i += 1
+            elif ch == '"':
+                in_double = False
+        elif ch == "'":
+            in_single = True
+        elif ch == '"':
+            in_double = True
+        elif ch == ":" and (i + 1 == len(content) or content[i + 1] in " \t"):
+            raw_key = content[:i].strip()
+            if not raw_key:
+                raise MiniYamlError("empty mapping key", lineno)
+            key = _parse_scalar(raw_key, lineno) if raw_key[0] in "'\"" else raw_key
+            if not isinstance(key, str):
+                raise MiniYamlError("mapping keys must be strings", lineno)
+            return key, content[i + 1 :].strip()
+        i += 1
+    raise MiniYamlError("expected a `key: value` mapping entry", lineno)
+
+
+# ---------------------------------------------------------------- scalars
+
+
+def _parse_scalar(s: str, lineno: int) -> Any:
+    s = s.strip()
+    if not s:
+        return None
+    first = s[0]
+    if first in "'\"":
+        value, end = _parse_quoted(s, lineno)
+        if s[end:].strip():
+            raise MiniYamlError(
+                f"unexpected trailing content after quoted string: {s[end:]!r}", lineno
+            )
+        return value
+    if first == "[":
+        return _parse_flow_seq(s, lineno)
+    if first == "{":
+        return _parse_flow_map(s, lineno)
+    if first in "&*":
+        raise MiniYamlError("anchors/aliases are not supported", lineno)
+    if first in "|>":
+        raise MiniYamlError("block scalars (| and >) are not supported", lineno)
+    if first == "!":
+        raise MiniYamlError("tags are not supported", lineno)
+    if s in _BOOL_TRUE:
+        return True
+    if s in _BOOL_FALSE:
+        return False
+    if s in _NULLS:
+        return None
+    if _INT_RE.match(s):
+        return int(s)
+    if _FLOAT_RE.match(s):
+        return float(s)
+    return s
+
+
+def _parse_quoted(s: str, lineno: int) -> tuple[str, int]:
+    """Parse a quoted string at the start of ``s``; return (value, end_index)."""
+    quote = s[0]
+    buf: list[str] = []
+    i = 1
+    while i < len(s):
+        ch = s[i]
+        if quote == "'":
+            if ch == "'":
+                if i + 1 < len(s) and s[i + 1] == "'":
+                    buf.append("'")
+                    i += 2
+                    continue
+                return "".join(buf), i + 1
+            buf.append(ch)
+            i += 1
+        else:  # double-quoted
+            if ch == "\\":
+                if i + 1 >= len(s):
+                    raise MiniYamlError("dangling escape in double-quoted string", lineno)
+                esc = s[i + 1]
+                if esc not in _DQ_ESCAPES:
+                    raise MiniYamlError(f"unsupported escape sequence \\{esc}", lineno)
+                buf.append(_DQ_ESCAPES[esc])
+                i += 2
+                continue
+            if ch == '"':
+                return "".join(buf), i + 1
+            buf.append(ch)
+            i += 1
+    raise MiniYamlError("unterminated quoted string", lineno)
+
+
+def _split_flow_items(inner: str) -> list[str]:
+    """Split flow-collection contents on top-level commas (quote/bracket-aware)."""
+    items: list[str] = []
+    depth = 0
+    in_single = in_double = False
+    start = 0
+    i = 0
+    while i < len(inner):
+        ch = inner[i]
+        if in_single:
+            if ch == "'":
+                if i + 1 < len(inner) and inner[i + 1] == "'":
+                    i += 1
+                else:
+                    in_single = False
+        elif in_double:
+            if ch == "\\":
+                i += 1
+            elif ch == '"':
+                in_double = False
+        elif ch == "'":
+            in_single = True
+        elif ch == '"':
+            in_double = True
+        elif ch in "[{":
+            depth += 1
+        elif ch in "]}":
+            depth -= 1
+        elif ch == "," and depth == 0:
+            items.append(inner[start:i])
+            start = i + 1
+        i += 1
+    items.append(inner[start:])
+    return [item.strip() for item in items if item.strip()]
+
+
+def _parse_flow_seq(s: str, lineno: int) -> list:
+    if not s.endswith("]"):
+        raise MiniYamlError(
+            "unterminated flow sequence (multi-line flow is not supported)", lineno
+        )
+    inner = s[1:-1].strip()
+    if not inner:
+        return []
+    return [_parse_scalar(item, lineno) for item in _split_flow_items(inner)]
+
+
+def _parse_flow_map(s: str, lineno: int) -> dict:
+    if not s.endswith("}"):
+        raise MiniYamlError(
+            "unterminated flow mapping (multi-line flow is not supported)", lineno
+        )
+    inner = s[1:-1].strip()
+    out: dict[str, Any] = {}
+    if not inner:
+        return out
+    for item in _split_flow_items(inner):
+        key, rest = _split_key(item, lineno)
+        if key in out:
+            raise MiniYamlError(f"duplicate key {key!r}", lineno)
+        out[key] = _parse_scalar(rest, lineno) if rest else None
+    return out

--- a/framework/tests/test_install_config.py
+++ b/framework/tests/test_install_config.py
@@ -1,0 +1,285 @@
+"""Tests for the unified install config: loader units, precedence, and the
+end-to-end non-interactive install (zero prompts, correct outputs, idempotent)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+_BOOTSTRAP = _FRAMEWORK_ROOT / "install" / "bootstrap.py"
+sys.path.insert(0, str(_FRAMEWORK_ROOT / "install"))
+
+import install_config  # noqa: E402
+
+
+def _run(*argv: str, stdin: int = subprocess.DEVNULL) -> subprocess.CompletedProcess:
+    """Run bootstrap.py with stdin closed — any prompt would EOFError/hang."""
+    return subprocess.run(
+        [sys.executable, str(_BOOTSTRAP), *argv],
+        capture_output=True,
+        text=True,
+        stdin=stdin,
+        timeout=120,
+    )
+
+
+# ---------------------------------------------------------------- loader units
+
+
+class TestLoader:
+    def test_defaults_resolve_to_shipped_values(self) -> None:
+        cfg, user_keys = install_config.load(None)
+        assert user_keys == set()
+        assert cfg["repo"]["expect"] == "fresh"
+        assert cfg["project"]["model"] == "standalone"
+        assert cfg["scm"]["provider"] == "github"
+        assert cfg["ci"]["provider"] == "github-actions"
+        assert cfg["ticketing"]["provider"] == "github-issues"
+        assert cfg["pre_push"]["mode"] == "noop"
+        assert cfg["ontology"]["enabled"] is True
+        assert cfg["team"]["enabled"] is True
+        assert cfg["children"] == []
+        problems, warnings = install_config.validate(cfg)
+        assert problems == []
+        assert warnings == []
+
+    def test_user_yaml_overrides_defaults(self, tmp_path: Path) -> None:
+        user = tmp_path / "install.yaml"
+        user.write_text(
+            "scm:\n  owner: acme\npre_push:\n  mode: none\nontology:\n  enabled: false\n",
+            encoding="utf-8",
+        )
+        cfg, user_keys = install_config.load(user)
+        assert cfg["scm"]["owner"] == "acme"
+        assert cfg["pre_push"]["mode"] == "none"
+        assert cfg["ontology"]["enabled"] is False
+        # Untouched keys keep the shipped defaults.
+        assert cfg["repo"]["expect"] == "fresh"
+        assert user_keys == {"scm.owner", "pre_push.mode", "ontology.enabled"}
+
+    def test_children_parsed_and_flavor_defaulted(self, tmp_path: Path) -> None:
+        user = tmp_path / "install.yaml"
+        user.write_text(
+            "project:\n  model: meta\nchildren:\n"
+            "  - path: services/api\n    flavor: product\n"
+            "  - path: infra/tf\n    flavor: infra\n"
+            "  - path: services/web\n",
+            encoding="utf-8",
+        )
+        cfg, _ = install_config.load(user)
+        problems, _ = install_config.validate(cfg)
+        assert problems == []
+        assert cfg["children"] == [
+            {"path": "services/api", "flavor": "product"},
+            {"path": "infra/tf", "flavor": "infra"},
+            {"path": "services/web", "flavor": "product"},  # flavor defaulted
+        ]
+
+    @pytest.mark.parametrize(
+        ("body", "fragment"),
+        [
+            ("repo:\n  expect: brand-new\n", "repo.expect"),
+            ("project:\n  model: mono\n", "project.model"),
+            ("scm:\n  provider: gitlab\n", "scm.provider"),
+            ("ci:\n  provider: jenkins\n", "ci.provider"),
+            ("ticketing:\n  provider: jira\n", "ticketing.provider"),
+            ("pre_push:\n  mode: strict\n", "pre_push.mode"),
+            ("ontology:\n  enabled: maybe\n", "ontology.enabled"),
+            ("team:\n  size: -2\n", "team.size"),
+            ("children:\n  - flavor: product\n", "children[0].path"),
+            ("children:\n  - path: a\n    flavor: exotic\n", "children[0].flavor"),
+            ("version: 2\n", "version"),
+        ],
+    )
+    def test_validate_rejects_bad_values(self, tmp_path: Path, body: str, fragment: str) -> None:
+        user = tmp_path / "install.yaml"
+        user.write_text(body, encoding="utf-8")
+        cfg, _ = install_config.load(user)
+        problems, _ = install_config.validate(cfg)
+        assert any(fragment in p for p in problems), problems
+
+    def test_unknown_keys_warn_and_are_carried(self, tmp_path: Path) -> None:
+        user = tmp_path / "install.yaml"
+        user.write_text("future_section:\n  knob: 1\n", encoding="utf-8")
+        cfg, _ = install_config.load(user)
+        problems, warnings = install_config.validate(cfg)
+        assert problems == []
+        assert any("future_section" in w for w in warnings)
+        assert cfg["future_section"] == {"knob": 1}  # carried, not dropped
+
+    def test_invalid_yaml_raises(self, tmp_path: Path) -> None:
+        user = tmp_path / "install.yaml"
+        user.write_text("scm: &anchor\n", encoding="utf-8")
+        with pytest.raises(install_config.InstallConfigError):
+            install_config.load(user)
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(install_config.InstallConfigError):
+            install_config.load(tmp_path / "nope.yaml")
+
+    def test_runtime_overlay_respects_user_keys(self) -> None:
+        cfg, _ = install_config.load(None)
+        # Default model is NOT overlaid (would clobber a --config JSON seed).
+        assert install_config.runtime_overlay(cfg, set()) == {}
+        install_config.set_key(cfg, "scm.owner", "acme")
+        install_config.set_key(cfg, "project.model", "meta")
+        overlay = install_config.runtime_overlay(cfg, {"scm.owner", "project.model"})
+        assert overlay == {"scm": {"owner": "acme"}, "project": {"model": "meta-and-children"}}
+
+
+# ---------------------------------------------------------------- e2e install
+
+
+class TestNonInteractiveInstall:
+    def test_e2e_fresh_install_zero_prompts(self, tmp_path: Path) -> None:
+        user = tmp_path / "install.yaml"
+        user.write_text(
+            "scm:\n  owner: acme\nteam:\n  size: 4\n"
+            "pre_push:\n  mode: enforce\nchildren: []\n",
+            encoding="utf-8",
+        )
+        target = tmp_path / "repo"
+        target.mkdir()
+        r = _run(str(target), "--install-config", str(user), "--non-interactive")
+        assert r.returncode == 0, r.stderr or r.stdout
+        # Zero prompts: no prompt strings ever printed, stdin was closed.
+        assert "Proceed with this team?" not in r.stdout
+        assert "GitHub owner" not in r.stdout
+
+        claude = target / ".claude"
+        assert (claude / "framework.config.json").is_file()
+        assert (claude / "settings.json").is_file()
+        assert (claude / "hooks" / "dispatcher.py").is_file()
+        # Ontology defaults ON per the shipped install defaults.
+        assert (target / "ontology" / "domain.yaml").is_file()
+
+        runtime = json.loads((claude / "framework.config.json").read_text())
+        assert runtime["scm"]["owner"] == "acme"
+
+        # The resolved install config is recorded and carries every key.
+        snapshot = json.loads((claude / "install.config.json").read_text())
+        assert snapshot["scm"]["owner"] == "acme"
+        assert snapshot["team"]["size"] == 4
+        assert snapshot["pre_push"]["mode"] == "enforce"
+        assert snapshot["repo"]["expect"] == "fresh"
+        assert snapshot["ticketing"]["provider"] == "github-issues"
+        assert snapshot["children"] == []
+
+        # Roster generated with the configured size, no proceed-prompt.
+        roster = json.loads((claude / "team" / "roster.json").read_text())
+        assert len(roster) == 4  # roster.json is the {name: email} allowlist
+
+    def test_e2e_reruns_are_idempotent(self, tmp_path: Path) -> None:
+        r1 = _run(str(tmp_path), "--owner", "acme", "--non-interactive", "--no-team")
+        assert r1.returncode == 0, r1.stderr
+        r2 = _run(str(tmp_path), "--owner", "acme", "--non-interactive", "--no-team")
+        assert r2.returncode == 0, r2.stderr
+        assert "skipped (exists)" in r2.stdout
+        assert "already wired" in r2.stdout
+        assert "install snapshot:  skipped" in r2.stdout
+
+    def test_interactive_without_tty_never_prompts(self, tmp_path: Path) -> None:
+        # Even with --interactive, a non-TTY stdin must not hang or EOFError.
+        r = _run(str(tmp_path), "--interactive", "--no-team")
+        assert r.returncode == 0, r.stderr
+
+    def test_interactive_and_non_interactive_are_mutually_exclusive(self, tmp_path: Path) -> None:
+        r = _run(str(tmp_path), "--interactive", "--non-interactive")
+        assert r.returncode == 2
+        assert "not allowed with" in r.stderr
+
+    def test_invalid_install_config_is_fatal(self, tmp_path: Path) -> None:
+        user = tmp_path / "install.yaml"
+        user.write_text("pre_push:\n  mode: strict\n", encoding="utf-8")
+        target = tmp_path / "repo"
+        target.mkdir()
+        r = _run(str(target), "--install-config", str(user), "--non-interactive")
+        assert r.returncode == 1
+        assert "pre_push.mode" in r.stderr
+        assert not (target / ".claude" / "framework.config.json").exists()
+
+    def test_children_carried_into_snapshot(self, tmp_path: Path) -> None:
+        user = tmp_path / "install.yaml"
+        user.write_text(
+            "project:\n  model: meta\nchildren:\n"
+            "  - path: services/api\n  - path: infra/tf\n    flavor: infra\n",
+            encoding="utf-8",
+        )
+        target = tmp_path / "repo"
+        target.mkdir()
+        r = _run(str(target), "--install-config", str(user), "--non-interactive", "--no-team")
+        assert r.returncode == 0, r.stderr or r.stdout
+        snapshot = json.loads((target / ".claude" / "install.config.json").read_text())
+        assert snapshot["project"]["model"] == "meta"
+        assert snapshot["children"] == [
+            {"path": "services/api", "flavor": "product"},
+            {"path": "infra/tf", "flavor": "infra"},
+        ]
+        # Explicit meta model flows into the runtime config.
+        runtime = json.loads((target / ".claude" / "framework.config.json").read_text())
+        assert runtime["project"]["model"] == "meta-and-children"
+
+
+class TestPrecedence:
+    def test_cli_flag_beats_user_yaml(self, tmp_path: Path) -> None:
+        user = tmp_path / "install.yaml"
+        user.write_text("scm:\n  owner: from-yaml\n", encoding="utf-8")
+        target = tmp_path / "repo"
+        target.mkdir()
+        r = _run(
+            str(target), "--install-config", str(user), "--owner", "from-flag",
+            "--non-interactive", "--no-team",
+        )
+        assert r.returncode == 0, r.stderr or r.stdout
+        runtime = json.loads((target / ".claude" / "framework.config.json").read_text())
+        assert runtime["scm"]["owner"] == "from-flag"
+        snapshot = json.loads((target / ".claude" / "install.config.json").read_text())
+        assert snapshot["scm"]["owner"] == "from-flag"
+
+    def test_user_yaml_beats_shipped_defaults(self, tmp_path: Path) -> None:
+        user = tmp_path / "install.yaml"
+        user.write_text("ontology:\n  enabled: false\nrepo:\n  expect: existing\n", encoding="utf-8")
+        target = tmp_path / "repo"
+        target.mkdir()
+        r = _run(str(target), "--install-config", str(user), "--non-interactive", "--no-team")
+        assert r.returncode == 0, r.stderr or r.stdout
+        assert not (target / "ontology").exists()  # default true overridden
+        snapshot = json.loads((target / ".claude" / "install.config.json").read_text())
+        assert snapshot["repo"]["expect"] == "existing"
+
+    def test_shipped_defaults_apply_without_user_yaml(self, tmp_path: Path) -> None:
+        r = _run(str(tmp_path), "--non-interactive", "--no-team")
+        assert r.returncode == 0, r.stderr or r.stdout
+        assert (tmp_path / "ontology" / "domain.yaml").is_file()  # ontology on
+        snapshot = json.loads((tmp_path / ".claude" / "install.config.json").read_text())
+        assert snapshot["pre_push"]["mode"] == "noop"
+        assert snapshot["repo"]["expect"] == "fresh"
+
+    def test_ontology_flag_beats_yaml(self, tmp_path: Path) -> None:
+        user = tmp_path / "install.yaml"
+        user.write_text("ontology:\n  enabled: true\n", encoding="utf-8")
+        target = tmp_path / "repo"
+        target.mkdir()
+        r = _run(
+            str(target), "--install-config", str(user), "--no-ontology",
+            "--non-interactive", "--no-team",
+        )
+        assert r.returncode == 0, r.stderr or r.stdout
+        assert not (target / "ontology").exists()
+        snapshot = json.loads((target / ".claude" / "install.config.json").read_text())
+        assert snapshot["ontology"]["enabled"] is False
+
+    def test_team_size_yaml_answers_roster_without_prompt(self, tmp_path: Path) -> None:
+        user = tmp_path / "install.yaml"
+        user.write_text("team:\n  size: 3\n", encoding="utf-8")
+        target = tmp_path / "repo"
+        target.mkdir()
+        r = _run(str(target), "--install-config", str(user), "--non-interactive")
+        assert r.returncode == 0, r.stderr or r.stdout
+        roster = json.loads((target / ".claude" / "team" / "roster.json").read_text())
+        assert len(roster) == 3

--- a/framework/tests/test_miniyaml.py
+++ b/framework/tests/test_miniyaml.py
@@ -1,0 +1,200 @@
+"""Unit tests for the stdlib-only YAML-subset parser (framework/install/miniyaml.py)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_FRAMEWORK_ROOT / "install"))
+
+import miniyaml  # noqa: E402
+
+
+# ---------------------------------------------------------------- scalars
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("a: 1", {"a": 1}),
+        ("a: -7", {"a": -7}),
+        ("a: 3.5", {"a": 3.5}),
+        ("a: true", {"a": True}),
+        ("a: True", {"a": True}),
+        ("a: false", {"a": False}),
+        ("a: FALSE", {"a": False}),
+        ("a: null", {"a": None}),
+        ("a: ~", {"a": None}),
+        ("a:", {"a": None}),
+        ("a: hello world", {"a": "hello world"}),
+        ("a: 'quoted: string'", {"a": "quoted: string"}),
+        ('a: "with # hash"', {"a": "with # hash"}),
+        ('a: "esc\\nline"', {"a": "esc\nline"}),
+        ("a: 'it''s'", {"a": "it's"}),
+        ("a: github-actions", {"a": "github-actions"}),
+        ("a: v1.2.3", {"a": "v1.2.3"}),
+    ],
+)
+def test_scalars(text: str, expected: dict) -> None:
+    assert miniyaml.loads(text) == expected
+
+
+def test_empty_document_is_none() -> None:
+    assert miniyaml.loads("") is None
+    assert miniyaml.loads("\n# only a comment\n") is None
+
+
+# ---------------------------------------------------------------- structure
+
+
+def test_nested_maps() -> None:
+    text = """
+scm:
+  provider: github
+  owner: my-org
+pre_push:
+  mode: noop
+"""
+    assert miniyaml.loads(text) == {
+        "scm": {"provider": "github", "owner": "my-org"},
+        "pre_push": {"mode": "noop"},
+    }
+
+
+def test_deeply_nested_maps() -> None:
+    text = "a:\n  b:\n    c:\n      d: 1\n"
+    assert miniyaml.loads(text) == {"a": {"b": {"c": {"d": 1}}}}
+
+
+def test_list_of_scalars() -> None:
+    text = "skills:\n  - retro\n  - wave-start\n  - 3\n"
+    assert miniyaml.loads(text) == {"skills": ["retro", "wave-start", 3]}
+
+
+def test_list_at_same_indent_as_key() -> None:
+    text = "skills:\n- retro\n- wave-start\nafter: yes-more\n"
+    assert miniyaml.loads(text) == {"skills": ["retro", "wave-start"], "after": "yes-more"}
+
+
+def test_list_of_maps_children_shape() -> None:
+    text = """
+children:
+  - path: services/api
+    flavor: product
+  - path: infra/terraform
+    flavor: infra
+"""
+    assert miniyaml.loads(text) == {
+        "children": [
+            {"path": "services/api", "flavor": "product"},
+            {"path": "infra/terraform", "flavor": "infra"},
+        ]
+    }
+
+
+def test_flow_collections() -> None:
+    text = "empty: []\nemptymap: {}\nnums: [1, 2, 3]\nchild: {path: a/b, flavor: infra}\n"
+    assert miniyaml.loads(text) == {
+        "empty": [],
+        "emptymap": {},
+        "nums": [1, 2, 3],
+        "child": {"path": "a/b", "flavor": "infra"},
+    }
+
+
+def test_list_of_flow_maps() -> None:
+    text = "children:\n  - {path: a, flavor: product}\n  - {path: b}\n"
+    assert miniyaml.loads(text) == {
+        "children": [{"path": "a", "flavor": "product"}, {"path": "b"}]
+    }
+
+
+def test_top_level_sequence() -> None:
+    assert miniyaml.loads("- a\n- b\n") == ["a", "b"]
+
+
+def test_document_start_marker_ignored() -> None:
+    assert miniyaml.loads("---\na: 1\n") == {"a": 1}
+
+
+# ---------------------------------------------------------------- comments
+
+
+def test_comments_full_line_and_trailing() -> None:
+    text = """
+# a full-line comment
+a: 1   # trailing comment
+b: "kept # inside quotes"
+  # indented comment
+c: 3
+"""
+    assert miniyaml.loads(text) == {"a": 1, "b": "kept # inside quotes", "c": 3}
+
+
+def test_hash_without_leading_space_is_not_a_comment() -> None:
+    assert miniyaml.loads("a: foo#bar") == {"a": "foo#bar"}
+
+
+# ---------------------------------------------------------------- errors
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "a: &anchor 1",
+        "a: *alias",
+        "a: |\n  block",
+        "a: >\n  folded",
+        "a: !!str tagged",
+        "\ta: 1",
+        "a: 'unterminated",
+        'a: "bad \\q escape"',
+        "a: [1, 2",
+        "a: {k: v",
+        "a: 1\na: 2",
+        "just a plain line",
+        "a: 1\n--- \nb: 2",
+    ],
+)
+def test_unsupported_or_malformed_raises(text: str) -> None:
+    with pytest.raises(miniyaml.MiniYamlError):
+        miniyaml.loads(text)
+
+
+def test_error_carries_line_number() -> None:
+    with pytest.raises(miniyaml.MiniYamlError) as exc_info:
+        miniyaml.loads("a: 1\nb: &x 2\n")
+    assert exc_info.value.line == 2
+    assert "line 2" in str(exc_info.value)
+
+
+def test_bad_indentation_raises() -> None:
+    with pytest.raises(miniyaml.MiniYamlError):
+        miniyaml.loads("a:\n  b: 1\n c: 2\n")
+
+
+# ---------------------------------------------------------------- shipped file
+
+
+def test_shipped_default_config_parses() -> None:
+    cfg = miniyaml.load(_FRAMEWORK_ROOT / "config" / "install.config.default.yaml")
+    assert cfg["version"] == 1
+    assert cfg["repo"]["expect"] == "fresh"
+    assert cfg["project"]["model"] == "standalone"
+    assert cfg["project"]["name"] is None
+    assert cfg["scm"] == {"provider": "github", "owner": None}
+    assert cfg["ci"]["provider"] == "github-actions"
+    assert cfg["ticketing"]["provider"] == "github-issues"
+    assert cfg["pre_push"]["mode"] == "noop"
+    assert cfg["ontology"]["enabled"] is True
+    assert cfg["team"] == {"enabled": True, "preset": None, "size": None}
+    assert cfg["children"] == []
+
+
+def test_shipped_default_matches_pyyaml_if_available() -> None:
+    yaml = pytest.importorskip("yaml")
+    path = _FRAMEWORK_ROOT / "config" / "install.config.default.yaml"
+    assert miniyaml.load(path) == yaml.safe_load(path.read_text(encoding="utf-8"))

--- a/python/src/real_team/cli.py
+++ b/python/src/real_team/cli.py
@@ -9,7 +9,13 @@ from rich.console import Console
 from rich.table import Table
 
 from .bootstrap import bootstrap_project, generate_team, make_email
-from .models import TeamConfig, YamlConfig
+from .models import (
+    InstallConfig,
+    TeamConfig,
+    YamlConfig,
+    _read_yaml_mapping,
+    is_unified_config,
+)
 from .presets import get_preset, list_presets
 
 app = typer.Typer(name="2real-team", help="AI agent team framework for Claude Code projects")
@@ -22,10 +28,19 @@ def init(
         None, help="Project preset (fullstack-monorepo, data-pipeline, library)"
     ),
     team_size: int = typer.Option(None, help="Override default team size"),
-    config: str = typer.Option(None, help="Path to config YAML file"),
+    config: str = typer.Option(
+        None,
+        help="Path to a YAML config file — either the unified install config "
+        "(see `init --help` key reference) or the legacy flat team config",
+    ),
     project_name: str = typer.Option(None, help="Project name"),
     target: str = typer.Option(".", help="Target directory"),
     interactive: bool = typer.Option(True, help="Interactive mode"),
+    non_interactive: bool = typer.Option(
+        False,
+        "--non-interactive",
+        help="Guarantee zero prompts; the config (flags > YAML > defaults) answers everything",
+    ),
     git_email_prefix: str = typer.Option(
         "", help="Email prefix (e.g., 'myorg' -> myorg+First.Last@gmail.com)"
     ),
@@ -41,32 +56,73 @@ def init(
         None, help="Default merge model: wave-branch | direct-to-main"
     ),
     with_ontology: bool = typer.Option(
-        True,
+        None,
         "--with-ontology/--no-ontology",
         help=(
             "Seed the ontology semantic-overlay template and generate the structural index "
-            "(ontology/structural/) at install time (requires --with-hooks)"
+            "(ontology/structural/) at install time (requires --with-hooks). "
+            "Unset, it follows the install config's ontology.enabled (default: on)"
         ),
     ),
 ) -> None:
-    """Bootstrap a new project with the team framework."""
-    target_path = Path(target).resolve()
+    """Bootstrap a new project with the team framework.
 
+    --config accepts either YAML schema (auto-detected):
+
+    UNIFIED install config (shared with framework/install/bootstrap.py;
+    precedence: CLI flags > YAML > shipped defaults):
+    version (1) | repo.expect fresh|existing|any | project.name |
+    project.model standalone|meta|child | scm.provider github | scm.owner |
+    ci.provider github-actions | ticketing.provider github-issues |
+    pre_push.mode noop|enforce|none | ontology.enabled bool |
+    team.enabled bool | team.preset | team.size |
+    children [{path, flavor: product|infra}]
+
+    LEGACY flat team config: preset (required) | project_name | team_size |
+    git_email_prefix | target | skills | members.
+
+    With --non-interactive (or any --config) there are zero prompts.
+    """
+    target_path = Path(target).resolve()
+    if non_interactive:
+        interactive = False
+
+    yaml_cfg: YamlConfig | None = None
+    install_cfg: InstallConfig | None = None
     if config:
         try:
-            yaml_cfg = YamlConfig.from_yaml(config)
+            raw = _read_yaml_mapping(config)
+            if is_unified_config(raw):
+                install_cfg = InstallConfig.from_yaml(config)
+            else:
+                yaml_cfg = YamlConfig.from_yaml(config)
         except (FileNotFoundError, ValueError) as exc:
             console.print(f"[red]Error:[/red] {exc}")
             raise typer.Exit(1) from exc
 
-        preset = yaml_cfg.preset
-        team_size = yaml_cfg.team_size or team_size
-        project_name = yaml_cfg.project_name or project_name
-        git_email_prefix = yaml_cfg.git_email_prefix or git_email_prefix
-        if yaml_cfg.target != ".":
-            target_path = Path(yaml_cfg.target).resolve()
-        # Config mode is fully non-interactive
+        # Config mode is fully non-interactive.
         interactive = False
+        if install_cfg is not None:
+            # Unified schema: CLI flags win over the YAML.
+            preset = preset or install_cfg.team.preset
+            team_size = team_size or install_cfg.team.size
+            project_name = project_name or install_cfg.project.name
+            owner = owner or install_cfg.scm.owner
+        else:
+            assert yaml_cfg is not None
+            preset = yaml_cfg.preset
+            team_size = yaml_cfg.team_size or team_size
+            project_name = yaml_cfg.project_name or project_name
+            git_email_prefix = yaml_cfg.git_email_prefix or git_email_prefix
+            if yaml_cfg.target != ".":
+                target_path = Path(yaml_cfg.target).resolve()
+
+    team_enabled = install_cfg.team.enabled if install_cfg is not None else True
+    if not team_enabled:
+        _install_runtime_only(
+            target_path, with_hooks, owner, merge_model, config, with_ontology
+        )
+        return
 
     if not preset and interactive:
         available = list_presets()
@@ -99,13 +155,13 @@ def init(
     console.print(f"\n[bold]Generating team for [cyan]{project_name}[/cyan]...[/bold]")
     # Determine skills list — config overrides preset defaults
     skills = preset_config.skills
-    if config and yaml_cfg.skills is not None:
+    if yaml_cfg is not None and yaml_cfg.skills is not None:
         skills = yaml_cfg.skills
 
     members = generate_team(preset_config, team_size)
 
-    # Apply per-member overrides from YAML config
-    if config and yaml_cfg.members:
+    # Apply per-member overrides from YAML config (legacy schema only)
+    if yaml_cfg is not None and yaml_cfg.members:
         for i, override in enumerate(yaml_cfg.members):
             if i >= len(members):
                 break
@@ -159,29 +215,16 @@ def init(
     # Install the config-driven framework runtime (hooks/lib/skills/config +
     # dispatcher wiring) on top of the mustache team scaffolding.
     if with_hooks:
-        from .framework_install import install_framework
-
-        proc = install_framework(
+        _run_framework_install(
             target_path,
             owner=owner or git_email_prefix or None,
             merge_model=merge_model,
+            install_config=config if install_cfg is not None else None,
             with_ontology=with_ontology,
         )
-        if proc is None:
-            console.print(
-                "\n[yellow]Framework runtime not installed:[/yellow] bundled assets not found "
-                "(re-run from a source checkout, or use the standalone framework installer)."
-            )
-        elif proc.returncode != 0:
-            console.print(
-                "\n[yellow]Framework runtime install reported an issue "
-                f"(exit {proc.returncode}):[/yellow]"
-            )
-            console.print(f"[dim]{(proc.stderr or proc.stdout).strip()[:500]}[/dim]")
-        else:
-            console.print(
-                "\n[green]Installed the framework runtime[/green] (hooks/lib/skills/config)."
-            )
+        # The bridge passes --no-team (this CLI scaffolded the roster itself),
+        # so correct the recorded install snapshot to reflect the real outcome.
+        _sync_install_snapshot(target_path, preset=preset, team_size=len(members))
 
     console.print(f"\n[bold green]Team framework bootstrapped for '{project_name}'![/bold green]")
     console.print("Next steps:")
@@ -192,6 +235,82 @@ def init(
         console.print(
             "  4. Review .claude/framework.config.json + restart Claude Code so hooks load."
         )
+
+
+def _run_framework_install(
+    target_path: Path,
+    *,
+    owner: str | None,
+    merge_model: str | None,
+    install_config: str | None,
+    with_ontology: bool | None = None,
+) -> None:
+    """Invoke the framework bootstrapper and report the outcome."""
+    from .framework_install import install_framework
+
+    proc = install_framework(
+        target_path,
+        owner=owner,
+        merge_model=merge_model,
+        install_config=install_config,
+        with_ontology=with_ontology,
+    )
+    if proc is None:
+        console.print(
+            "\n[yellow]Framework runtime not installed:[/yellow] bundled assets not found "
+            "(re-run from a source checkout, or use the standalone framework installer)."
+        )
+    elif proc.returncode != 0:
+        console.print(
+            "\n[yellow]Framework runtime install reported an issue "
+            f"(exit {proc.returncode}):[/yellow]"
+        )
+        console.print(f"[dim]{(proc.stderr or proc.stdout).strip()[:500]}[/dim]")
+    else:
+        console.print(
+            "\n[green]Installed the framework runtime[/green] (hooks/lib/skills/config)."
+        )
+
+
+def _sync_install_snapshot(target_path: Path, *, preset: str | None, team_size: int) -> None:
+    """Record the team the CLI actually scaffolded in .claude/install.config.json."""
+    import json
+
+    snapshot_path = target_path / ".claude" / "install.config.json"
+    if not snapshot_path.is_file():
+        return
+    try:
+        snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return
+    team = snapshot.setdefault("team", {})
+    team["enabled"] = True
+    team["preset"] = preset
+    team["size"] = team_size
+    snapshot_path.write_text(json.dumps(snapshot, indent=2) + "\n", encoding="utf-8")
+
+
+def _install_runtime_only(
+    target_path: Path,
+    with_hooks: bool,
+    owner: str | None,
+    merge_model: str | None,
+    config: str | None,
+    with_ontology: bool | None = None,
+) -> None:
+    """Config said ``team.enabled: false`` — skip team scaffolding entirely."""
+    console.print("[dim]team.enabled is false — skipping team scaffolding.[/dim]")
+    if with_hooks:
+        _run_framework_install(
+            target_path,
+            owner=owner,
+            merge_model=merge_model,
+            install_config=config,
+            with_ontology=with_ontology,
+        )
+        console.print("\n[bold green]Framework runtime installed (no team layer).[/bold green]")
+    else:
+        console.print("[yellow]Nothing to do:[/yellow] team disabled and --no-hooks given.")
 
 
 @app.command()

--- a/python/src/real_team/framework_install.py
+++ b/python/src/real_team/framework_install.py
@@ -53,10 +53,22 @@ def install_framework(
     shell: str = "bash",
     reviewers: int | None = None,
     merge_model: str | None = None,
-    with_ontology: bool = True,
+    install_config: Path | str | None = None,
+    with_ontology: bool | None = None,
     dry_run: bool = False,
 ) -> subprocess.CompletedProcess | None:
     """Install the framework runtime into ``target`` via its own bootstrapper.
+
+    ``install_config`` forwards a unified YAML install config so the
+    bootstrapper resolves every install-time decision (ontology, pre_push,
+    children, …) from the same file the CLI read. The subprocess always runs
+    ``--non-interactive`` — it can never prompt.
+
+    ``with_ontology`` is tri-state: ``True`` passes ``--with-ontology``,
+    ``False`` passes ``--no-ontology``, and ``None`` (default) passes neither
+    so the bootstrapper resolves ``ontology.enabled`` from the install config
+    (flags > user YAML > shipped default ON). This keeps a CLI default from
+    silently overriding a forwarded YAML.
 
     Returns the CompletedProcess (inspect ``.returncode`` / ``.stdout``), or
     None when the framework assets could not be located (caller should report a
@@ -71,17 +83,22 @@ def install_framework(
         str(root / "install" / "bootstrap.py"),
         str(target),
         "--no-team",
+        "--non-interactive",
         "--shell",
         shell,
     ]
+    if install_config:
+        cmd += ["--install-config", str(install_config)]
     if owner:
         cmd += ["--owner", owner]
     if reviewers is not None:
         cmd += ["--reviewers", str(reviewers)]
     if merge_model:
         cmd += ["--merge-model", merge_model]
-    if with_ontology:
+    if with_ontology is True:
         cmd += ["--with-ontology"]
+    elif with_ontology is False:
+        cmd += ["--no-ontology"]
     if dry_run:
         cmd += ["--dry-run"]
 

--- a/python/src/real_team/models.py
+++ b/python/src/real_team/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import yaml
 from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
@@ -95,24 +95,138 @@ class YamlConfig(BaseModel):
         Raises ``ValueError`` with a human-readable message on validation
         failure, and ``FileNotFoundError`` when the file does not exist.
         """
-        p = Path(path)
-        if not p.exists():
-            raise FileNotFoundError(f"Config file not found: {path}")
-
-        with open(p) as f:
-            try:
-                raw: Any = yaml.safe_load(f)
-            except yaml.YAMLError as exc:
-                raise ValueError(f"Invalid YAML in config file ({path}): {exc}") from exc
-
-        if not isinstance(raw, dict):
-            raise ValueError(f"Config file must be a YAML mapping, got {type(raw).__name__}")
-
+        raw = _read_yaml_mapping(path)
         try:
             return cls(**raw)
         except ValidationError as exc:
-            lines = [f"Invalid config file ({path}):"]
-            for err in exc.errors():
-                loc = " -> ".join(str(part) for part in err["loc"])
-                lines.append(f"  {loc}: {err['msg']}")
-            raise ValueError("\n".join(lines)) from exc
+            raise ValueError(_format_validation_error(path, exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# Unified install-config schema (install.config.yaml — shared with
+# framework/install/bootstrap.py; see framework/config/install.config.default.yaml)
+# ---------------------------------------------------------------------------
+
+#: Top-level keys that mark a YAML file as a UNIFIED install config rather than
+#: the legacy flat team config (which has a required top-level ``preset``).
+UNIFIED_CONFIG_MARKERS = frozenset(
+    {"version", "repo", "scm", "ci", "ticketing", "pre_push", "ontology", "children"}
+)
+
+
+class RepoSection(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    expect: Literal["fresh", "existing", "any"] = "fresh"
+
+
+class ProjectSection(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    name: str | None = None
+    model: Literal["standalone", "meta", "child"] = "standalone"
+
+
+class ScmSection(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    provider: Literal["github"] = "github"
+    owner: str | None = None
+
+
+class CiSection(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    provider: Literal["github-actions"] = "github-actions"
+
+
+class TicketingSection(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    provider: Literal["github-issues"] = "github-issues"
+
+
+class PrePushSection(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    mode: Literal["noop", "enforce", "none"] = "noop"
+
+
+class OntologySection(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    enabled: bool = True
+
+
+class TeamSection(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    enabled: bool = True
+    preset: str | None = None
+    size: int | None = None
+
+
+class ChildSpec(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    path: str
+    flavor: Literal["product", "infra"] = "product"
+
+
+class InstallConfig(BaseModel):
+    """The unified YAML install config (see the framework key reference).
+
+    Covers every interactive decision point of both installers. Extra keys are
+    allowed (forward compatibility) and carried through to the framework
+    bootstrapper, which records the resolved config in the target repo.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    version: Literal[1] = 1
+    repo: RepoSection = RepoSection()
+    project: ProjectSection = ProjectSection()
+    scm: ScmSection = ScmSection()
+    ci: CiSection = CiSection()
+    ticketing: TicketingSection = TicketingSection()
+    pre_push: PrePushSection = PrePushSection()
+    ontology: OntologySection = OntologySection()
+    team: TeamSection = TeamSection()
+    children: list[ChildSpec] = []
+
+    @classmethod
+    def from_yaml(cls, path: str | Path) -> InstallConfig:
+        raw = _read_yaml_mapping(path)
+        try:
+            return cls(**raw)
+        except ValidationError as exc:
+            raise ValueError(_format_validation_error(path, exc)) from exc
+
+
+def is_unified_config(raw: dict) -> bool:
+    """True when the mapping uses the unified install-config schema."""
+    if UNIFIED_CONFIG_MARKERS & set(raw):
+        return True
+    return isinstance(raw.get("team"), dict) or isinstance(raw.get("project"), dict)
+
+
+def _read_yaml_mapping(path: str | Path) -> dict:
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Config file not found: {path}")
+    with open(p) as f:
+        try:
+            raw: Any = yaml.safe_load(f)
+        except yaml.YAMLError as exc:
+            raise ValueError(f"Invalid YAML in config file ({path}): {exc}") from exc
+    if not isinstance(raw, dict):
+        raise ValueError(f"Config file must be a YAML mapping, got {type(raw).__name__}")
+    return raw
+
+
+def _format_validation_error(path: str | Path, exc: ValidationError) -> str:
+    lines = [f"Invalid config file ({path}):"]
+    for err in exc.errors():
+        loc = " -> ".join(str(part) for part in err["loc"])
+        lines.append(f"  {loc}: {err['msg']}")
+    return "\n".join(lines)

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -708,7 +708,8 @@ class TestInitCommand:
 
 
 # ---------------------------------------------------------------------------
-# framework_install bridge — flag threading
+# framework_install bridge — flag threading (tri-state: the config decides
+# unless the operator passed an explicit CLI ontology flag)
 # ---------------------------------------------------------------------------
 
 
@@ -727,19 +728,206 @@ class TestFrameworkInstallBridge:
         monkeypatch.setattr(fi.subprocess, "run", fake_run)
         return captured
 
-    def test_with_ontology_default_passes_flag(self, monkeypatch, tmp_path: Path):
+    def test_default_defers_ontology_to_config(self, monkeypatch, tmp_path: Path):
+        """No explicit flag: the bootstrapper resolves ontology.enabled itself
+        (shipped default ON — the default-init e2e asserts the generated
+        structural files land on disk)."""
         from real_team.framework_install import install_framework
 
         captured = self._capture_cmd(monkeypatch)
         install_framework(tmp_path)
+        assert "--with-ontology" not in captured["cmd"]
+        assert "--no-ontology" not in captured["cmd"]
+
+    def test_with_ontology_true_passes_flag(self, monkeypatch, tmp_path: Path):
+        from real_team.framework_install import install_framework
+
+        captured = self._capture_cmd(monkeypatch)
+        install_framework(tmp_path, with_ontology=True)
         assert "--with-ontology" in captured["cmd"]
 
-    def test_no_ontology_omits_flag(self, monkeypatch, tmp_path: Path):
+    def test_with_ontology_false_passes_no_ontology(self, monkeypatch, tmp_path: Path):
         from real_team.framework_install import install_framework
 
         captured = self._capture_cmd(monkeypatch)
         install_framework(tmp_path, with_ontology=False)
+        assert "--no-ontology" in captured["cmd"]
         assert "--with-ontology" not in captured["cmd"]
+
+    def test_install_config_forwarded(self, monkeypatch, tmp_path: Path):
+        from real_team.framework_install import install_framework
+
+        captured = self._capture_cmd(monkeypatch)
+        install_framework(tmp_path, install_config=tmp_path / "my.yaml")
+        cmd = captured["cmd"]
+        assert "--install-config" in cmd
+        assert str(tmp_path / "my.yaml") in cmd
+        assert "--non-interactive" in cmd
+
+
+# ---------------------------------------------------------------------------
+# CLI commands — init with the UNIFIED install config / --non-interactive
+# ---------------------------------------------------------------------------
+
+
+class TestInitUnifiedConfig:
+    def _write_unified(self, tmp_path: Path, **overrides) -> Path:
+        import yaml
+
+        data = {
+            "version": 1,
+            "repo": {"expect": "fresh"},
+            "project": {"name": "unified-test", "model": "standalone"},
+            "scm": {"provider": "github", "owner": "acme"},
+            "ci": {"provider": "github-actions"},
+            "ticketing": {"provider": "github-issues"},
+            "pre_push": {"mode": "noop"},
+            "ontology": {"enabled": True},
+            "team": {"enabled": True, "preset": "library", "size": 3},
+            "children": [],
+        }
+        data.update(overrides)
+        cfg = tmp_path / "install.yaml"
+        cfg.write_text(yaml.dump(data))
+        return cfg
+
+    def test_unified_config_scaffolds_team(self, tmp_path: Path):
+        cfg = self._write_unified(tmp_path)
+        target = tmp_path / "output"
+        target.mkdir()
+        result = runner.invoke(app, [
+            "init", "--config", str(cfg), "--target", str(target), "--no-hooks",
+        ])
+        assert result.exit_code == 0, result.output
+        assert (target / ".claude" / "team" / "charter.md").exists()
+        cards = list((target / ".claude" / "team" / "roster").glob("*.md"))
+        assert len(cards) == 3
+
+    def test_unified_config_installs_runtime_with_owner(self, tmp_path: Path):
+        cfg = self._write_unified(tmp_path)
+        target = tmp_path / "output"
+        target.mkdir()
+        result = runner.invoke(app, [
+            "init", "--config", str(cfg), "--target", str(target), "--non-interactive",
+        ])
+        assert result.exit_code == 0, result.output
+        claude = target / ".claude"
+        fw_cfg = json.loads((claude / "framework.config.json").read_text())
+        assert fw_cfg["scm"]["owner"] == "acme"
+        # The resolved install config is recorded by the bootstrapper.
+        snapshot = json.loads((claude / "install.config.json").read_text())
+        assert snapshot["pre_push"]["mode"] == "noop"
+        assert snapshot["ticketing"]["provider"] == "github-issues"
+        # The snapshot reflects the team the CLI actually scaffolded.
+        assert snapshot["team"] == {"enabled": True, "preset": "library", "size": 3}
+        # ontology.enabled: true (the shipped default) lays the seed overlay.
+        assert (target / "ontology" / "domain.yaml").is_file()
+
+    def test_unified_config_cli_flags_win(self, tmp_path: Path):
+        cfg = self._write_unified(tmp_path)
+        target = tmp_path / "output"
+        target.mkdir()
+        result = runner.invoke(app, [
+            "init", "--config", str(cfg), "--target", str(target),
+            "--team-size", "2", "--project-name", "flag-name", "--no-hooks",
+        ])
+        assert result.exit_code == 0, result.output
+        cards = list((target / ".claude" / "team" / "roster").glob("*.md"))
+        assert len(cards) == 2  # flag beat team.size: 3
+        assert "flag-name" in result.output
+
+    def test_unified_config_team_disabled_skips_scaffolding(self, tmp_path: Path):
+        cfg = self._write_unified(tmp_path, team={"enabled": False})
+        target = tmp_path / "output"
+        target.mkdir()
+        result = runner.invoke(app, [
+            "init", "--config", str(cfg), "--target", str(target), "--no-hooks",
+        ])
+        assert result.exit_code == 0, result.output
+        assert not (target / ".claude" / "team").exists()
+
+    def test_unified_config_missing_preset_errors(self, tmp_path: Path):
+        cfg = self._write_unified(tmp_path, team={"enabled": True})
+        target = tmp_path / "output"
+        target.mkdir()
+        result = runner.invoke(app, [
+            "init", "--config", str(cfg), "--target", str(target), "--no-hooks",
+        ])
+        assert result.exit_code == 1
+        assert "required" in result.output.lower()
+
+    def test_unified_config_invalid_enum_errors(self, tmp_path: Path):
+        cfg = self._write_unified(tmp_path, pre_push={"mode": "strict"})
+        target = tmp_path / "output"
+        target.mkdir()
+        result = runner.invoke(app, [
+            "init", "--config", str(cfg), "--target", str(target), "--no-hooks",
+        ])
+        assert result.exit_code == 1
+        assert "pre_push" in result.output
+
+    def test_non_interactive_flag(self, tmp_path: Path):
+        result = runner.invoke(app, [
+            "init", "--preset", "library", "--team-size", "2",
+            "--project-name", "ni-test", "--target", str(tmp_path),
+            "--non-interactive", "--no-hooks",
+        ])
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / ".claude" / "team" / "charter.md").exists()
+
+    def test_non_interactive_missing_preset_errors(self, tmp_path: Path):
+        result = runner.invoke(app, [
+            "init", "--target", str(tmp_path), "--non-interactive", "--no-hooks",
+        ])
+        assert result.exit_code == 1
+        assert "required" in result.output.lower()
+
+
+class TestInstallConfigModel:
+    def test_detection_unified_vs_legacy(self):
+        from real_team.models import is_unified_config
+
+        assert is_unified_config({"version": 1})
+        assert is_unified_config({"team": {"preset": "library"}})
+        assert is_unified_config({"scm": {"owner": "acme"}})
+        assert not is_unified_config({"preset": "library", "team_size": 3})
+        assert not is_unified_config({"preset": "library", "members": []})
+
+    def test_install_config_defaults(self):
+        from real_team.models import InstallConfig
+
+        cfg = InstallConfig()
+        assert cfg.repo.expect == "fresh"
+        assert cfg.project.model == "standalone"
+        assert cfg.scm.provider == "github"
+        assert cfg.ci.provider == "github-actions"
+        assert cfg.ticketing.provider == "github-issues"
+        assert cfg.pre_push.mode == "noop"
+        assert cfg.ontology.enabled is True
+        assert cfg.team.enabled is True
+        assert cfg.children == []
+
+    def test_install_config_children_flavor_default(self):
+        from real_team.models import InstallConfig
+
+        cfg = InstallConfig(children=[{"path": "services/api"}])
+        assert cfg.children[0].flavor == "product"
+
+    def test_install_config_rejects_bad_values(self):
+        import pydantic
+
+        from real_team.models import InstallConfig
+
+        with pytest.raises(pydantic.ValidationError):
+            InstallConfig(repo={"expect": "brand-new"})
+        with pytest.raises(pydantic.ValidationError):
+            InstallConfig(children=[{"flavor": "product"}])  # path required
+
+    def test_install_config_extra_keys_carried(self):
+        from real_team.models import InstallConfig
+
+        cfg = InstallConfig(future_section={"knob": 1})
+        assert cfg.model_dump()["future_section"] == {"knob": 1}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #64

## Summary

One unified `install.config.yaml` schema now covers **every** interactive decision point across both installers (stdlib-only `framework/install/bootstrap.py` and `2real-team init`), with a `--non-interactive` mode that guarantees zero prompts on any path. Precedence: **CLI flags > user YAML > shipped defaults**.

## The schema (v1) — foundation for #65/#66/#67/#70

```yaml
version: 1
repo:      { expect: fresh }            # fresh | existing | any
project:   { name: null, model: standalone }   # standalone | meta | child
scm:       { provider: github, owner: null }
ci:        { provider: github-actions }
ticketing: { provider: github-issues }
pre_push:  { mode: noop }               # noop | enforce | none
ontology:  { enabled: true }
team:      { enabled: true, preset: null, size: null }
children: []                            # - path: <rel>, flavor: product|infra (default product)
```

Shipped commented default: `framework/config/install.config.default.yaml` (fresh / standalone / github / github-actions / github-issues / pre-push noop / ontology on — exactly per AC).

## Design decisions

- **New `--install-config` flag on bootstrap.py** rather than overloading `--config`: `--config` stays the JSON *runtime*-config seed (framework.config.json shape) — two different contracts, kept explicit. The CLI reuses its existing `--config` and **auto-detects** unified vs legacy schema (legacy flat team configs keep working unchanged).
- **Resolved config is recorded at `<target>/.claude/install.config.json`** — the carry-point for keys whose behaviour lands in later tranches (`repo.expect` enforcement → #65, `children`/meta-child → #65, `pre_push` installer → #67). All keys are parsed + validated + carried; unknown keys warn and are carried (forward compat); invalid enums/types are fatal.
- **Stdlib-only YAML-subset parser** `framework/install/miniyaml.py` (self-contained, asset-copyable): nested maps, block sequences incl. lists of maps, flow `[]`/`{}`, bool/int/float/null/quoted scalars, quote-aware comments, line-numbered errors. Anchors/block scalars/tabs fail loudly.
- **`ontology.enabled` defaults on** (per AC) and now drives the overlay install; `--with-ontology`/`--no-ontology` override. `team.size`/`team.enabled` in the config answer the roster proceed-prompt ("config consulted first"), and the interactive owner prompt only fires when the config left `scm.owner` null.
- **`--non-interactive` and `--interactive` are mutually exclusive** (argparse group) — zero prompts is structural, not best-effort. The CLI→bootstrap bridge always runs the subprocess `--non-interactive`; the CLI then syncs the snapshot's `team` section to the roster it actually scaffolded (the bridge passes `--no-team` by design).
- Overlapping keys flow into the generated `framework.config.json` (`scm.owner`, `project.name`, `project.model` → `single-repo`/`meta-and-children`), but only user-decided keys are overlaid so an install default never clobbers a `--config` JSON seed.
- `bootstrap.py --help` (epilog) and `2real-team init --help` (docstring) document all keys; README gains an "Install configuration" section with the full key/type/default/effect table.

## Test evidence

- `python3 -m pytest framework/tests/ -q` → **134 passed** (was 100): 33 miniyaml units, e2e non-interactive fresh install to tmp dir with **stdin closed** (any prompt would fail), precedence (flag > YAML > defaults), snapshot carry (children/pre_push/repo.expect), invalid-config fatal, idempotent re-run (`skipped (exists)` / `already wired` / snapshot skipped).
- `cd python && python -m pytest -q` → **119 passed** (was 107): unified-config init paths (scaffold, runtime install w/ owner flow-through, flags-beat-YAML, team.enabled=false runtime-only, missing-preset error, invalid-enum error), `--non-interactive`, InstallConfig model units.
- `ruff check framework/` and `ruff check src/ tests/` → clean.
- Manual e2e: fresh install + re-run no-op verified against a scratch dir; `2real-team init --config <unified> --non-interactive` verified end-to-end from source.

## Deviations from AC

- None functional. Note: `pre_push.mode` / `repo.expect` / `children` are validated + recorded (not enforced) — their behaviour is owned by #67/#65 per the wave plan; a `repo.expect` mismatch prints a non-fatal note today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1sHWTyKtu8DAExDn9DgLS
