### PR TITLE
feat(node): bridge init to the bundled Python framework bootstrap (#70)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,13 @@ dist/
 # ---- Test / coverage output ----
 coverage/
 
+# ---- npm packaging ----
+# node/framework/ is copied from the repo-root framework/ at prepack time
+# (scripts/copy-shared.js) so the npm tarball bundles the runtime; it is a
+# build artifact, never committed (templates/presets/skills copies ARE tracked).
+node/framework/
+node/*.tgz
+
 # ---- Framework runtime output ----
 # .claude/framework/ holds the events.jsonl observability log (paths.events_log).
 # NOTE: gitignore has no inline comments — keep patterns on their own lines.

--- a/node/README.md
+++ b/node/README.md
@@ -1,0 +1,84 @@
+# 2real-team-framework
+
+A drop-in AI agent team framework for [Claude Code](https://claude.ai/code)
+projects. Bootstrap a simulated team of specialized agents with persistent
+identities, trust matrices, feedback loops, and structured workflows.
+
+This is the **Node.js CLI** for the framework. The same package is also
+published on PyPI (`pip install 2real-team-framework`); both CLIs share the
+same templates, presets, and framework runtime, and expose the same `init`
+contract. Full documentation lives in the
+[GitHub repository README](https://github.com/parametrization/2real-team-framework#readme).
+
+## Install
+
+```bash
+npm install -g 2real-team-framework
+
+# Or use without installing
+npx 2real-team-framework init --preset library
+```
+
+## Quick start
+
+```bash
+# Interactive bootstrap in the current directory
+2real-team init
+
+# Fully specified, zero prompts
+2real-team init --preset fullstack-monorepo --team-size 10 \
+  --project-name my-app --non-interactive
+
+# Driven by a unified YAML install config (shared with the framework's own
+# installer; CLI flags win over the YAML)
+2real-team init --config install.yaml --non-interactive
+```
+
+`init` scaffolds the team layer (charter, roster cards, trust matrix, feedback
+log, skills, root `CLAUDE.md`) and — by default — also installs the
+config-driven **framework runtime** (hooks, libs, lifecycle state machine,
+`framework.config.json`, `settings.json` wiring) by bridging to the bundled
+Python bootstrapper (`framework/install/bootstrap.py`).
+
+### `init` options
+
+| Flag | Meaning |
+| --- | --- |
+| `--preset <name>` | `fullstack-monorepo`, `data-pipeline`, or `library` |
+| `--team-size <n>` | Override the preset's default headcount |
+| `--config <yaml>` | Unified install config **or** legacy flat team config (auto-detected) |
+| `--non-interactive` | Guarantee zero prompts; flags > YAML > defaults answer everything |
+| `--with-hooks` / `--no-hooks` | Install the framework runtime (default: on) |
+| `--owner <owner>` | GitHub org/user recorded as `scm.owner` |
+| `--merge-model <m>` | `wave-branch` or `direct-to-main` |
+| `--with-ontology` / `--no-ontology` | Seed the ontology layer; unset defers to the install config |
+
+### Python runtime requirement
+
+The framework runtime installer is Python; the bridge looks for `python3`
+(falling back to `python`) on PATH. If no interpreter is found, `init` still
+completes the team scaffolding and prints what was skipped and how to finish —
+install [Python 3](https://www.python.org/downloads/) and re-run
+`2real-team init --with-hooks`, or use the PyPI package instead.
+
+## Other commands
+
+```bash
+2real-team status              # Show team composition
+2real-team validate            # Verify charter/roster/skills consistency
+2real-team add-member --role "Software Engineer"
+2real-team remove-member "Ada Park"
+2real-team update-member "Ada Park" --level Staff
+2real-team randomize-member "Ada Park"
+```
+
+## What's in this package
+
+- `dist/` — the compiled CLI
+- `templates/`, `presets/`, `skills/` — shared scaffolding data
+- `framework/` — the config-driven runtime (installer + assets + config +
+  recipes; tests are excluded from the tarball)
+
+## License
+
+Apache-2.0

--- a/node/package.json
+++ b/node/package.json
@@ -36,7 +36,8 @@
     "dist/",
     "templates/",
     "presets/",
-    "skills/"
+    "skills/",
+    "framework/"
   ],
   "scripts": {
     "build": "tsc && node -e \"const fs=require('fs');const c=fs.readFileSync('dist/index.js','utf-8');if(!c.startsWith('#!')){fs.writeFileSync('dist/index.js','#!/usr/bin/env node\\n'+c)}\"",

--- a/node/scripts/copy-shared.js
+++ b/node/scripts/copy-shared.js
@@ -1,12 +1,24 @@
 /**
- * Copy shared data directories (templates, presets, skills) into the node
- * package directory so they are included in the npm tarball.
+ * Copy shared data directories into the node package directory so they are
+ * included in the npm tarball.
  *
- * This runs as part of `npm run prepack`.
+ * This runs as part of `npm run prepack`. What gets bundled:
+ *
+ *   templates/   mustache templates for charter, roster cards, CLAUDE.md, ...
+ *   presets/     team-shape presets (fullstack-monorepo, data-pipeline, library)
+ *   skills/      mustache skill templates rendered into .claude/skills/
+ *   framework/   the config-driven runtime (install/ + assets/ + config/ +
+ *                recipes/) that `2real-team init --with-hooks` bridges to via
+ *                framework/install/bootstrap.py — the npm mirror of the Python
+ *                package's hatch BundleSharedDataHook.
+ *
+ * To keep the tarball lean, development-only subtrees are excluded from the
+ * copy: framework/tests/ (pytest suite, not needed at install time) and any
+ * __pycache__/ or tool cache directories.
  */
 
 import { cpSync, existsSync, mkdirSync } from "node:fs";
-import { resolve, dirname } from "node:path";
+import { resolve, dirname, basename } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -14,7 +26,18 @@ const __dirname = dirname(__filename);
 const PKG_ROOT = resolve(__dirname, "..");
 const REPO_ROOT = resolve(PKG_ROOT, "..");
 
-const DIRS = ["templates", "presets", "skills"];
+const DIRS = ["templates", "presets", "skills", "framework"];
+
+// Excluded anywhere in the copied trees (dev/test-only content).
+const EXCLUDED_DIRS = new Set(["tests", "__pycache__", ".pytest_cache", ".ruff_cache"]);
+
+/** cpSync filter: skip excluded directory subtrees and compiled bytecode. */
+function includeInBundle(src) {
+  const name = basename(src);
+  if (EXCLUDED_DIRS.has(name)) return false;
+  if (name.endsWith(".pyc")) return false;
+  return true;
+}
 
 for (const dir of DIRS) {
   const src = resolve(REPO_ROOT, dir);
@@ -31,6 +54,6 @@ for (const dir of DIRS) {
   }
 
   mkdirSync(dest, { recursive: true });
-  cpSync(src, dest, { recursive: true });
+  cpSync(src, dest, { recursive: true, filter: includeInBundle });
   console.log(`Copied ${src} -> ${dest}`);
 }

--- a/node/src/bootstrap.ts
+++ b/node/src/bootstrap.ts
@@ -8,6 +8,12 @@ import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 import Mustache from "mustache";
 
+import {
+  installFramework,
+  describeInstallResult,
+  type FrameworkInstallResult,
+} from "./framework-install.js";
+
 const _require = createRequire(import.meta.url);
 
 const __filename = fileURLToPath(import.meta.url);
@@ -38,6 +44,14 @@ interface BootstrapOptions {
   interactive: boolean;
   aiPersonas?: boolean;
   seed?: number;
+  /** Also install the framework runtime (hooks/lib/skills/config). Default true. */
+  withHooks?: boolean;
+  /** SCM org/user forwarded to the framework config (scm.owner). */
+  owner?: string;
+  /** Default merge model: wave-branch | direct-to-main. */
+  mergeModel?: string;
+  /** Tri-state ontology flag; undefined defers to the install config. */
+  withOntology?: boolean;
 }
 
 interface PresetRole {
@@ -177,7 +191,8 @@ interface YamlConfig {
   members?: MemberOverride[];
 }
 
-export function loadYamlConfig(configPath: string): YamlConfig {
+/** Read a YAML file and require it to be a mapping. */
+export function readYamlMapping(configPath: string): Record<string, unknown> {
   const absPath = resolve(configPath);
   if (!existsSync(absPath)) {
     throw new Error(`Config file not found: ${configPath}`);
@@ -193,7 +208,60 @@ export function loadYamlConfig(configPath: string): YamlConfig {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
     throw new Error(`Config file must be a YAML mapping, got ${typeof raw}`);
   }
-  const cfg = raw as Record<string, unknown>;
+  return raw as Record<string, unknown>;
+}
+
+/**
+ * Top-level keys that only appear in the unified install-config schema
+ * (mirrors `UNIFIED_CONFIG_MARKERS` in the Python package's models.py).
+ */
+const UNIFIED_CONFIG_MARKERS = new Set([
+  "version",
+  "repo",
+  "scm",
+  "ci",
+  "ticketing",
+  "pre_push",
+  "ontology",
+  "children",
+]);
+
+function isMapping(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === "object" && !Array.isArray(v);
+}
+
+/** True when the mapping uses the unified install-config schema. */
+export function isUnifiedConfig(raw: Record<string, unknown>): boolean {
+  for (const key of UNIFIED_CONFIG_MARKERS) {
+    if (key in raw) return true;
+  }
+  return isMapping(raw.team) || isMapping(raw.project);
+}
+
+/** The subset of the unified install config the team scaffolder consumes. */
+export interface UnifiedConfig {
+  teamEnabled: boolean;
+  preset?: string;
+  teamSize?: number;
+  projectName?: string;
+  owner?: string;
+}
+
+export function parseUnifiedConfig(raw: Record<string, unknown>): UnifiedConfig {
+  const team = isMapping(raw.team) ? raw.team : {};
+  const project = isMapping(raw.project) ? raw.project : {};
+  const scm = isMapping(raw.scm) ? raw.scm : {};
+  return {
+    teamEnabled: team.enabled !== false,
+    preset: typeof team.preset === "string" ? team.preset : undefined,
+    teamSize: typeof team.size === "number" ? team.size : undefined,
+    projectName: typeof project.name === "string" ? project.name : undefined,
+    owner: typeof scm.owner === "string" ? scm.owner : undefined,
+  };
+}
+
+export function loadYamlConfig(configPath: string): YamlConfig {
+  const cfg = readYamlMapping(configPath);
   if (!cfg.preset || typeof cfg.preset !== "string" || !cfg.preset.trim()) {
     throw new Error(`Invalid config file (${configPath}):\n  preset: Field required`);
   }
@@ -224,25 +292,60 @@ export async function bootstrap(opts: BootstrapOptions): Promise<void> {
   let configSkills: string[] | undefined;
   let memberOverrides: MemberOverride[] | undefined;
   let emailPrefix = "";
+  let owner = opts.owner;
+  const withHooks = opts.withHooks !== false;
+  // Set only for the unified schema: forwarded to the framework bootstrapper
+  // as --install-config so it resolves install-time decisions (ontology,
+  // pre_push, children, …) from the same file this CLI read.
+  let installConfigPath: string | undefined;
+  let unifiedCfg: UnifiedConfig | undefined;
 
-  // Load YAML config if provided
+  // Load YAML config if provided — auto-detects the unified install-config
+  // schema (shared with framework/install/bootstrap.py) vs the legacy flat
+  // team config. Either way, config mode is fully non-interactive.
   if (opts.config) {
-    let yamlCfg: YamlConfig;
     try {
-      yamlCfg = loadYamlConfig(opts.config);
+      const raw = readYamlMapping(opts.config);
+      if (isUnifiedConfig(raw)) {
+        unifiedCfg = parseUnifiedConfig(raw);
+        installConfigPath = resolve(opts.config);
+        // Unified schema: CLI flags win over the YAML.
+        presetName = presetName ?? unifiedCfg.preset;
+        if (!opts.teamSize && unifiedCfg.teamSize) opts.teamSize = unifiedCfg.teamSize;
+        if (!opts.projectName && unifiedCfg.projectName) opts.projectName = unifiedCfg.projectName;
+        owner = owner ?? unifiedCfg.owner;
+      } else {
+        const yamlCfg = loadYamlConfig(opts.config);
+        presetName = yamlCfg.preset;
+        if (yamlCfg.project_name) opts.projectName = yamlCfg.project_name;
+        if (yamlCfg.team_size) opts.teamSize = yamlCfg.team_size;
+        if (yamlCfg.git_email_prefix) emailPrefix = yamlCfg.git_email_prefix;
+        if (yamlCfg.target && yamlCfg.target !== ".") target = resolve(yamlCfg.target);
+        if (yamlCfg.skills) configSkills = yamlCfg.skills;
+        if (yamlCfg.members) memberOverrides = yamlCfg.members;
+      }
     } catch (err) {
       console.error(`Error: ${err instanceof Error ? err.message : err}`);
       process.exit(1);
     }
-    presetName = yamlCfg.preset;
-    if (yamlCfg.project_name) opts.projectName = yamlCfg.project_name;
-    if (yamlCfg.team_size) opts.teamSize = yamlCfg.team_size;
-    if (yamlCfg.git_email_prefix) emailPrefix = yamlCfg.git_email_prefix;
-    if (yamlCfg.target && yamlCfg.target !== ".") target = resolve(yamlCfg.target);
-    if (yamlCfg.skills) configSkills = yamlCfg.skills;
-    if (yamlCfg.members) memberOverrides = yamlCfg.members;
-    // Config mode is fully non-interactive
     opts.interactive = false;
+  }
+
+  // Unified config said team.enabled: false — skip team scaffolding entirely.
+  if (unifiedCfg && !unifiedCfg.teamEnabled) {
+    console.log("team.enabled is false — skipping team scaffolding.");
+    if (withHooks) {
+      runFrameworkInstall(target, {
+        owner,
+        mergeModel: opts.mergeModel,
+        installConfig: installConfigPath,
+        withOntology: opts.withOntology,
+      });
+      console.log("\nFramework runtime installed (no team layer).");
+    } else {
+      console.log("Nothing to do: team disabled and --no-hooks given.");
+    }
+    return;
   }
 
   if (!presetName) {
@@ -418,7 +521,72 @@ export async function bootstrap(opts: BootstrapOptions): Promise<void> {
   for (const f of created) {
     console.log(`  ${f}`);
   }
+
+  // Install the config-driven framework runtime (hooks/lib/skills/config +
+  // dispatcher wiring) on top of the mustache team scaffolding.
+  if (withHooks) {
+    const result = runFrameworkInstall(target, {
+      owner: owner ?? (emailPrefix || undefined),
+      mergeModel: opts.mergeModel,
+      installConfig: installConfigPath,
+      withOntology: opts.withOntology,
+    });
+    // The bridge passes --no-team (this CLI scaffolded the roster itself),
+    // so correct the recorded install snapshot to reflect the real outcome.
+    if (result.kind === "ran" && result.status === 0) {
+      syncInstallSnapshot(target, presetName, members.length);
+    }
+  }
+
   console.log(`\nTeam framework bootstrapped for '${projectName}'!`);
+}
+
+/** Invoke the framework bootstrapper bridge and report the outcome. */
+function runFrameworkInstall(
+  target: string,
+  opts: {
+    owner?: string;
+    mergeModel?: string;
+    installConfig?: string;
+    withOntology?: boolean;
+  },
+): FrameworkInstallResult {
+  const result = installFramework(target, {
+    owner: opts.owner,
+    mergeModel: opts.mergeModel,
+    installConfig: opts.installConfig,
+    withOntology: opts.withOntology,
+  });
+  const message = describeInstallResult(result);
+  if (result.kind === "ran" && result.status === 0) {
+    console.log(`\n${message}`);
+  } else {
+    console.warn(`\n${message}`);
+  }
+  return result;
+}
+
+/** Record the team the CLI actually scaffolded in .claude/install.config.json. */
+function syncInstallSnapshot(
+  target: string,
+  preset: string | undefined,
+  teamSize: number,
+): void {
+  const snapshotPath = join(target, ".claude", "install.config.json");
+  if (!existsSync(snapshotPath)) return;
+  let snapshot: Record<string, unknown>;
+  try {
+    snapshot = JSON.parse(readFileSync(snapshotPath, "utf-8"));
+  } catch {
+    return;
+  }
+  if (!snapshot || typeof snapshot !== "object") return;
+  const team = isMapping(snapshot.team) ? snapshot.team : {};
+  team.enabled = true;
+  team.preset = preset ?? null;
+  team.size = teamSize;
+  snapshot.team = team;
+  writeFileSync(snapshotPath, JSON.stringify(snapshot, null, 2) + "\n");
 }
 
 // ---------------------------------------------------------------------------

--- a/node/src/framework-install.ts
+++ b/node/src/framework-install.ts
@@ -1,0 +1,199 @@
+/**
+ * Bridge: install the config-driven framework runtime (hooks/lib/skills/config).
+ *
+ * Node twin of the Python package's `real_team/framework_install.py`. The
+ * mustache layer (`bootstrap.ts`) scaffolds the *team* (charter, roster cards,
+ * trust matrix). This module installs the *runtime* — the genericised hooks,
+ * libs, the lifecycle state machine, the `wave-lifecycle` skill,
+ * `framework.config.json`, and the dispatcher wiring in `settings.json` — by
+ * invoking the framework's own deterministic installer
+ * (`framework/install/bootstrap.py`) against the same target. That keeps a
+ * single source of truth for the install logic (no duplicated copy/merge code)
+ * and lets `2real-team init` lay down a complete, runnable `.claude/` instead
+ * of templates alone.
+ *
+ * The framework assets are bundled into the npm tarball under `framework/`
+ * (see `scripts/copy-shared.js`); in a source checkout they resolve to the
+ * repo-root `framework/`. The installer itself is Python, so the bridge needs
+ * a Python 3 interpreter on PATH (`python3`, falling back to `python`). When
+ * either the assets or the interpreter are missing the bridge degrades
+ * gracefully (returns a typed non-`ran` result) so `init` still completes its
+ * team scaffolding.
+ *
+ * `--no-team` is always passed: the CLI already wrote its own roster cards, so
+ * the framework installer lays down only hooks/lib/skills/config.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve, join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Minimal shape of the `spawnSync` result the bridge consumes. Kept structural
+ * so tests can inject a fake runner and assert the exact argv.
+ */
+export interface SpawnResult {
+  status: number | null;
+  stdout?: string | Buffer | null;
+  stderr?: string | Buffer | null;
+  error?: Error;
+}
+
+export type SpawnRunner = (
+  command: string,
+  args: string[],
+  options: Record<string, unknown>,
+) => SpawnResult;
+
+const defaultRunner: SpawnRunner = (command, args, options) =>
+  spawnSync(command, args, options) as SpawnResult;
+
+/**
+ * Locate the framework root (the dir holding `install/` + `assets/`).
+ *
+ * Prefers the tarball-bundled copy (`dist/ -> ../framework`); falls back to
+ * the repo-checkout layout (`node/src|dist -> ../../framework`). Returns null
+ * when neither has a runnable `install/bootstrap.py`.
+ */
+export function resolveFrameworkRoot(): string | null {
+  const candidates = [
+    resolve(__dirname, "..", "framework"),
+    resolve(__dirname, "../..", "framework"),
+  ];
+  for (const root of candidates) {
+    if (existsSync(join(root, "install", "bootstrap.py"))) return root;
+  }
+  return null;
+}
+
+/**
+ * Find a Python 3 interpreter on PATH. Tries `python3` first, then `python`.
+ * Returns the command name, or null when neither runs.
+ */
+export function findPython(runner: SpawnRunner = defaultRunner): string | null {
+  for (const cmd of ["python3", "python"]) {
+    const res = runner(cmd, ["--version"], { stdio: "ignore" });
+    if (!res.error && res.status === 0) return cmd;
+  }
+  return null;
+}
+
+export interface FrameworkInstallOptions {
+  /** scm.owner (GitHub org/user) forwarded as `--owner`. */
+  owner?: string | null;
+  /** Hook shell; the bootstrapper default. Always forwarded. */
+  shell?: string;
+  /** Merge model forwarded as `--merge-model`. */
+  mergeModel?: string | null;
+  /**
+   * Unified YAML install config, forwarded as `--install-config` so the
+   * bootstrapper resolves every install-time decision (ontology, pre_push,
+   * children, …) from the same file the CLI read.
+   */
+  installConfig?: string | null;
+  /**
+   * Tri-state: `true` passes `--with-ontology`, `false` passes
+   * `--no-ontology`, and `undefined` (default) passes neither so the
+   * bootstrapper resolves `ontology.enabled` from the install config
+   * (flags > user YAML > shipped default ON). This keeps a CLI default from
+   * silently overriding a forwarded YAML.
+   */
+  withOntology?: boolean;
+  dryRun?: boolean;
+}
+
+export type FrameworkInstallResult =
+  | { kind: "ran"; status: number; stdout: string; stderr: string; argv: string[] }
+  | { kind: "no-framework" }
+  | { kind: "no-python" };
+
+/**
+ * Build the exact argv used to subprocess the framework bootstrapper. The
+ * subprocess always runs `--no-team --non-interactive` — it can never prompt.
+ */
+export function buildBootstrapArgv(
+  python: string,
+  frameworkRoot: string,
+  target: string,
+  opts: FrameworkInstallOptions = {},
+): string[] {
+  const argv = [
+    python,
+    join(frameworkRoot, "install", "bootstrap.py"),
+    target,
+    "--no-team",
+    "--non-interactive",
+    "--shell",
+    opts.shell ?? "bash",
+  ];
+  if (opts.installConfig) argv.push("--install-config", String(opts.installConfig));
+  if (opts.owner) argv.push("--owner", opts.owner);
+  if (opts.mergeModel) argv.push("--merge-model", opts.mergeModel);
+  if (opts.withOntology === true) argv.push("--with-ontology");
+  else if (opts.withOntology === false) argv.push("--no-ontology");
+  if (opts.dryRun) argv.push("--dry-run");
+  return argv;
+}
+
+/**
+ * Install the framework runtime into `target` via its own bootstrapper.
+ *
+ * Degrades gracefully: `{ kind: "no-framework" }` when the bundled assets are
+ * missing, `{ kind: "no-python" }` when no Python 3 interpreter is on PATH.
+ * Callers should report a soft notice for either, not fail — the team
+ * scaffolding is already in place.
+ */
+export function installFramework(
+  target: string,
+  opts: FrameworkInstallOptions = {},
+  runner: SpawnRunner = defaultRunner,
+): FrameworkInstallResult {
+  const root = resolveFrameworkRoot();
+  if (root === null) return { kind: "no-framework" };
+
+  const python = findPython(runner);
+  if (python === null) return { kind: "no-python" };
+
+  const argv = buildBootstrapArgv(python, root, target, opts);
+  const res = runner(argv[0], argv.slice(1), { encoding: "utf-8" });
+  return {
+    kind: "ran",
+    status: res.status ?? 1,
+    stdout: String(res.stdout ?? ""),
+    stderr: String(res.stderr ?? ""),
+    argv,
+  };
+}
+
+/**
+ * Human-readable outcome message for a bridge result, including the
+ * degradation guidance when the Python runtime is unavailable.
+ */
+export function describeInstallResult(result: FrameworkInstallResult): string {
+  switch (result.kind) {
+    case "no-framework":
+      return (
+        "Framework runtime not installed: bundled assets not found " +
+        "(re-run from a source checkout, or use the standalone framework installer)."
+      );
+    case "no-python":
+      return (
+        "Framework runtime not installed: no Python 3 interpreter found on PATH.\n" +
+        "The team scaffolding (charter, roster, skills) was still created, but the\n" +
+        "hooks/lib/lifecycle runtime was skipped — it is installed by a Python\n" +
+        "bootstrapper bundled with this package. To finish the install either:\n" +
+        "  - install python3 (https://www.python.org/downloads/) and re-run\n" +
+        "    `2real-team init --with-hooks`, or\n" +
+        "  - use the Python package instead: `pip install 2real-team-framework`."
+      );
+    case "ran":
+      if (result.status !== 0) {
+        const detail = (result.stderr || result.stdout).trim().slice(0, 500);
+        return `Framework runtime install reported an issue (exit ${result.status}):\n${detail}`;
+      }
+      return "Installed the framework runtime (hooks/lib/skills/config).";
+  }
+}

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -16,35 +16,66 @@ import {
   validateTeam,
   showStatus,
 } from "./bootstrap.js";
+import { readPackageVersion } from "./version.js";
 
 const program = new Command();
 
 program
   .name("2real-team")
   .description("AI agent team framework for Claude Code projects")
-  .version("0.3.2");
+  .version(readPackageVersion());
 
 program
   .command("init")
   .description("Bootstrap a new project with the team framework")
   .option("--preset <name>", "Project preset (fullstack-monorepo, data-pipeline, library)")
   .option("--team-size <n>", "Override default team size", parseInt)
-  .option("--config <path>", "Path to config YAML file")
+  .option(
+    "--config <path>",
+    "Path to a YAML config file — either the unified install config " +
+      "(shared with framework/install/bootstrap.py) or the legacy flat team config",
+  )
   .option("--project-name <name>", "Project name")
   .option("--target <dir>", "Target directory", ".")
   .option("--no-interactive", "Disable interactive mode")
+  .option(
+    "--non-interactive",
+    "Guarantee zero prompts; the config (flags > YAML > defaults) answers everything",
+  )
   .option("--ai-personas", "Use Claude API to generate rich personas")
   .option("--seed <n>", "Seed for reproducible AI persona generation", parseInt)
+  .option(
+    "--with-hooks",
+    "Also install the framework runtime (hooks/lib/skills/config + settings wiring); default",
+  )
+  .option("--no-hooks", "Skip the framework runtime install (team scaffolding only)")
+  .option("--owner <owner>", "SCM org/user for the framework config (scm.owner)")
+  .option("--merge-model <model>", "Default merge model: wave-branch | direct-to-main")
+  .option(
+    "--with-ontology",
+    "Seed the ontology semantic overlay + structural index (requires hooks). " +
+      "Unset, follows the install config's ontology.enabled (default: on)",
+  )
+  .option("--no-ontology", "Skip the ontology seed + structural index")
   .action(async (opts) => {
+    // Tri-state: --with-ontology => true, --no-ontology => false, neither =>
+    // undefined (defer to the install config so a CLI default never silently
+    // overrides a forwarded YAML).
+    const withOntology =
+      opts.withOntology === true ? true : opts.ontology === false ? false : undefined;
     await bootstrap({
       preset: opts.preset,
       teamSize: opts.teamSize,
       config: opts.config,
       projectName: opts.projectName,
       target: opts.target,
-      interactive: opts.interactive !== false,
+      interactive: opts.interactive !== false && opts.nonInteractive !== true,
       aiPersonas: opts.aiPersonas ?? false,
       seed: opts.seed,
+      withHooks: opts.hooks !== false,
+      owner: opts.owner,
+      mergeModel: opts.mergeModel,
+      withOntology,
     });
   });
 

--- a/node/src/version.ts
+++ b/node/src/version.ts
@@ -1,0 +1,21 @@
+/**
+ * Read the CLI version from the package's own package.json (single source of
+ * truth — no hardcoded version strings in code). Works from both `src/` (dev,
+ * via vitest/tsx) and `dist/` (built package): each is one level below the
+ * package root.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export function readPackageVersion(): string {
+  const pkgPath = resolve(__dirname, "..", "package.json");
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as { version?: string };
+  if (!pkg.version) {
+    throw new Error(`package.json at ${pkgPath} has no version field`);
+  }
+  return pkg.version;
+}

--- a/node/tests/cli.test.ts
+++ b/node/tests/cli.test.ts
@@ -3,6 +3,23 @@
  */
 
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+
+// bootstrap() now bridges to the Python framework installer by default
+// (--with-hooks). Mock the bridge so these team-scaffolding tests never
+// spawn a subprocess; the bridge has its own dedicated test files.
+vi.mock("../src/framework-install.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("../src/framework-install.js")>();
+  return {
+    ...mod,
+    installFramework: vi.fn(() => ({
+      kind: "ran",
+      status: 0,
+      stdout: "",
+      stderr: "",
+      argv: [],
+    })),
+  };
+});
 import {
   existsSync,
   readFileSync,

--- a/node/tests/framework-install.test.ts
+++ b/node/tests/framework-install.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Tests for the Node -> Python framework-install bridge: framework root
+ * resolution, python detection, exact argv mapping, degradation results, the
+ * unified-vs-legacy config detection, and version-from-package.json.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  resolveFrameworkRoot,
+  findPython,
+  buildBootstrapArgv,
+  installFramework,
+  describeInstallResult,
+  type SpawnRunner,
+  type SpawnResult,
+} from "../src/framework-install.js";
+import { isUnifiedConfig, parseUnifiedConfig } from "../src/bootstrap.js";
+import { readPackageVersion } from "../src/version.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_FRAMEWORK = resolve(__dirname, "../../framework");
+const PKG_ROOT = resolve(__dirname, "..");
+
+interface Call {
+  cmd: string;
+  args: string[];
+}
+
+/** Runner that answers python probes and the bootstrap call with `status`. */
+function makeRunner(
+  calls: Call[],
+  pythonResults: Record<string, SpawnResult>,
+  bootstrapResult: SpawnResult = { status: 0, stdout: "", stderr: "" },
+): SpawnRunner {
+  return (cmd, args) => {
+    calls.push({ cmd, args });
+    if (args.length === 1 && args[0] === "--version") {
+      return pythonResults[cmd] ?? { status: null, error: new Error(`ENOENT: ${cmd}`) };
+    }
+    return bootstrapResult;
+  };
+}
+
+const PYTHON3_OK: Record<string, SpawnResult> = { python3: { status: 0 } };
+
+describe("resolveFrameworkRoot", () => {
+  it("resolves the repo-root framework/ in a dev checkout", () => {
+    const root = resolveFrameworkRoot();
+    expect(root).not.toBeNull();
+    // Either the package-local bundle (post-prepack) or the repo checkout.
+    expect([resolve(PKG_ROOT, "framework"), REPO_FRAMEWORK]).toContain(root);
+  });
+});
+
+describe("findPython", () => {
+  it("prefers python3", () => {
+    const calls: Call[] = [];
+    const runner = makeRunner(calls, { python3: { status: 0 }, python: { status: 0 } });
+    expect(findPython(runner)).toBe("python3");
+    expect(calls).toHaveLength(1);
+  });
+
+  it("falls back to python when python3 is missing", () => {
+    const calls: Call[] = [];
+    const runner = makeRunner(calls, {
+      python3: { status: null, error: new Error("ENOENT") },
+      python: { status: 0 },
+    });
+    expect(findPython(runner)).toBe("python");
+    expect(calls.map((c) => c.cmd)).toEqual(["python3", "python"]);
+  });
+
+  it("returns null when neither interpreter runs", () => {
+    const calls: Call[] = [];
+    const runner = makeRunner(calls, {});
+    expect(findPython(runner)).toBeNull();
+    expect(calls.map((c) => c.cmd)).toEqual(["python3", "python"]);
+  });
+
+  it("treats a nonzero exit as missing", () => {
+    const runner = makeRunner([], { python3: { status: 1 }, python: { status: 0 } });
+    expect(findPython(runner)).toBe("python");
+  });
+});
+
+describe("buildBootstrapArgv — exact flag mapping", () => {
+  const bootstrapPath = join("/fw", "install", "bootstrap.py");
+
+  it("maps the full flag set exactly", () => {
+    const argv = buildBootstrapArgv("python3", "/fw", "/target", {
+      installConfig: "/cfg/install.yaml",
+      owner: "acme",
+      mergeModel: "wave-branch",
+      withOntology: true,
+    });
+    expect(argv).toEqual([
+      "python3",
+      bootstrapPath,
+      "/target",
+      "--no-team",
+      "--non-interactive",
+      "--shell",
+      "bash",
+      "--install-config",
+      "/cfg/install.yaml",
+      "--owner",
+      "acme",
+      "--merge-model",
+      "wave-branch",
+      "--with-ontology",
+    ]);
+  });
+
+  it("always passes --no-team and --non-interactive with minimal options", () => {
+    const argv = buildBootstrapArgv("python3", "/fw", "/target");
+    expect(argv).toEqual([
+      "python3",
+      bootstrapPath,
+      "/target",
+      "--no-team",
+      "--non-interactive",
+      "--shell",
+      "bash",
+    ]);
+  });
+
+  it("tri-state ontology: false maps to --no-ontology", () => {
+    const argv = buildBootstrapArgv("python3", "/fw", "/t", { withOntology: false });
+    expect(argv).toContain("--no-ontology");
+    expect(argv).not.toContain("--with-ontology");
+  });
+
+  it("tri-state ontology: unset forwards neither flag", () => {
+    const argv = buildBootstrapArgv("python3", "/fw", "/t", {});
+    expect(argv).not.toContain("--with-ontology");
+    expect(argv).not.toContain("--no-ontology");
+  });
+
+  it("maps --dry-run", () => {
+    expect(buildBootstrapArgv("python3", "/fw", "/t", { dryRun: true })).toContain("--dry-run");
+  });
+});
+
+describe("installFramework", () => {
+  it("subprocesses the bundled bootstrap with the mapped argv", () => {
+    const calls: Call[] = [];
+    const runner = makeRunner(calls, PYTHON3_OK, { status: 0, stdout: "ok", stderr: "" });
+    const result = installFramework(
+      "/target",
+      { owner: "acme", mergeModel: "direct-to-main", withOntology: false },
+      runner,
+    );
+    expect(result.kind).toBe("ran");
+    if (result.kind !== "ran") return;
+    expect(result.status).toBe(0);
+    const root = resolveFrameworkRoot()!;
+    expect(result.argv).toEqual([
+      "python3",
+      join(root, "install", "bootstrap.py"),
+      "/target",
+      "--no-team",
+      "--non-interactive",
+      "--shell",
+      "bash",
+      "--owner",
+      "acme",
+      "--merge-model",
+      "direct-to-main",
+      "--no-ontology",
+    ]);
+    // Last spawn is the bootstrap subprocess itself, with the same argv.
+    const last = calls[calls.length - 1];
+    expect([last.cmd, ...last.args]).toEqual(result.argv);
+  });
+
+  it("degrades to no-python without invoking the bootstrapper", () => {
+    const calls: Call[] = [];
+    const runner = makeRunner(calls, {});
+    const result = installFramework("/target", {}, runner);
+    expect(result).toEqual({ kind: "no-python" });
+    // Only the two interpreter probes — never the bootstrap subprocess.
+    expect(calls.map((c) => c.cmd)).toEqual(["python3", "python"]);
+  });
+
+  it("surfaces a nonzero bootstrap exit", () => {
+    const runner = makeRunner([], PYTHON3_OK, { status: 3, stdout: "", stderr: "boom" });
+    const result = installFramework("/target", {}, runner);
+    expect(result.kind).toBe("ran");
+    if (result.kind !== "ran") return;
+    expect(result.status).toBe(3);
+    expect(result.stderr).toBe("boom");
+  });
+});
+
+describe("describeInstallResult", () => {
+  it("explains the no-python degradation with recovery paths", () => {
+    const msg = describeInstallResult({ kind: "no-python" });
+    expect(msg).toContain("python3");
+    expect(msg).toContain("pip install 2real-team-framework");
+    expect(msg).toContain("team scaffolding");
+  });
+
+  it("explains missing bundled assets", () => {
+    const msg = describeInstallResult({ kind: "no-framework" });
+    expect(msg).toContain("bundled assets not found");
+  });
+
+  it("reports a nonzero exit with detail", () => {
+    const msg = describeInstallResult({
+      kind: "ran",
+      status: 2,
+      stdout: "",
+      stderr: "traceback",
+      argv: [],
+    });
+    expect(msg).toContain("exit 2");
+    expect(msg).toContain("traceback");
+  });
+
+  it("reports success", () => {
+    const msg = describeInstallResult({ kind: "ran", status: 0, stdout: "", stderr: "", argv: [] });
+    expect(msg).toContain("Installed the framework runtime");
+  });
+});
+
+describe("unified vs legacy config detection", () => {
+  it("detects marker keys as unified", () => {
+    for (const raw of [
+      { version: 1 },
+      { repo: { expect: "fresh" } },
+      { scm: { owner: "acme" } },
+      { ontology: { enabled: false } },
+      { children: [] },
+      { pre_push: { mode: "noop" } },
+    ]) {
+      expect(isUnifiedConfig(raw as Record<string, unknown>)).toBe(true);
+    }
+  });
+
+  it("detects team/project mappings as unified", () => {
+    expect(isUnifiedConfig({ team: { preset: "library" } })).toBe(true);
+    expect(isUnifiedConfig({ project: { name: "x" } })).toBe(true);
+  });
+
+  it("treats the legacy flat team schema as legacy", () => {
+    expect(isUnifiedConfig({ preset: "library", team_size: 5 })).toBe(false);
+    expect(isUnifiedConfig({ preset: "library", members: [{ name: "A B" }] })).toBe(false);
+  });
+
+  it("does not treat a non-mapping team key as unified", () => {
+    expect(isUnifiedConfig({ team: ["a"] })).toBe(false);
+  });
+
+  it("parseUnifiedConfig extracts the team-relevant subset", () => {
+    const cfg = parseUnifiedConfig({
+      version: 1,
+      project: { name: "acme-app" },
+      scm: { owner: "acme" },
+      team: { enabled: true, preset: "library", size: 4 },
+    });
+    expect(cfg).toEqual({
+      teamEnabled: true,
+      preset: "library",
+      teamSize: 4,
+      projectName: "acme-app",
+      owner: "acme",
+    });
+  });
+
+  it("parseUnifiedConfig defaults team.enabled to true and honors false", () => {
+    expect(parseUnifiedConfig({ version: 1 }).teamEnabled).toBe(true);
+    expect(parseUnifiedConfig({ team: { enabled: false } }).teamEnabled).toBe(false);
+  });
+});
+
+describe("CLI version", () => {
+  it("reads the version from package.json (no hardcoded string)", () => {
+    const pkg = JSON.parse(readFileSync(join(PKG_ROOT, "package.json"), "utf-8"));
+    expect(readPackageVersion()).toBe(pkg.version);
+    expect(readPackageVersion()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it("index.ts wires program.version() to readPackageVersion", () => {
+    const src = readFileSync(join(PKG_ROOT, "src", "index.ts"), "utf-8");
+    expect(src).toContain(".version(readPackageVersion())");
+    expect(src).not.toMatch(/\.version\("\d/);
+  });
+});

--- a/node/tests/init-bridge.test.ts
+++ b/node/tests/init-bridge.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Integration tests for `init` + the framework bridge: hook invocation with
+ * mapped options, unified-config forwarding (--install-config), team.enabled
+ * false runtime-only path, --no-hooks, and the python3-missing degradation
+ * path (team scaffolding must still land).
+ *
+ * `installFramework` is mocked (spawn never runs); everything else is real.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+vi.mock("../src/framework-install.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("../src/framework-install.js")>();
+  return {
+    ...mod,
+    installFramework: vi.fn(() => ({
+      kind: "ran",
+      status: 0,
+      stdout: "",
+      stderr: "",
+      argv: [],
+    })),
+  };
+});
+
+import { bootstrap } from "../src/bootstrap.js";
+import { installFramework } from "../src/framework-install.js";
+
+const installFrameworkMock = vi.mocked(installFramework);
+
+let target: string;
+let logSpy: ReturnType<typeof vi.spyOn>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  target = mkdtempSync(join(tmpdir(), "2real-bridge-"));
+  installFrameworkMock.mockClear();
+  installFrameworkMock.mockReturnValue({
+    kind: "ran",
+    status: 0,
+    stdout: "",
+    stderr: "",
+    argv: [],
+  });
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+  warnSpy.mockRestore();
+  rmSync(target, { recursive: true, force: true });
+});
+
+function output(spy: ReturnType<typeof vi.spyOn>): string {
+  return spy.mock.calls.map((c) => c.join(" ")).join("\n");
+}
+
+describe("init --with-hooks bridge", () => {
+  it("invokes the bridge by default with mapped options", async () => {
+    await bootstrap({
+      preset: "library",
+      target,
+      interactive: false,
+      owner: "acme",
+      mergeModel: "wave-branch",
+      withOntology: true,
+    });
+    expect(installFrameworkMock).toHaveBeenCalledTimes(1);
+    expect(installFrameworkMock).toHaveBeenCalledWith(resolve(target), {
+      owner: "acme",
+      mergeModel: "wave-branch",
+      installConfig: undefined,
+      withOntology: true,
+    });
+    expect(existsSync(join(target, ".claude", "team", "charter.md"))).toBe(true);
+  });
+
+  it("skips the bridge with --no-hooks", async () => {
+    await bootstrap({ preset: "library", target, interactive: false, withHooks: false });
+    expect(installFrameworkMock).not.toHaveBeenCalled();
+    expect(existsSync(join(target, ".claude", "team", "charter.md"))).toBe(true);
+  });
+
+  it("forwards a unified config as --install-config and takes team/scm fields from it", async () => {
+    const cfgPath = join(target, "install.yaml");
+    writeFileSync(
+      cfgPath,
+      [
+        "version: 1",
+        "project:",
+        "  name: acme-app",
+        "scm:",
+        "  owner: acme",
+        "team:",
+        "  preset: library",
+        "  size: 4",
+      ].join("\n") + "\n",
+    );
+    await bootstrap({ config: cfgPath, target, interactive: true });
+    expect(installFrameworkMock).toHaveBeenCalledWith(resolve(target), {
+      owner: "acme",
+      mergeModel: undefined,
+      installConfig: resolve(cfgPath),
+      withOntology: undefined,
+    });
+    expect(existsSync(join(target, ".claude", "team", "charter.md"))).toBe(true);
+    expect(output(logSpy)).toContain("acme-app");
+  });
+
+  it("CLI flags win over the unified YAML", async () => {
+    const cfgPath = join(target, "install.yaml");
+    writeFileSync(cfgPath, "version: 1\nscm:\n  owner: yaml-owner\nteam:\n  preset: library\n");
+    await bootstrap({ config: cfgPath, target, interactive: false, owner: "flag-owner" });
+    expect(installFrameworkMock.mock.calls[0][1]).toMatchObject({ owner: "flag-owner" });
+  });
+
+  it("does not forward a legacy config as --install-config", async () => {
+    const cfgPath = join(target, "team.yaml");
+    writeFileSync(cfgPath, "preset: library\nteam_size: 3\n");
+    await bootstrap({ config: cfgPath, target, interactive: false });
+    expect(installFrameworkMock.mock.calls[0][1]).toMatchObject({ installConfig: undefined });
+  });
+
+  it("team.enabled false installs the runtime only (no team scaffolding)", async () => {
+    const cfgPath = join(target, "install.yaml");
+    writeFileSync(cfgPath, "version: 1\nteam:\n  enabled: false\n");
+    await bootstrap({ config: cfgPath, target, interactive: false });
+    expect(installFrameworkMock).toHaveBeenCalledWith(resolve(target), {
+      owner: undefined,
+      mergeModel: undefined,
+      installConfig: resolve(cfgPath),
+      withOntology: undefined,
+    });
+    expect(existsSync(join(target, ".claude", "team"))).toBe(false);
+    expect(output(logSpy)).toContain("skipping team scaffolding");
+  });
+});
+
+describe("python3-missing degradation", () => {
+  it("still installs the team scaffolding and explains what was skipped", async () => {
+    installFrameworkMock.mockReturnValue({ kind: "no-python" });
+    await bootstrap({ preset: "library", target, interactive: false });
+
+    // Team layer landed despite the missing runtime.
+    expect(existsSync(join(target, ".claude", "team", "charter.md"))).toBe(true);
+    expect(existsSync(join(target, "CLAUDE.md"))).toBe(true);
+    expect(output(logSpy)).toContain("Team framework bootstrapped");
+
+    // Clear degradation message: what was skipped and how to get the runtime.
+    const warned = output(warnSpy);
+    expect(warned).toContain("no Python 3 interpreter found");
+    expect(warned).toContain("python3");
+    expect(warned).toContain("pip install 2real-team-framework");
+  });
+
+  it("reports a failed bootstrap subprocess without aborting", async () => {
+    installFrameworkMock.mockReturnValue({
+      kind: "ran",
+      status: 2,
+      stdout: "",
+      stderr: "explosion",
+      argv: [],
+    });
+    await bootstrap({ preset: "library", target, interactive: false });
+    expect(existsSync(join(target, ".claude", "team", "charter.md"))).toBe(true);
+    const warned = output(warnSpy);
+    expect(warned).toContain("exit 2");
+    expect(warned).toContain("explosion");
+  });
+});


### PR DESCRIPTION
Closes #70

## Summary

Brings the Node CLI to parity with the Python CLI: `2real-team init` now bundles `framework/` into the npm package and bridges to the bundled Python bootstrapper (`framework/install/bootstrap.py`), mirroring the Python package's `framework_install.py` contract established in #79.

## Design

**Bridge (`node/src/framework-install.ts`)** — Node twin of `real_team/framework_install.py`:
- `resolveFrameworkRoot()`: package-local `framework/` (npm tarball) first, dev fallback to repo-root `framework/`; requires a runnable `install/bootstrap.py`.
- `findPython()`: `python3` first, `python` fallback, probed via `--version`.
- `installFramework()`: subprocesses the bootstrapper with `--no-team --non-interactive --shell bash` plus mapped flags — `--install-config`, `--owner`, `--merge-model`, tri-state `--with-ontology`/`--no-ontology` (unset forwards **neither**, so a CLI default never overrides a forwarded YAML). Returns typed results (`ran` / `no-framework` / `no-python`); the spawn runner is injectable for tests.

**CLI surface (`init`)** — mirrors the Python CLI's #79 contract:
- `--with-hooks` (default) / `--no-hooks`, `--owner`, `--merge-model`, `--non-interactive`, `--with-ontology` / `--no-ontology`.
- `--config <yaml>` auto-detects **unified install config** vs **legacy flat team config** using the same markers as Python `models.py` (`version|repo|scm|ci|ticketing|pre_push|ontology|children`, or mapping-typed `team`/`project`). Unified: CLI flags win over YAML, the file is forwarded as `--install-config`, `team.enabled: false` installs the runtime only. Legacy: unchanged behavior, nothing forwarded.
- After a successful bridge run, the recorded `.claude/install.config.json` team section is synced to the roster the CLI actually scaffolded (the bridge passes `--no-team`), matching Python's `_sync_install_snapshot`.

**Graceful degradation** — no Python on PATH: team scaffolding still installs; a clear message explains the runtime was skipped and how to finish (install python3 + re-run `init --with-hooks`, or `pip install 2real-team-framework`).

**Packaging** — `scripts/copy-shared.js` now also copies `framework/` at prepack (npm mirror of the hatch `BundleSharedDataHook`), excluding `tests/`, `__pycache__/`, tool caches, and `.pyc`. `package.json` `files` gains `framework/`. `node/framework/` is gitignored as a build artifact. Tarball: **187.9 kB packed / 598 kB unpacked / 108 files** (framework/tests confirmed absent).

**Version** — hardcoded `.version("0.3.2")` removed; `src/version.ts` reads `package.json` (works from both `src/` and `dist/`).

**npm long description** — npm only renders the README inside the package dir (the repo-root README is not in the tarball), so added a focused `node/README.md` (install, `init` flag table, Python-runtime note, pointer to the repo README).

## Test evidence

- `npm test -- --run`: **127 passed** (4 files) — new `framework-install.test.ts` (exact argv assertions incl. full flag set + tri-state ontology, python fallback/missing, unified-vs-legacy detection, version-from-package.json) and `init-bridge.test.ts` (bridge wiring with spawn mocked, `--install-config` forwarding, flags-over-YAML, `team.enabled: false` runtime-only path, python3-missing degradation with scaffolding intact). `cli.test.ts` mocks the bridge so existing scaffolding tests never spawn.
- `npm run build`: clean.
- E2E (real subprocess, no mocks): `node dist/index.js init --preset library --non-interactive --owner acme --merge-model wave-branch --no-ontology` → 19 hooks + lib + skills + `framework.config.json` installed, `install.config.json` shows `scm.owner=acme`, `team {enabled: true, preset: library, size: 3}`, `ontology.enabled=false`, no `ontology/` dir. Verified both resolution paths (repo-root fallback and package-local bundle after prepack).
- Python untouched: `ruff check framework/` clean, `pytest framework/tests/` **150 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1sHWTyKtu8DAExDn9DgLS
