### PR TITLE
feat(install): meta/child install modes + fresh-vs-existing detection (#65)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,9 +178,10 @@ tooling reads one canonical record of the install-time decisions. This is the
 | Key | Type | Default | Effect |
 |-----|------|---------|--------|
 | `version` | integer | `1` | Config schema version (must be `1`) |
-| `repo.expect` | `fresh` \| `existing` \| `any` | `fresh` | Expectation about the target repo. Recorded today (a mismatch prints a note); detection/enforcement ships with the meta/child install modes |
+| `repo.expect` | `fresh` \| `existing` \| `any` | `fresh` | Expectation about the target repo — **enforced**. The installer detects the actual state (git repo? commits? non-framework files?) and reports it. Non-interactive installs **refuse** on a mismatch (`any` always proceeds); interactive installs ask for explicit confirmation before touching an existing repo; idempotent re-runs skip the gate. Also available as the `--expect` flag |
 | `project.name` | string \| null | `null` | Display name; `null` falls back to the target directory name |
-| `project.model` | `standalone` \| `meta` \| `child` | `standalone` | Project shape. Maps into the runtime config (`standalone`/`child` → `single-repo`, `meta` → `meta-and-children`) |
+| `project.model` | `standalone` \| `meta` \| `child` | `standalone` | Project shape. Maps into the runtime config (`standalone` → `single-repo`, `meta` → `meta-and-children`, `child` → `child` — first-class, so a child repo is recoverable from its runtime config) |
+| `project.flavor` | `product` \| `infra` | `product` | **Child model only:** this repo's flavor (see the flavor table below) |
 | `scm.provider` | `github` | `github` | SCM host (only GitHub is implemented) |
 | `scm.owner` | string \| null | `null` | GitHub org/user. Replaces the interactive owner prompt; flows into `framework.config.json` |
 | `ci.provider` | `github-actions` | `github-actions` | CI system (only GitHub Actions is implemented) |
@@ -190,7 +191,8 @@ tooling reads one canonical record of the install-time decisions. This is the
 | `team.enabled` | bool | `true` | Generate the team layer (roster, identity gate); `false` installs the runtime only |
 | `team.preset` | string \| null | `null` | Team preset for `2real-team init` (`fullstack-monorepo`, `data-pipeline`, `library`). Replaces the preset prompt |
 | `team.size` | integer \| null | `null` | Target headcount. Replaces the team-size and roster-proceed prompts; `null` lets the preset/introspection decide |
-| `children` | list | `[]` | Child repos for meta/child models: `- path: <rel-path>` with optional `flavor: product\|infra` (default `product`). Parsed, validated, and recorded for the meta/child install modes |
+| `parent.path` | string \| null | `null` | **Child model only (required there):** relative path from this repo to its parent meta-repo (e.g. `..`). Must be relative — portable paths only. The parent must already have the framework installed |
+| `children` | list | `[]` | **Meta model only:** child repos to install — `- path: <rel-path>` with optional `flavor: product\|infra` (default `product`). Non-interactive installs use this list **verbatim** (no detection surprises); interactive installs multi-select from detected subdir git repos |
 
 Unknown keys are warned about and **carried** into the recorded snapshot (forward
 compatibility). Invalid values (bad enums/types) are fatal — the install refuses to proceed.
@@ -199,6 +201,48 @@ With `--non-interactive` there are **zero prompts on any path**: `scm.owner` lef
 produces a warning (not a prompt), and the team is generated exactly as configured.
 `bootstrap.py` stays stdlib-only — it reads the YAML with a bundled minimal parser
 (`framework/install/miniyaml.py`); the Python CLI uses PyYAML.
+
+### Meta-repo and child installs
+
+A **meta** install lays the full framework at the meta root, then a hook-less *child
+layout* into each selected child repo. A **child** install lays only that child layout,
+pointing at an already-bootstrapped parent. Children carry **no hook code** — one copy of
+the hooks lives at the meta root and every child's `.claude/settings.json` invokes the
+parent's dispatchers via **portable** parent-relative commands
+(`python3 "$CLAUDE_PROJECT_DIR/../.claude/hooks/dispatcher.py"` — never machine-absolute
+paths, so the whole tree clones anywhere; the traversal depth is derived from the child's
+configured path).
+
+```yaml
+# meta.install.yaml — run at the META root
+repo: { expect: existing }        # meta roots usually already exist
+project: { model: meta }
+children:
+  - path: api                     # full harness
+  - path: infra/tf                # commit-safety + CI subset
+    flavor: infra
+```
+
+```yaml
+# child.install.yaml — run at the CHILD root (e.g. a child added later)
+project: { model: child, flavor: product }
+parent: { path: .. }              # must already have the framework installed
+```
+
+Each selected child gets: a flavor-appropriate `.claude/settings.json`, its own
+`framework.config.json` (`project.model: child` + `project.parent` + `project.flavor`,
+inheriting `scm`/`identity`/`policy`/`hooks` from the parent config), a scoped
+`.claude/team/` roster subset (`roster.json` + persona cards; trust matrix and feedback
+log stay at the meta), and a child `CLAUDE.md` (an existing one is preserved as
+`CLAUDE.md.bak`). The meta's `framework.config.json` records the children in
+`project.repos`. The commit-identity gate unions each child's roster with the meta roster
+(parent ∪ child), so org leads can commit in any child but one child's engineers cannot
+commit in another.
+
+| Flavor | Wired hook events |
+|--------|-------------------|
+| `product` | The full harness: SessionStart (ontology refresh), pre/post Bash dispatchers, file-edit tracking |
+| `infra` | Commit-safety + CI subset: pre/post **Bash** dispatchers only — no ontology/session extras |
 
 ## AI Persona Generation
 

--- a/framework/assets/hooks/_framework_config.py
+++ b/framework/assets/hooks/_framework_config.py
@@ -47,6 +47,8 @@ CONFIG_FILENAME = "framework.config.json"
 # framework/config/framework.config.schema.json.
 _DEFAULTS: dict[str, Any] = {
     "version": 1,
+    # model enum: single-repo | meta-and-children | child (child repos carry
+    # project.parent + project.flavor; the DEFAULT stays single-repo).
     "project": {"model": "single-repo"},
     "scm": {"provider": "github", "default_branch": "main", "allow_force": False},
     "branch": {"feature": "{initials}/{issue}-{slug}", "integration": "deployments/wave-{wave}"},

--- a/framework/config/README.md
+++ b/framework/config/README.md
@@ -22,7 +22,7 @@ capability but do not error.
 | Key | Why you'd change it |
 |-----|---------------------|
 | `scm.owner` | Your GitHub org/user. Needed by every `gh`-calling hook. |
-| `project.model` | `single-repo` vs `meta-and-children` (a meta-repo + child repos). |
+| `project.model` | `single-repo` vs `meta-and-children` (a meta-repo + child repos) vs `child` (one child repo — carries no hook code; `project.parent` is the portable relative path to its meta-repo, `project.flavor` is `product`/`infra`). |
 | `shell` | Set `zsh` to activate the zsh bash-ism advisory. |
 | `policy.reviewers_required` | The N-reviewer-before-merge threshold. |
 | `policy.merge_model` | `wave-branch` vs `direct-to-main`. |

--- a/framework/config/framework.config.schema.json
+++ b/framework/config/framework.config.schema.json
@@ -20,13 +20,22 @@
         "name": { "type": "string", "description": "Display name." },
         "model": {
           "type": "string",
-          "enum": ["single-repo", "meta-and-children"],
+          "enum": ["single-repo", "meta-and-children", "child"],
           "default": "single-repo",
-          "description": "single-repo: one repository. meta-and-children: a parent meta-repo that .gitignores N child repos (the cross-repo orchestration model)."
+          "description": "single-repo: one repository. meta-and-children: a parent meta-repo that .gitignores N child repos (the cross-repo orchestration model). child: one child repo inside a meta-and-children project — it carries NO hook code; its settings.json invokes the parent's installed hooks (see project.parent)."
         },
         "meta_repo": {
           "type": "string",
           "description": "Name of the meta-repo (meta-and-children model only). The repo that holds the shared .claude/ config."
+        },
+        "parent": {
+          "type": "string",
+          "description": "Child model only: PORTABLE relative path from this repo's root to its parent meta-repo (e.g. `..` or `../..`). Never an absolute path — the whole meta tree stays cloneable anywhere."
+        },
+        "flavor": {
+          "type": "string",
+          "enum": ["product", "infra"],
+          "description": "Child model only: which hook events this child wires to the parent's dispatchers. product = the full harness; infra = the commit-safety + CI subset (pre/post Bash only; no ontology/session extras)."
         },
         "repos": {
           "type": "array",

--- a/framework/config/install.config.default.yaml
+++ b/framework/config/install.config.default.yaml
@@ -18,10 +18,13 @@ version: 1
 
 repo:
   # What the installer should expect at the target:
-  #   fresh    — a brand-new project (no established repo yet)
-  #   existing — an already-established repository
+  #   fresh    — a brand-new project (no commits, no real files yet)
+  #   existing — an already-established repository (has commits and/or files)
   #   any      — no expectation; install either way
-  # (Fresh-vs-existing detection/enforcement ships with the meta/child install modes.)
+  # ENFORCED: the installer detects the actual state and reports it. A
+  # non-interactive install REFUSES on a mismatch (`any` always proceeds);
+  # an interactive install asks for explicit confirmation before touching an
+  # existing repo. Idempotent re-runs (framework already installed) skip the gate.
   expect: fresh
 
 project:
@@ -29,9 +32,14 @@ project:
   name: null
   # Project shape:
   #   standalone — a single self-contained repository
-  #   meta       — a parent meta-repo orchestrating N child repos
-  #   child      — one child repo inside a meta-repo project
+  #   meta       — a parent meta-repo orchestrating N child repos (see `children:`)
+  #   child      — one child repo inside a meta-repo project (see `parent:`)
   model: standalone
+  # Child-model only: THIS repo's flavor (which hook events its settings.json
+  # wires to the parent's dispatchers):
+  #   product — the full harness (session/ontology + pre/post Bash + file edits)
+  #   infra   — commit-safety + CI subset (pre/post Bash dispatchers only)
+  flavor: product
 
 scm:
   # Source-control host. Only `github` is implemented today.
@@ -70,8 +78,19 @@ team:
   # Target headcount. null -> the preset default / repo introspection decides.
   size: null
 
-# Child repositories (meta/child project models only). Each entry:
-#   - path: relative path (or bare repo name) of the child
+# Parent meta-repo (child model only). REQUIRED when project.model is `child`:
+# the relative path from THIS repo to its parent meta-repo (e.g. `..`). The
+# parent must already have the framework installed (its .claude/hooks are what
+# this child's settings.json invokes).
+parent:
+  path: null
+
+# Child repositories (meta model only). Each entry:
+#   - path: relative path (from the meta root) of the child
 #     flavor: product | infra        (defaults to product)
-# Consumed by the meta/child install modes; parsed and carried today.
+# A non-interactive meta install uses this list VERBATIM (no detection
+# surprises); an interactive install multi-selects from the detected
+# immediate-subdirectory git repos. Each selected child gets a parent-relative
+# .claude/settings.json, a child framework.config.json, a roster subset, and a
+# child CLAUDE.md.
 children: []

--- a/framework/install/bootstrap.py
+++ b/framework/install/bootstrap.py
@@ -760,6 +760,7 @@ def install_children(
     members_by_child: dict[str, list],
     *,
     install_permissions: bool,
+    force: bool,
     dry_run: bool,
 ) -> list[tuple[str, str, dict[str, str]]]:
     """Lay the child layout (parent-relative settings, child runtime config,
@@ -777,7 +778,7 @@ def install_children(
             install_permissions=install_permissions, template=child_tmpl,
         )
         ccfg = child_install.child_runtime_config(meta_cfg, child_root.name, rel, c["flavor"])
-        cfg_status = write_config(child_root / ".claude", ccfg, force=False, dry_run=dry_run)
+        cfg_status = write_config(child_root / ".claude", ccfg, force=force, dry_run=dry_run)
         members = [
             (p.role, p.level, p.name) for p in members_by_child.get(child_root.name, [])
         ]
@@ -1107,7 +1108,8 @@ def main() -> int:
             )
         child_reports = install_children(
             target, cfg, selected_children, members_by_child,
-            install_permissions=not args.no_permissions, dry_run=args.dry_run,
+            install_permissions=not args.no_permissions, force=args.force,
+            dry_run=args.dry_run,
         )
 
     print("\n-- plan --" if args.dry_run else "\n-- result --")

--- a/framework/install/bootstrap.py
+++ b/framework/install/bootstrap.py
@@ -16,6 +16,14 @@ guarantees zero prompts on every path. The resolved install config is recorded
 at ``<target>/.claude/install.config.json``; the RUNTIME config the hooks read
 remains ``<target>/.claude/framework.config.json``.
 
+Project models: ``standalone`` (default) installs everything here; ``meta``
+additionally lays a hook-less child layout (parent-relative settings, child
+config/roster/CLAUDE.md) into each selected child repo; ``child`` installs ONLY
+that child layout, pointing at an already-bootstrapped parent (``parent.path``).
+A fresh-vs-existing gate reports the target's state and enforces ``repo.expect``
+(non-interactive mismatches refuse; interactive installs confirm before touching
+an existing repo; idempotent re-runs skip the gate).
+
 Usage
 =====
 
@@ -42,7 +50,8 @@ Flags
   --config PATH          JSON RUNTIME-config seed (framework.config.json shape).
   --owner NAME           scm.owner (GitHub org/user). Overlays the configs.
   --project-name NAME    project.name.
-  --model {single-repo,meta-and-children}
+  --model {single-repo,meta-and-children,child}
+  --expect {fresh,existing,any}  repo.expect override (fresh-vs-existing gate).
   --shell {bash,zsh}
   --reviewers N          policy.reviewers_required.
   --merge-model {wave-branch,direct-to-main}
@@ -60,10 +69,12 @@ from __future__ import annotations
 import argparse
 import json
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+import child_install  # noqa: E402  (sibling module in install/)
 import install_config  # noqa: E402  (sibling module in install/)
 import roster_gen  # noqa: E402  (sibling module in install/)
 
@@ -138,6 +149,7 @@ def resolve_install_config(args: argparse.Namespace) -> tuple[dict, set[str]]:
         "scm.owner": args.owner,
         "project.name": args.project_name,
         "team.size": args.team_size,
+        "repo.expect": args.expect,
     }
     if args.model:  # runtime enum -> install enum
         flag_map["project.model"] = install_config.INSTALL_MODEL_MAP[args.model]
@@ -358,7 +370,13 @@ def _merge_permissions(template: dict, existing: dict) -> bool:
     return changed
 
 
-def merge_settings(target_claude: Path, *, dry_run: bool, install_permissions: bool = True) -> str:
+def merge_settings(
+    target_claude: Path,
+    *,
+    dry_run: bool,
+    install_permissions: bool = True,
+    template: dict | None = None,
+) -> str:
     """Idempotently merge the template hook wiring into <target>/.claude/settings.json.
 
     Generic over events (PreToolUse / PostToolUse / SessionStart / …): blocks match by
@@ -368,8 +386,13 @@ def merge_settings(target_claude: Path, *, dry_run: bool, install_permissions: b
     Also merges the template's curated ``permissions.allow`` allowlist (union, no duplicates,
     user-added rules preserved) unless ``install_permissions`` is False, in which case the
     template's permissions block is not installed and any existing one is left untouched.
+
+    ``template`` overrides the shipped ``settings.template.json`` — used by the child-repo
+    install, whose template is the shipped one rewritten to parent-relative commands (and
+    flavor-filtered). The merge/idempotency semantics are identical.
     """
-    template = json.loads((_ASSETS / "settings.template.json").read_text(encoding="utf-8"))
+    if template is None:
+        template = json.loads((_ASSETS / "settings.template.json").read_text(encoding="utf-8"))
     dest = target_claude / "settings.json"
     existing: dict = {}
     if dest.exists():
@@ -569,6 +592,311 @@ def generate_structural(
     return msg
 
 
+# ------------------------------------------------------ fresh-vs-existing gate
+
+#: Framework-owned entries that never make a target count as "existing" — the
+#: CLI's team scaffolding and our own artifacts must not trip the gate.
+_FRAMEWORK_OWNED = {".git", ".claude", "ontology"}
+
+
+def detect_repo_state(target: Path) -> dict:
+    """Detect the target's fresh-vs-existing state. Fail-open (never raises).
+
+    Signals reported: is it a git repo, does it have commits, does it contain
+    non-framework files. ``classification`` is ``existing`` when there are
+    commits OR foreign files, else ``fresh``. ``installed`` means the framework
+    itself is already there (idempotent re-runs skip the gate entirely).
+    """
+    has_git = (target / ".git").exists()
+    has_commits = False
+    if has_git:
+        try:
+            r = subprocess.run(
+                ["git", "-C", str(target), "rev-parse", "--verify", "-q", "HEAD"],
+                capture_output=True, timeout=10,
+            )
+            has_commits = r.returncode == 0
+        except (OSError, subprocess.SubprocessError):
+            pass  # fail-open: git unavailable -> judge by files alone
+    nonempty = False
+    if target.is_dir():
+        for entry in target.iterdir():
+            if entry.name in _FRAMEWORK_OWNED or entry.name.startswith("CLAUDE.md"):
+                continue
+            nonempty = True
+            break
+    return {
+        "has_git": has_git,
+        "has_commits": has_commits,
+        "nonempty": nonempty,
+        "installed": (target / ".claude" / "framework.config.json").is_file(),
+        "classification": "existing" if (has_commits or nonempty) else "fresh",
+    }
+
+
+def repo_expectation_gate(
+    state: dict,
+    expect: str,
+    *,
+    non_interactive: bool,
+    interactive_tty: bool,
+    dry_run: bool = False,
+    ask=input,
+) -> tuple[bool, list[str]]:
+    """Decide whether the install may proceed given detection vs ``repo.expect``.
+
+    Returns ``(proceed, notes)``. Rules:
+
+    * already installed        -> proceed (idempotent re-run; gate skipped)
+    * ``expect == any`` /match -> proceed
+    * mismatch, dry-run        -> proceed (report what a real run would do)
+    * mismatch, non-interactive-> REFUSE with a clear message (deliberate: automation
+      against an established repo must say so via ``repo.expect: existing|any``)
+    * existing repo, interactive TTY -> explicit confirmation prompt ([y/N])
+    * otherwise (plain mode / no TTY) -> note and proceed (back-compat)
+    """
+    notes: list[str] = []
+    if state["installed"]:
+        notes.append("framework already installed here — idempotent re-run; expectation gate skipped.")
+        return True, notes
+    actual = state["classification"]
+    if expect == "any" or actual == expect:
+        if actual == "existing":
+            notes.append(f"installing into an EXISTING repo (repo.expect={expect}).")
+        return True, notes
+    detail = (
+        f"repo.expect={expect} but the target looks {actual.upper()} "
+        f"(git repo: {'yes' if state['has_git'] else 'no'}, "
+        f"commits: {'yes' if state['has_commits'] else 'no'}, "
+        f"non-framework files: {'yes' if state['nonempty'] else 'no'})."
+    )
+    if dry_run:
+        notes.append(detail + " Dry-run continues; a non-interactive install would refuse.")
+        return True, notes
+    if non_interactive:
+        notes.append(
+            detail + " Refusing: set repo.expect to match the target (or `any`) in the "
+            "install config / --expect flag, or run with --interactive to confirm."
+        )
+        return False, notes
+    if interactive_tty and actual == "existing":
+        ans = ask(f"{detail}\nInstall into this EXISTING repo anyway? [y/N]: ").strip().lower()
+        if ans in ("y", "yes"):
+            notes.append("existing repo explicitly confirmed — proceeding.")
+            return True, notes
+        notes.append("aborted at the existing-repo confirmation.")
+        return False, notes
+    notes.append(detail + " Proceeding (advisory in this mode).")
+    return True, notes
+
+
+# ------------------------------------------------------ meta/child install modes
+
+
+def _prompt_children(candidates: list[Path]) -> list[dict]:
+    """Interactive multi-select of the meta-repo's children (+ per-child flavor)."""
+    if not candidates:
+        print("no candidate child repos detected (immediate subdirs with .git).")
+        return []
+    print("\n-- meta-repo children --")
+    print("candidate child repos (immediate subdirs with .git):")
+    for i, c in enumerate(candidates, 1):
+        print(f"  {i}. {c.name}")
+    ans = input(
+        "Which are children of this meta-repo? [a]ll / [n]one / numbers (e.g. 1,3) [all]: "
+    ).strip().lower()
+    if ans in ("", "a", "all"):
+        chosen = list(candidates)
+    elif ans in ("n", "none"):
+        chosen = []
+    else:
+        picked: set[int] = set()
+        for tok in ans.replace(",", " ").split():
+            try:
+                picked.add(int(tok))
+            except ValueError:
+                print(f"  (ignored {tok!r} — not a number)")
+        chosen = [c for i, c in enumerate(candidates, 1) if i in picked]
+    selected: list[dict] = []
+    for c in chosen:
+        f = input(f"flavor for {c.name}? [p]roduct / [i]nfra [product]: ").strip().lower()
+        selected.append({"path": c.name, "flavor": "infra" if f.startswith("i") else "product"})
+    return selected
+
+
+def select_children(
+    inst: dict, user_keys: set[str], target: Path, *, interactive_tty: bool
+) -> list[dict]:
+    """Resolve the meta install's children as ``{path, flavor}`` dicts.
+
+    The config is consulted first: an explicit ``children:`` list (YAML/flags)
+    is used VERBATIM — detection never overrides it. Interactive mode (TTY,
+    no configured list) multi-selects from ``detect_child_repos`` candidates.
+    Non-interactive without a list installs no children (no detection
+    surprises). Missing configured paths are fatal.
+    """
+    if "children" in user_keys or not interactive_tty:
+        selected = [dict(c) for c in inst.get("children") or []]
+    else:
+        selected = _prompt_children(roster_gen.detect_child_repos(target))
+    for c in selected:
+        c.setdefault("flavor", "product")
+    missing = [c["path"] for c in selected if not (target / c["path"]).is_dir()]
+    if missing:
+        raise SystemExit(
+            f"ERROR: configured children not found under {target}: {', '.join(missing)} "
+            "— children must exist before the meta install (create/clone them first)."
+        )
+    for c in selected:
+        if not ((target / c["path"]) / ".git").exists():
+            print(f"warn:          child {c['path']} is not a git repo (no .git) — installing anyway.")
+    return selected
+
+
+def install_children(
+    target: Path,
+    meta_cfg: dict,
+    selected: list[dict],
+    members_by_child: dict[str, list],
+    *,
+    install_permissions: bool,
+    dry_run: bool,
+) -> list[tuple[str, str, dict[str, str]]]:
+    """Lay the child layout (parent-relative settings, child runtime config,
+    child CLAUDE.md) into each selected child. Roster subsets are written by
+    ``roster_gen.write_roster`` (per-child branch). Idempotent throughout."""
+    template = json.loads((_ASSETS / "settings.template.json").read_text(encoding="utf-8"))
+    reports: list[tuple[str, str, dict[str, str]]] = []
+    meta_name = meta_cfg.get("project", {}).get("name") or target.name
+    for c in selected:
+        rel = child_install.parent_rel_for_child(c["path"])
+        child_root = target / c["path"]
+        child_tmpl = child_install.build_child_settings(template, rel, c["flavor"])
+        settings_status = merge_settings(
+            child_root / ".claude", dry_run=dry_run,
+            install_permissions=install_permissions, template=child_tmpl,
+        )
+        ccfg = child_install.child_runtime_config(meta_cfg, child_root.name, rel, c["flavor"])
+        cfg_status = write_config(child_root / ".claude", ccfg, force=False, dry_run=dry_run)
+        members = [
+            (p.role, p.level, p.name) for p in members_by_child.get(child_root.name, [])
+        ]
+        md = child_install.child_claude_md(
+            meta_name=meta_name, rel=rel, flavor=c["flavor"], members=members
+        )
+        md_status = child_install.write_child_claude_md(child_root, md, dry_run=dry_run)
+        reports.append((c["path"], c["flavor"], {
+            "settings": settings_status, "config": cfg_status, "CLAUDE.md": md_status,
+        }))
+    return reports
+
+
+def _print_child_reports(reports: list[tuple[str, str, dict[str, str]]]) -> None:
+    for path, flavor, statuses in reports:
+        detail = "; ".join(f"{k} {v}" for k, v in statuses.items())
+        print(f"child {path} [{flavor}]: {detail}")
+
+
+def install_child_mode(args: argparse.Namespace, inst: dict, user_keys: set[str], target: Path) -> int:
+    """The standalone CHILD install (``project.model: child``).
+
+    Installs the child-flavor layout into ``target``, pointing at the parent
+    meta-repo from ``parent.path``: parent-relative settings.json, a child
+    ``framework.config.json`` (model=child + parent + flavor, shared sections
+    inherited from the parent's config), a child-scoped roster, and a child
+    CLAUDE.md. No hook/lib assets, charter, or ontology are laid here — those
+    live once, at the parent.
+    """
+    rel = "/".join(child_install.normalize_rel(install_config.get_key(inst, "parent.path"))) or "."
+    parent_root = (target / rel).resolve()
+    err = child_install.parent_install_error(parent_root)
+    if err:
+        print(f"ERROR: {err}", file=sys.stderr)
+        return 1
+    try:
+        parent_cfg = json.loads(
+            (parent_root / ".claude" / "framework.config.json").read_text(encoding="utf-8")
+        )
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"ERROR: parent framework.config.json is unreadable: {e}", file=sys.stderr)
+        return 1
+
+    flavor = install_config.get_key(inst, "project.flavor", "product")
+    name = install_config.get_key(inst, "project.name") or target.name
+    cfg = child_install.child_runtime_config(parent_cfg, name, rel, flavor)
+    cfg = _deep_merge(cfg, install_config.runtime_overlay(inst, user_keys))
+    cfg.setdefault("project", {})["model"] = "child"  # never remapped by overlays
+
+    print(f"parent repo:   {parent_root} (framework found)")
+    print(f"child flavor:  {flavor}; hook commands anchored at $CLAUDE_PROJECT_DIR/{rel}/.claude/")
+
+    # Child-scoped roster (lead + fitting engineers; org artifacts stay at the meta).
+    team_enabled = bool(install_config.get_key(inst, "team.enabled", True))
+    roster_plan = None
+    if team_enabled:
+        email_pattern = cfg.get("identity", {}).get("email_pattern") or "team+{First}.{Last}@example.com"
+        roster_plan = roster_gen.plan(
+            target, email_pattern=email_pattern, declared_model="child",
+            declared_repos=[], team_size=install_config.get_key(inst, "team.size"),
+        )
+        print("\n-- repo introspection + proposed team --")
+        print(roster_plan.summary())
+        if not args.no_enforce_identity:
+            cfg.setdefault("identity", {})["enforce"] = True
+            pre = cfg.setdefault("hooks", {}).setdefault("pre_bash", [])
+            if "validate_commit_identity" not in pre:
+                pre.insert(0, "validate_commit_identity")
+    else:
+        # Without a child roster the gate would have nothing to allow — leave
+        # enforcement to an explicit later opt-in (mirrors --no-team standalone).
+        cfg.setdefault("identity", {})["enforce"] = False
+
+    problems = validate_config(cfg)
+    if problems:
+        print("config problems:")
+        for p in problems:
+            print(f"  - {p}")
+        if any("version" in p for p in problems):
+            print("ERROR: refusing to install an invalid config.", file=sys.stderr)
+            return 1
+        print("  (continuing; non-fatal)")
+
+    target_claude = target / ".claude"
+    template = json.loads((_ASSETS / "settings.template.json").read_text(encoding="utf-8"))
+    child_tmpl = child_install.build_child_settings(template, rel, flavor)
+    settings_status = merge_settings(
+        target_claude, dry_run=args.dry_run,
+        install_permissions=not args.no_permissions, template=child_tmpl,
+    )
+    cfg_status = write_config(target_claude, cfg, force=args.force, dry_run=args.dry_run)
+    snapshot_status = write_install_snapshot(target_claude, inst, force=args.force, dry_run=args.dry_run)
+
+    roster_status = "skipped (team disabled)"
+    if roster_plan is not None:
+        rep = roster_gen.write_roster(target_claude / "team", roster_plan, force=args.force, dry_run=args.dry_run)
+        if args.dry_run:
+            roster_status = f"would write {len(rep['would_write'])} file(s) for {len(roster_plan.personas)} member(s)"
+        else:
+            roster_status = f"wrote {len(rep['written'])} file(s) ({len(roster_plan.personas)} member(s)); {len(rep['skipped'])} skipped"
+
+    members = [(p.role, p.level, p.name) for p in (roster_plan.personas if roster_plan else [])]
+    md = child_install.child_claude_md(
+        meta_name=parent_root.name, rel=rel, flavor=flavor, members=members
+    )
+    md_status = child_install.write_child_claude_md(target, md, dry_run=args.dry_run)
+
+    print("\n-- plan --" if args.dry_run else "\n-- result --")
+    print("hook assets:       none (child repos invoke the PARENT's hooks)")
+    print(f"settings.json:     {settings_status}")
+    print(f"framework.config:  {cfg_status} (project.model=child, parent={rel}, flavor={flavor})")
+    print(f"install snapshot:  {snapshot_status}")
+    print(f"team roster:       {roster_status}")
+    print(f"CLAUDE.md:         {md_status}")
+    if roster_plan is not None and not args.no_enforce_identity:
+        print("identity gate:     ENABLED (this roster ∪ the meta roster via the parent-merge)")
+    return 0
+
+
 # ---------------------------------------------------------------- main
 
 
@@ -585,7 +913,10 @@ def main() -> int:
     ap.add_argument("--config", help="JSON RUNTIME-config seed (framework.config.json shape)")
     ap.add_argument("--owner", help="scm.owner (GitHub org/user)")
     ap.add_argument("--project-name", help="project.name")
-    ap.add_argument("--model", choices=["single-repo", "meta-and-children"])
+    ap.add_argument("--model", choices=["single-repo", "meta-and-children", "child"])
+    ap.add_argument("--expect", choices=["fresh", "existing", "any"],
+                    help="repo.expect override: what the target should look like "
+                         "(non-interactive installs refuse on a mismatch; `any` always proceeds)")
     ap.add_argument("--shell", choices=["bash", "zsh"])
     ap.add_argument("--reviewers", type=int)
     ap.add_argument("--merge-model", choices=["wave-branch", "direct-to-main"])
@@ -620,19 +951,48 @@ def main() -> int:
     print(f"target repo:   {target}")
 
     inst, user_keys = resolve_install_config(args)
+    interactive_tty = args.interactive and sys.stdin.isatty()
 
-    # repo.expect: informational today — detection/enforcement lands with the
-    # meta/child install modes. Mismatches are noted, never fatal.
-    expect = install_config.get_key(inst, "repo.expect", "fresh")
-    has_git = (target / ".git").exists()
-    if not has_git:
-        print("note:          no .git here — installing anyway (new repo / pre-init).")
-    if expect == "existing" and not has_git:
-        print("note:          repo.expect=existing but no .git found — proceeding.")
-    elif expect == "fresh" and has_git:
-        print("note:          repo.expect=fresh but a .git already exists — proceeding.")
+    # Fresh-vs-existing gate: detect, REPORT, then enforce repo.expect.
+    state = detect_repo_state(target)
+    print("\n-- target repo state --")
+    print(f"git repo:      {'yes' if state['has_git'] else 'no'}"
+          f"{' (with commits)' if state['has_commits'] else ' (no commits yet)' if state['has_git'] else ''}")
+    print(f"other files:   {'yes' if state['nonempty'] else 'no'} "
+          "(framework-owned .claude/, CLAUDE.md*, ontology/ excluded)")
+    print(f"verdict:       {state['classification']} "
+          f"(repo.expect: {install_config.get_key(inst, 'repo.expect', 'fresh')})")
+    proceed, notes = repo_expectation_gate(
+        state, install_config.get_key(inst, "repo.expect", "fresh"),
+        non_interactive=args.non_interactive, interactive_tty=interactive_tty,
+        dry_run=args.dry_run,
+    )
+    for n in notes:
+        print(f"repo gate:     {n}", file=None if proceed else sys.stderr)
+    if not proceed:
+        print("ERROR: refusing to install (repo expectation gate).", file=sys.stderr)
+        return 1
+
+    # The CHILD install mode is a different layout (no hook code of its own) —
+    # dedicated path.
+    if install_config.get_key(inst, "project.model") == "child":
+        return install_child_mode(args, inst, user_keys, target)
 
     cfg = build_config(args, inst, user_keys)
+
+    # META install: resolve which subdir repos are children (config verbatim in
+    # non-interactive mode; multi-select from detection in interactive mode).
+    install_model = install_config.get_key(inst, "project.model", "standalone")
+    selected_children: list[dict] = []
+    if install_model == "meta":
+        selected_children = select_children(
+            inst, user_keys, target, interactive_tty=interactive_tty
+        )
+        inst["children"] = selected_children  # the snapshot records the SELECTION
+        cfg.setdefault("project", {})["model"] = "meta-and-children"
+        cfg["project"]["repos"] = [target.name] + [
+            (target / c["path"]).name for c in selected_children
+        ]
 
     # --- introspect the repo + plan the roster (the team layer) ---
     team_enabled = bool(install_config.get_key(inst, "team.enabled", True))
@@ -640,11 +1000,18 @@ def main() -> int:
     roster_plan = None
     if team_enabled:
         email_pattern = cfg.get("identity", {}).get("email_pattern") or "team+{First}.{Last}@example.com"
+        # A meta SELECTION drives the roster exactly (paths, not detection);
+        # otherwise a --config seed's declared repos / detection apply as before.
+        declared_repos = (
+            [c["path"] for c in selected_children]
+            if install_model == "meta"
+            else cfg.get("project", {}).get("repos")
+        )
         roster_plan = roster_gen.plan(
             target,
             email_pattern=email_pattern,
             declared_model=cfg.get("project", {}).get("model"),
-            declared_repos=cfg.get("project", {}).get("repos"),
+            declared_repos=declared_repos,
             team_size=team_size,
         )
         # Record what introspection found back into the configs.
@@ -674,7 +1041,7 @@ def main() -> int:
                     size = int(ans.split()[-1])
                     roster_plan = roster_gen.plan(target, email_pattern=email_pattern,
                                                   declared_model=cfg["project"]["model"],
-                                                  declared_repos=cfg.get("project", {}).get("repos"),
+                                                  declared_repos=declared_repos,
                                                   team_size=size)
                     print(roster_plan.summary())
                     install_config.set_key(inst, "team.size", size)
@@ -728,6 +1095,21 @@ def main() -> int:
         else:
             roster_status = f"wrote {len(rep['written'])} file(s) ({len(roster_plan.personas)} member(s){child_note}); {len(rep['skipped'])} skipped"
 
+    # META model: lay the child layout (parent-relative settings, child runtime
+    # config, child CLAUDE.md) into every SELECTED child. Runs after the meta
+    # cfg is final so children inherit the real identity/hooks sections.
+    child_reports: list[tuple[str, str, dict[str, str]]] = []
+    if selected_children:
+        members_by_child: dict[str, list] = {}
+        if roster_plan is not None and roster_plan.intro.model == "meta-and-children":
+            _, members_by_child = roster_gen.partition_for_children(
+                roster_plan.personas, roster_plan.intro
+            )
+        child_reports = install_children(
+            target, cfg, selected_children, members_by_child,
+            install_permissions=not args.no_permissions, dry_run=args.dry_run,
+        )
+
     print("\n-- plan --" if args.dry_run else "\n-- result --")
     print(f"hooks/lib copied:  {len(assets['copied'])}")
     if assets["would_copy"]:
@@ -747,6 +1129,7 @@ def main() -> int:
     children = inst.get("children") or []
     if children:
         print(f"children:          {len(children)} recorded ({', '.join(c.get('path', '?') for c in children[:4])}{' …' if len(children) > 4 else ''})")
+    _print_child_reports(child_reports)
     if overlay is not None:
         laid = overlay["would_copy"] if args.dry_run else overlay["copied"]
         print(f"ontology overlay:  {len(laid)} file(s) {'would be laid' if args.dry_run else 'laid'}; {len(overlay['skipped'])} skipped")

--- a/framework/install/child_install.py
+++ b/framework/install/child_install.py
@@ -1,0 +1,231 @@
+"""Child-repo install layout for the meta/child project models.
+
+Children carry NO hook code. A child repo's ``.claude/settings.json`` invokes
+the PARENT meta-repo's installed dispatchers, so there is exactly one copy of
+the hook/lib assets per project tree (at the meta root) and every child stays
+on the same version automatically.
+
+Portable hook-command form
+==========================
+
+The child's hook commands are anchored at ``$CLAUDE_PROJECT_DIR`` (which Claude
+Code sets to the CHILD's root at runtime) plus a *relative* traversal up to the
+parent::
+
+    python3 "$CLAUDE_PROJECT_DIR/../.claude/hooks/dispatcher.py"
+
+The reference design this is drawn from used machine-absolute paths; we require
+portability instead — **no machine-specific absolute path ever appears in a
+child settings.json**. Trade-off of the relative form: it assumes the child
+keeps its position relative to the parent (e.g. stays an immediate subdir).
+That is exactly the meta-and-children contract — the parent .gitignores its
+children in place — and in exchange the whole tree can be cloned to any path on
+any machine and the wiring keeps working. The traversal depth is derived from
+the child's configured path (``api`` -> ``..``; ``services/api`` -> ``../..``).
+
+Flavors
+=======
+
+``product``  — the full harness: every event in ``settings.template.json``
+               (SessionStart ontology refresh, pre/post Bash dispatchers, file-edit
+               tracking), rewritten to the parent-relative form.
+``infra``    — the commit-safety + CI subset: ONLY the ``Bash``-matched
+               PreToolUse/PostToolUse dispatcher blocks (identity/safety gates,
+               CI/pipe-mask checks). No SessionStart, no file-edit ontology
+               extras — an infra child is plumbing, not a product surface.
+
+Both flavors get a child ``framework.config.json`` (``project.model: child`` +
+``project.parent`` + ``project.flavor``, with ``scm``/``identity``/``policy``/
+``hooks`` inherited from the parent config) so the dispatchers — which resolve
+their config by walking up from the invocation cwd — read child-correct
+settings, and the commit-identity gate can union this child's roster with the
+meta roster (parent ∪ child).
+
+Stdlib only. Used by ``bootstrap.py`` for both the meta install (lay out each
+selected child) and the standalone child install (``project.model: child``).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+#: Events an ``infra``-flavor child wires (matcher -> event); everything else
+#: (SessionStart, file-edit matchers) is product-only.
+_INFRA_EVENTS = ("PreToolUse", "PostToolUse")
+_INFRA_MATCHER = "Bash"
+
+_PROJECT_DIR_PREFIX = "$CLAUDE_PROJECT_DIR/.claude/"
+
+
+def normalize_rel(path: str) -> list[str]:
+    """Split a config-supplied relative path into clean posix parts."""
+    return [p for p in path.replace("\\", "/").split("/") if p not in ("", ".")]
+
+
+def parent_rel_for_child(child_rel_path: str) -> str:
+    """Traversal from a child (at ``child_rel_path`` under the meta root) back up
+    to the meta root: ``api`` -> ``..``; ``services/api`` -> ``../..``."""
+    depth = len(normalize_rel(child_rel_path))
+    return "/".join([".."] * depth) if depth else "."
+
+
+def _rewrite_command(command: str, rel: str) -> str:
+    """Re-anchor a template hook command at the parent: the child's
+    ``$CLAUDE_PROJECT_DIR`` plus the relative traversal ``rel``."""
+    return command.replace(_PROJECT_DIR_PREFIX, f"$CLAUDE_PROJECT_DIR/{rel}/.claude/")
+
+
+def _rewrite_permission(rule: str, rel: str) -> str:
+    """Point hook/lib permission rules at the parent's assets; child-local
+    ``.claude`` rules (team files, settings) are left alone."""
+    if ".claude/hooks" in rule or ".claude/lib" in rule:
+        return rule.replace(".claude/hooks", f"{rel}/.claude/hooks").replace(
+            ".claude/lib", f"{rel}/.claude/lib"
+        )
+    return rule
+
+
+def build_child_settings(template: dict, rel: str, flavor: str) -> dict:
+    """Derive a child settings template (parent-relative, flavor-filtered) from
+    the shipped ``settings.template.json`` dict. Pure — returns a new dict."""
+    out: dict = json.loads(json.dumps(template))  # deep copy
+
+    hooks = out.get("hooks", {})
+    if flavor == "infra":
+        hooks = {
+            event: [b for b in blocks if b.get("matcher") == _INFRA_MATCHER]
+            for event, blocks in hooks.items()
+            if event in _INFRA_EVENTS
+        }
+        hooks = {event: blocks for event, blocks in hooks.items() if blocks}
+    for blocks in hooks.values():
+        for block in blocks:
+            for hook in block.get("hooks", []):
+                if "command" in hook:
+                    hook["command"] = _rewrite_command(hook["command"], rel)
+    out["hooks"] = hooks
+
+    perms = out.get("permissions")
+    if isinstance(perms, dict):
+        for key, rules in perms.items():
+            if isinstance(rules, list):
+                perms[key] = [
+                    _rewrite_permission(r, rel) if isinstance(r, str) else r for r in rules
+                ]
+    return out
+
+
+def child_runtime_config(parent_cfg: dict, name: str, rel: str, flavor: str) -> dict:
+    """Build a child ``framework.config.json``: first-class ``model: child`` with
+    the portable parent pointer, inheriting the parent's shared sections."""
+    cfg: dict = {
+        "version": 1,
+        "project": {"name": name, "model": "child", "parent": rel, "flavor": flavor},
+    }
+    for section in ("scm", "identity", "policy", "hooks"):
+        value = parent_cfg.get(section)
+        if isinstance(value, dict):
+            cfg[section] = json.loads(json.dumps(value))  # deep copy
+    return cfg
+
+
+def parent_install_error(parent_root: Path) -> str | None:
+    """Human-readable reason the parent cannot serve children, or None if it can."""
+    if not (parent_root / ".claude" / "framework.config.json").is_file():
+        return (
+            f"parent repo at {parent_root} does not have the framework installed "
+            "(missing .claude/framework.config.json). Bootstrap the parent meta-repo "
+            "first, then re-run this child install."
+        )
+    if not (parent_root / ".claude" / "hooks" / "dispatcher.py").is_file():
+        return (
+            f"parent repo at {parent_root} has a framework config but no installed "
+            "hooks (missing .claude/hooks/dispatcher.py). Re-run the framework "
+            "bootstrap at the parent, then re-run this child install."
+        )
+    return None
+
+
+# ---------------------------------------------------------------- child CLAUDE.md
+
+_CLAUDE_MD_TEMPLATE = """\
+# CLAUDE.md
+
+## Team Workflow — child repo of `{meta_name}`
+
+This repository is a **{flavor} child** in a meta-and-children project. The
+parent meta-repo lives at `{rel}` (relative to this repo's root) and holds the
+single installed copy of the framework: hooks, libs, charter, trust matrix,
+and feedback log.
+
+- **No hook code lives here.** `.claude/settings.json` invokes the parent's
+  dispatchers via portable `$CLAUDE_PROJECT_DIR/{rel}/.claude/hooks/...`
+  commands — never machine-absolute paths.
+- **Charter & rules:** `{rel}/.claude/team/charter/` (at the meta-repo)
+- **This repo's roster:** `.claude/team/roster/` (one file per member);
+  allowlist at `.claude/team/roster.json`. The commit-identity gate accepts
+  this roster PLUS the meta roster (parent ∪ child union), so org leads can
+  commit here but another child's engineers cannot.
+{composition}
+### Key Rules
+
+- **Commit identity:** each team member commits using per-commit
+  `-c user.name="..." -c user.email="..."` flags with two `Co-Authored-By`
+  trailers (team member + Claude) — **never** set global/repo git config.
+- **Worktrees** are the preferred isolation method for all code-writing agents.
+- Cross-repo coordination (waves, releases, trust/feedback) happens at the
+  meta-repo — this file covers only work scoped to this child.
+"""
+
+
+def child_claude_md(
+    *, meta_name: str, rel: str, flavor: str, members: list[tuple[str, str, str]]
+) -> str:
+    """Render the child CLAUDE.md (team section only). ``members`` rows are
+    ``(role, level, name)``; an empty list omits the composition table."""
+    composition = ""
+    if members:
+        rows = "\n".join(f"| {role} | {level} | {name} |" for role, level, name in members)
+        composition = (
+            "\n### Team Composition\n\n"
+            "| Role | Level | Name |\n|------|-------|------|\n" + rows + "\n"
+        )
+    return _CLAUDE_MD_TEMPLATE.format(
+        meta_name=meta_name, rel=rel, flavor=flavor, composition=composition
+    )
+
+
+def next_backup_path(path: Path) -> Path:
+    """Non-clobbering backup path: ``<name>.bak``, else ``<name>.bak.1``, … —
+    the same pattern the ``2real-team`` CLI uses for its root CLAUDE.md."""
+    backup = path.with_name(path.name + ".bak")
+    counter = 1
+    while backup.exists():
+        backup = path.with_name(f"{path.name}.bak.{counter}")
+        counter += 1
+    return backup
+
+
+def write_child_claude_md(child_root: Path, content: str, *, dry_run: bool) -> str:
+    """Write the child CLAUDE.md with backup-on-conflict. Idempotent: identical
+    content is a no-op; different pre-existing content is preserved as a .bak."""
+    dest = child_root / "CLAUDE.md"
+    if dest.exists():
+        try:
+            existing = dest.read_text(encoding="utf-8")
+        except OSError:
+            existing = None
+        if existing == content:
+            return "up to date"
+        backup = next_backup_path(dest)
+        if dry_run:
+            return f"would write (existing would be preserved as {backup.name})"
+        dest.rename(backup)
+        dest.write_text(content, encoding="utf-8")
+        return f"written (existing preserved as {backup.name})"
+    if dry_run:
+        return "would write"
+    child_root.mkdir(parents=True, exist_ok=True)
+    dest.write_text(content, encoding="utf-8")
+    return "written"

--- a/framework/install/install_config.py
+++ b/framework/install/install_config.py
@@ -14,6 +14,7 @@ Schema (v1) — every key, with the shipped default:
     repo.expect:         fresh | existing | any          (fresh)
     project.name:        str | null                      (null -> target dir name)
     project.model:       standalone | meta | child       (standalone)
+    project.flavor:      product | infra                 (product; child model only)
     scm.provider:        github                          (github)
     scm.owner:           str | null                      (null)
     ci.provider:         github-actions                  (github-actions)
@@ -23,13 +24,15 @@ Schema (v1) — every key, with the shipped default:
     team.enabled:        bool                            (true)
     team.preset:         str | null                      (null)
     team.size:           int | null                      (null)
+    parent.path:         str | null                      (null; REQUIRED for model: child)
     children:            list of {path: str, flavor: product|infra}   ([])
 
-Keys whose behaviour lands in later issues (``repo.expect`` enforcement,
-``project.model`` meta/child modes, ``children``, ``pre_push``) are parsed,
-validated, and carried — the resolved config is written to
-``.claude/install.config.json`` so downstream consumers read one canonical
-record of the install-time decisions.
+``repo.expect`` (fresh-vs-existing gate), ``project.model: meta`` (per-child
+installs from ``children``), and ``project.model: child`` (a standalone child
+install pointing at ``parent.path``) are enforced by the bootstrapper.
+``pre_push`` is still parse-and-carry (hook installer is a separate tranche).
+The resolved config is written to ``.claude/install.config.json`` so downstream
+consumers read one canonical record of the install-time decisions.
 
 Stdlib only (uses the sibling ``miniyaml`` parser).
 """
@@ -50,20 +53,24 @@ DEFAULTS_PATH = _FRAMEWORK_ROOT / "config" / "install.config.default.yaml"
 #: Where the resolved install config is recorded inside the target repo.
 SNAPSHOT_REL = "install.config.json"
 
+CHILD_FLAVORS = ("product", "infra")
+
 ENUMS: dict[str, tuple[str, ...]] = {
     "repo.expect": ("fresh", "existing", "any"),
     "project.model": ("standalone", "meta", "child"),
+    "project.flavor": CHILD_FLAVORS,
     "scm.provider": ("github",),
     "ci.provider": ("github-actions",),
     "ticketing.provider": ("github-issues",),
     "pre_push.mode": ("noop", "enforce", "none"),
 }
-CHILD_FLAVORS = ("product", "infra")
 
-#: install-config project.model -> runtime framework.config.json project.model
-RUNTIME_MODEL_MAP = {"standalone": "single-repo", "meta": "meta-and-children", "child": "single-repo"}
+#: install-config project.model -> runtime framework.config.json project.model.
+#: ``child`` is FIRST-CLASS in the runtime schema (not folded into single-repo),
+#: so a child repo's runtime config is recoverable as what it is.
+RUNTIME_MODEL_MAP = {"standalone": "single-repo", "meta": "meta-and-children", "child": "child"}
 #: runtime project.model -> install-config project.model (for flag reverse-mapping)
-INSTALL_MODEL_MAP = {"single-repo": "standalone", "meta-and-children": "meta"}
+INSTALL_MODEL_MAP = {"single-repo": "standalone", "meta-and-children": "meta", "child": "child"}
 
 
 class InstallConfigError(ValueError):
@@ -75,13 +82,14 @@ def builtin_defaults() -> dict:
     return {
         "version": 1,
         "repo": {"expect": "fresh"},
-        "project": {"name": None, "model": "standalone"},
+        "project": {"name": None, "model": "standalone", "flavor": "product"},
         "scm": {"provider": "github", "owner": None},
         "ci": {"provider": "github-actions"},
         "ticketing": {"provider": "github-issues"},
         "pre_push": {"mode": "noop"},
         "ontology": {"enabled": True},
         "team": {"enabled": True, "preset": None, "size": None},
+        "parent": {"path": None},
         "children": [],
     }
 
@@ -183,10 +191,27 @@ def validate(cfg: dict) -> tuple[list[str], list[str]]:
     if size is not None and (not isinstance(size, int) or isinstance(size, bool) or size < 1):
         problems.append(f"team.size: must be a positive integer or null (got {size!r})")
 
-    for dotted in ("project.name", "scm.owner", "team.preset"):
+    for dotted in ("project.name", "scm.owner", "team.preset", "parent.path"):
         value = get_key(cfg, dotted)
         if value is not None and not isinstance(value, str):
             problems.append(f"{dotted}: must be a string or null (got {value!r})")
+
+    model = get_key(cfg, "project.model")
+    parent_path = get_key(cfg, "parent.path")
+    if model == "child" and not (isinstance(parent_path, str) and parent_path.strip()):
+        problems.append(
+            "parent.path: required for project.model: child "
+            "(the relative path from this repo to its parent meta-repo, e.g. `..`)"
+        )
+    if isinstance(parent_path, str) and parent_path.startswith(("/", "~")):
+        problems.append(
+            f"parent.path: must be RELATIVE (portable — no machine-specific "
+            f"absolute paths): got {parent_path!r}"
+        )
+    if parent_path and model != "child":
+        warnings.append(
+            f"parent.path: set but project.model is {model!r} — only the child model uses it"
+        )
 
     children = cfg.get("children")
     if children is None:
@@ -202,11 +227,21 @@ def validate(cfg: dict) -> tuple[list[str], list[str]]:
             path = child.get("path")
             if not isinstance(path, str) or not path.strip():
                 problems.append(f"{loc}.path: required non-empty string")
+            elif path.startswith(("/", "~")) or ".." in path.replace("\\", "/").split("/"):
+                problems.append(
+                    f"{loc}.path: must be a relative path INSIDE the meta repo "
+                    f"(portable, no absolutes / `..`): got {path!r}"
+                )
             flavor = child.setdefault("flavor", "product")
             if flavor not in CHILD_FLAVORS:
                 problems.append(f"{loc}.flavor: {flavor!r} is not one of {list(CHILD_FLAVORS)}")
             for extra in sorted(set(child) - {"path", "flavor"}):
                 warnings.append(f"{loc}: unknown key {extra!r} (carried as-is)")
+        if children and get_key(cfg, "project.model") != "meta":
+            warnings.append(
+                "children: listed but project.model is not `meta` — per-child installs "
+                "run only under the meta model (the list is recorded as-is)"
+            )
 
     known_top = set(builtin_defaults())
     for extra in sorted(set(cfg) - known_top):
@@ -240,8 +275,11 @@ HELP_EPILOG = """\
 install config keys (--install-config YAML; precedence: flags > user YAML > shipped defaults):
   version              config schema version (must be 1)
   repo.expect          fresh | existing | any        target-repo expectation (default: fresh)
+                       enforced: non-interactive installs REFUSE on a mismatch (`any` always
+                       proceeds); interactive installs confirm before touching an existing repo
   project.name         str | null                    display name (default: target dir name)
   project.model        standalone | meta | child     project shape (default: standalone)
+  project.flavor       product | infra               THIS repo's flavor (child model; default: product)
   scm.provider         github                        SCM host (default: github)
   scm.owner            str | null                    GitHub org/user (replaces the owner prompt)
   ci.provider          github-actions                CI system (default: github-actions)
@@ -251,7 +289,11 @@ install config keys (--install-config YAML; precedence: flags > user YAML > ship
   team.enabled         bool                          generate the team layer (default: true)
   team.preset          str | null                    team preset (used by `2real-team init`)
   team.size            int | null                    target headcount (replaces the roster prompt)
-  children             [{path, flavor: product|infra}]  child repos (meta/child models)
+  parent.path          str | null                    child model: relative path to the parent
+                       meta-repo (REQUIRED for project.model: child, e.g. `..`)
+  children             [{path, flavor: product|infra}]  meta model: child repos to install
+                       (non-interactive uses this list VERBATIM — no detection surprises;
+                       interactive multi-selects from detected subdir git repos)
 
 Shipped defaults: framework/config/install.config.default.yaml. The resolved
 config is recorded at <target>/.claude/install.config.json. With

--- a/framework/install/roster_gen.py
+++ b/framework/install/roster_gen.py
@@ -192,13 +192,16 @@ def introspect(target: Path, *, declared_model: str | None = None,
     """Examine ``target`` and return its model + per-repo stacks.
 
     A declared model/repos from config wins over filesystem detection (so an
-    operator can override). Otherwise: child repos present -> meta-and-children.
+    operator can override). A declared repo LIST is used verbatim — even when
+    empty, it never falls back to detection (no detection surprises for a
+    config-driven meta install). Otherwise: child repos present ->
+    meta-and-children; a declared ``child`` model is single-repo-shaped.
     """
     target = target.resolve()
-    children = detect_child_repos(target)
-    if declared_repos:
-        child_paths = [target / r for r in declared_repos if (target / r).is_dir()]
-        children = child_paths or children
+    if declared_repos is not None:
+        children = [target / r for r in declared_repos if (target / r).is_dir()]
+    else:
+        children = detect_child_repos(target)
 
     model = declared_model or ("meta-and-children" if children else "single-repo")
 
@@ -489,6 +492,10 @@ def write_roster(team_dir: Path, plan_: RosterPlan, *, force: bool, dry_run: boo
     Single-repo: one team dir at ``team_dir`` with the full roster, all cards,
     and the org artifacts (trust_matrix + feedback_log).
 
+    Child: one team dir with the roster + cards but NO org artifacts —
+    trust/feedback are org-wide and live at the parent meta-repo; the identity
+    gate's parent-merge unions this roster with the meta roster.
+
     Meta-and-children: the META roster (org roles + lead + unmatched engineers)
     plus org artifacts and ALL persona cards land at ``team_dir``; each child
     repo gets its own ``<child>/.claude/team/roster.json`` + that child's persona
@@ -499,8 +506,9 @@ def write_roster(team_dir: Path, plan_: RosterPlan, *, force: bool, dry_run: boo
     report: dict = {"written": [], "skipped": [], "would_write": []}
 
     if plan_.intro.model != "meta-and-children" or len(plan_.intro.repos) <= 1:
+        org_for = None if plan_.intro.model == "child" else plan_.personas
         _write_team(team_dir, allowlist=plan_.personas, cards_for=plan_.personas,
-                    org_artifacts_for=plan_.personas, report=report, force=force, dry_run=dry_run)
+                    org_artifacts_for=org_for, report=report, force=force, dry_run=dry_run)
         return report
 
     meta_personas, child_rosters = partition_for_children(plan_.personas, plan_.intro)

--- a/framework/tests/test_install_config.py
+++ b/framework/tests/test_install_config.py
@@ -206,12 +206,15 @@ class TestNonInteractiveInstall:
     def test_children_carried_into_snapshot(self, tmp_path: Path) -> None:
         user = tmp_path / "install.yaml"
         user.write_text(
+            "repo:\n  expect: any\n"
             "project:\n  model: meta\nchildren:\n"
             "  - path: services/api\n  - path: infra/tf\n    flavor: infra\n",
             encoding="utf-8",
         )
         target = tmp_path / "repo"
-        target.mkdir()
+        # Meta children must exist — the meta install lays a child layout into them.
+        (target / "services" / "api" / ".git").mkdir(parents=True)
+        (target / "infra" / "tf" / ".git").mkdir(parents=True)
         r = _run(str(target), "--install-config", str(user), "--non-interactive", "--no-team")
         assert r.returncode == 0, r.stderr or r.stdout
         snapshot = json.loads((target / ".claude" / "install.config.json").read_text())
@@ -246,6 +249,8 @@ class TestPrecedence:
         user.write_text("ontology:\n  enabled: false\nrepo:\n  expect: existing\n", encoding="utf-8")
         target = tmp_path / "repo"
         target.mkdir()
+        # repo.expect=existing is now ENFORCED — make the target genuinely existing.
+        (target / "src.py").write_text("x = 1\n", encoding="utf-8")
         r = _run(str(target), "--install-config", str(user), "--non-interactive", "--no-team")
         assert r.returncode == 0, r.stderr or r.stdout
         assert not (target / "ontology").exists()  # default true overridden

--- a/framework/tests/test_meta_child_install.py
+++ b/framework/tests/test_meta_child_install.py
@@ -1,0 +1,438 @@
+"""Tests for the meta/child install modes + the fresh-vs-existing gate (issue #65).
+
+End-to-end (subprocess, stdin CLOSED so any prompt would EOFError): a meta
+install with two fake child git repos (flavors, PORTABLE parent-relative paths),
+the standalone child install, repo.expect enforcement, and idempotent re-runs.
+Unit: the child settings/template derivation, the expectation-gate decision
+table, and the interactive children multi-select (input stubbed).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+_BOOTSTRAP = _FRAMEWORK_ROOT / "install" / "bootstrap.py"
+sys.path.insert(0, str(_FRAMEWORK_ROOT / "install"))
+
+import bootstrap  # noqa: E402
+import child_install  # noqa: E402
+import roster_gen  # noqa: E402
+
+
+def _run(*argv: str) -> subprocess.CompletedProcess:
+    """Run bootstrap.py with stdin closed — any prompt would EOFError/hang."""
+    return subprocess.run(
+        [sys.executable, str(_BOOTSTRAP), *argv],
+        capture_output=True, text=True, stdin=subprocess.DEVNULL, timeout=120,
+    )
+
+
+def _git_repo(path: Path, *, commit: bool = False) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "-C", str(path), "init", "-q"], check=True, capture_output=True)
+    if commit:
+        (path / "README.md").write_text("hello\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(path), "add", "-A"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(path), "-c", "user.name=T", "-c", "user.email=t@e.com",
+             "commit", "-q", "-m", "init"],
+            check=True, capture_output=True,
+        )
+    return path
+
+
+def _meta_yaml(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "install.yaml"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------- meta install
+
+
+class TestMetaInstall:
+    def _install_meta(self, tmp_path: Path) -> tuple[Path, subprocess.CompletedProcess]:
+        meta = tmp_path / "meta"
+        meta.mkdir()
+        _git_repo(meta / "api")
+        (meta / "api" / "pyproject.toml").write_text("[project]\nname='api'\n", encoding="utf-8")
+        _git_repo(meta / "infra" / "tf")
+        yaml = _meta_yaml(tmp_path, (
+            "repo:\n  expect: any\n"
+            "scm:\n  owner: acme\n"
+            "project:\n  model: meta\n"
+            "children:\n"
+            "  - path: api\n"
+            "  - path: infra/tf\n    flavor: infra\n"
+        ))
+        r = _run(str(meta), "--install-config", str(yaml), "--non-interactive")
+        return meta, r
+
+    def test_e2e_two_children_flavors_and_portable_paths(self, tmp_path: Path) -> None:
+        meta, r = self._install_meta(tmp_path)
+        assert r.returncode == 0, r.stderr or r.stdout
+
+        # -- product child: full harness, parent one level up --
+        api_settings_text = (meta / "api" / ".claude" / "settings.json").read_text(encoding="utf-8")
+        api_settings = json.loads(api_settings_text)
+        assert set(api_settings["hooks"]) == {"SessionStart", "PreToolUse", "PostToolUse"}
+        assert '$CLAUDE_PROJECT_DIR/../.claude/hooks/dispatcher.py' in api_settings_text
+        # PORTABLE: no machine-specific absolute path anywhere in a child settings.
+        assert str(tmp_path) not in api_settings_text
+
+        # -- infra child (nested two deep): commit-safety + CI subset only --
+        tf_settings_text = (meta / "infra" / "tf" / ".claude" / "settings.json").read_text(encoding="utf-8")
+        tf_settings = json.loads(tf_settings_text)
+        assert set(tf_settings["hooks"]) == {"PreToolUse", "PostToolUse"}
+        matchers = {b.get("matcher") for blocks in tf_settings["hooks"].values() for b in blocks}
+        assert matchers == {"Bash"}  # no SessionStart / file-edit extras
+        assert '$CLAUDE_PROJECT_DIR/../../.claude/hooks/dispatcher.py' in tf_settings_text
+        assert str(tmp_path) not in tf_settings_text
+
+        # -- child runtime configs: first-class model=child + parent + flavor --
+        api_cfg = json.loads((meta / "api" / ".claude" / "framework.config.json").read_text())
+        assert api_cfg["project"]["model"] == "child"
+        assert api_cfg["project"]["parent"] == ".."
+        assert api_cfg["project"]["flavor"] == "product"
+        assert api_cfg["scm"]["owner"] == "acme"  # inherited from the meta config
+        assert api_cfg["identity"]["enforce"] is True
+        tf_cfg = json.loads((meta / "infra" / "tf" / ".claude" / "framework.config.json").read_text())
+        assert tf_cfg["project"]["parent"] == "../.."
+        assert tf_cfg["project"]["flavor"] == "infra"
+
+        # -- roster subsets + child CLAUDE.md; org artifacts stay at the meta --
+        assert (meta / "api" / ".claude" / "team" / "roster.json").is_file()
+        assert not (meta / "api" / ".claude" / "team" / "trust_matrix.md").exists()
+        assert (meta / ".claude" / "team" / "trust_matrix.md").is_file()
+        api_md = (meta / "api" / "CLAUDE.md").read_text(encoding="utf-8")
+        assert "$CLAUDE_PROJECT_DIR/../.claude/hooks/" in api_md
+        assert str(tmp_path) not in api_md
+
+        # -- children recorded: meta runtime project.repos + install snapshot --
+        meta_cfg = json.loads((meta / ".claude" / "framework.config.json").read_text())
+        assert meta_cfg["project"]["model"] == "meta-and-children"
+        assert {"api", "tf"} <= set(meta_cfg["project"]["repos"])
+        snapshot = json.loads((meta / ".claude" / "install.config.json").read_text())
+        assert snapshot["children"] == [
+            {"path": "api", "flavor": "product"},
+            {"path": "infra/tf", "flavor": "infra"},
+        ]
+        # No hook code in the children — the parent holds the single copy.
+        assert not (meta / "api" / ".claude" / "hooks").exists()
+        assert (meta / ".claude" / "hooks" / "dispatcher.py").is_file()
+
+    def test_e2e_meta_rerun_is_idempotent(self, tmp_path: Path) -> None:
+        meta, r1 = self._install_meta(tmp_path)
+        assert r1.returncode == 0, r1.stderr or r1.stdout
+        before = (meta / "api" / ".claude" / "settings.json").read_text(encoding="utf-8")
+
+        yaml = tmp_path / "install.yaml"
+        r2 = _run(str(meta), "--install-config", str(yaml), "--non-interactive")
+        assert r2.returncode == 0, r2.stderr or r2.stdout
+        assert "idempotent re-run" in r2.stdout  # gate skipped: already installed
+        assert "child api [product]: settings already wired" in r2.stdout
+        assert "CLAUDE.md up to date" in r2.stdout
+        assert (meta / "api" / ".claude" / "settings.json").read_text(encoding="utf-8") == before
+        assert not list((meta / "api").glob("CLAUDE.md.bak*"))  # no backup churn
+
+    def test_missing_configured_child_is_fatal(self, tmp_path: Path) -> None:
+        meta = tmp_path / "meta"
+        meta.mkdir()
+        yaml = _meta_yaml(tmp_path, (
+            "project:\n  model: meta\nchildren:\n  - path: nope\n"
+        ))
+        r = _run(str(meta), "--install-config", str(yaml), "--non-interactive")
+        assert r.returncode == 1
+        assert "nope" in r.stderr
+        assert not (meta / ".claude" / "framework.config.json").exists()
+
+    def test_child_claude_md_conflict_is_backed_up(self, tmp_path: Path) -> None:
+        meta = tmp_path / "meta"
+        meta.mkdir()
+        _git_repo(meta / "api")
+        (meta / "api" / "CLAUDE.md").write_text("my own notes\n", encoding="utf-8")
+        yaml = _meta_yaml(tmp_path, (
+            "repo:\n  expect: any\nproject:\n  model: meta\nchildren:\n  - path: api\n"
+        ))
+        r = _run(str(meta), "--install-config", str(yaml), "--non-interactive")
+        assert r.returncode == 0, r.stderr or r.stdout
+        assert (meta / "api" / "CLAUDE.md.bak").read_text(encoding="utf-8") == "my own notes\n"
+        assert "child repo" in (meta / "api" / "CLAUDE.md").read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------- child install
+
+
+class TestChildInstall:
+    def test_e2e_standalone_child_mode(self, tmp_path: Path) -> None:
+        parent = tmp_path / "meta"
+        parent.mkdir()
+        r = _run(str(parent), "--owner", "acme", "--non-interactive", "--no-team")
+        assert r.returncode == 0, r.stderr or r.stdout
+
+        child = _git_repo(parent / "svc")
+        yaml = _meta_yaml(tmp_path, (
+            "project:\n  model: child\n  flavor: infra\nparent:\n  path: ..\n"
+        ))
+        r = _run(str(child), "--install-config", str(yaml), "--non-interactive")
+        assert r.returncode == 0, r.stderr or r.stdout
+
+        text = (child / ".claude" / "settings.json").read_text(encoding="utf-8")
+        settings = json.loads(text)
+        assert set(settings["hooks"]) == {"PreToolUse", "PostToolUse"}
+        assert '$CLAUDE_PROJECT_DIR/../.claude/hooks/dispatcher.py' in text
+        assert str(tmp_path) not in text  # portable
+        cfg = json.loads((child / ".claude" / "framework.config.json").read_text())
+        assert cfg["project"] == {
+            "name": "svc", "model": "child", "parent": "..", "flavor": "infra",
+        }
+        assert cfg["scm"]["owner"] == "acme"  # inherited from the parent config
+        assert (child / ".claude" / "team" / "roster.json").is_file()
+        assert not (child / ".claude" / "team" / "trust_matrix.md").exists()
+        assert not (child / ".claude" / "hooks").exists()  # no hook code in a child
+        assert "child repo" in (child / "CLAUDE.md").read_text(encoding="utf-8")
+        snapshot = json.loads((child / ".claude" / "install.config.json").read_text())
+        assert snapshot["project"]["model"] == "child"
+        assert snapshot["parent"]["path"] == ".."
+
+        # Idempotent re-run.
+        r2 = _run(str(child), "--install-config", str(yaml), "--non-interactive")
+        assert r2.returncode == 0, r2.stderr or r2.stdout
+        assert "already wired" in r2.stdout
+        assert "up to date" in r2.stdout
+
+    def test_child_mode_without_installed_parent_is_fatal(self, tmp_path: Path) -> None:
+        parent = tmp_path / "bare-parent"
+        child = _git_repo(parent / "svc")
+        yaml = _meta_yaml(tmp_path, "project:\n  model: child\nparent:\n  path: ..\n")
+        r = _run(str(child), "--install-config", str(yaml), "--non-interactive")
+        assert r.returncode == 1
+        assert "does not have the framework installed" in r.stderr
+        assert not (child / ".claude" / "settings.json").exists()
+
+    def test_child_mode_requires_parent_path(self, tmp_path: Path) -> None:
+        yaml = _meta_yaml(tmp_path, "project:\n  model: child\n")
+        target = tmp_path / "svc"
+        target.mkdir()
+        r = _run(str(target), "--install-config", str(yaml), "--non-interactive")
+        assert r.returncode == 1
+        assert "parent.path" in r.stderr
+
+    def test_absolute_parent_path_is_rejected(self, tmp_path: Path) -> None:
+        yaml = _meta_yaml(
+            tmp_path, f"project:\n  model: child\nparent:\n  path: {tmp_path}\n"
+        )
+        target = tmp_path / "svc"
+        target.mkdir()
+        r = _run(str(target), "--install-config", str(yaml), "--non-interactive")
+        assert r.returncode == 1
+        assert "RELATIVE" in r.stderr
+
+
+# ------------------------------------------------------ fresh-vs-existing gate
+
+
+class TestFreshVsExisting:
+    def test_non_interactive_mismatch_is_fatal(self, tmp_path: Path) -> None:
+        repo = _git_repo(tmp_path / "estab", commit=True)
+        r = _run(str(repo), "--non-interactive", "--no-team")  # default expect: fresh
+        assert r.returncode == 1
+        assert "looks EXISTING" in r.stderr
+        assert "repo.expect" in r.stderr
+        assert not (repo / ".claude" / "framework.config.json").exists()
+
+    def test_expect_existing_and_any_proceed(self, tmp_path: Path) -> None:
+        repo = _git_repo(tmp_path / "estab", commit=True)
+        r = _run(str(repo), "--non-interactive", "--no-team", "--expect", "existing")
+        assert r.returncode == 0, r.stderr or r.stdout
+        repo2 = _git_repo(tmp_path / "estab2", commit=True)
+        r2 = _run(str(repo2), "--non-interactive", "--no-team", "--expect", "any")
+        assert r2.returncode == 0, r2.stderr or r2.stdout
+
+    def test_expect_existing_on_fresh_target_is_fatal(self, tmp_path: Path) -> None:
+        r = _run(str(tmp_path), "--non-interactive", "--no-team", "--expect", "existing")
+        assert r.returncode == 1
+        assert "looks FRESH" in r.stderr
+
+    def test_detection_is_reported(self, tmp_path: Path) -> None:
+        repo = _git_repo(tmp_path / "estab", commit=True)
+        r = _run(str(repo), "--non-interactive", "--no-team", "--expect", "existing")
+        assert "-- target repo state --" in r.stdout
+        assert "git repo:      yes (with commits)" in r.stdout
+        assert "verdict:       existing" in r.stdout
+
+    def test_rerun_after_install_skips_gate(self, tmp_path: Path) -> None:
+        r1 = _run(str(tmp_path), "--non-interactive", "--no-team")
+        assert r1.returncode == 0, r1.stderr
+        # Target is nonempty now (framework-owned files only) — still proceeds.
+        r2 = _run(str(tmp_path), "--non-interactive", "--no-team")
+        assert r2.returncode == 0, r2.stderr or r2.stdout
+        assert "idempotent re-run" in r2.stdout
+
+    def test_dry_run_reports_but_never_refuses(self, tmp_path: Path) -> None:
+        repo = _git_repo(tmp_path / "estab", commit=True)
+        r = _run(str(repo), "--non-interactive", "--no-team", "--dry-run")
+        assert r.returncode == 0, r.stderr or r.stdout
+        assert "would refuse" in r.stdout
+        assert not (repo / ".claude").exists()
+
+    # -- gate decision table (unit) --
+
+    @staticmethod
+    def _state(**over) -> dict:
+        base = {"has_git": False, "has_commits": False, "nonempty": False,
+                "installed": False, "classification": "fresh"}
+        base.update(over)
+        return base
+
+    def test_gate_interactive_confirmation_yes_and_no(self) -> None:
+        existing = self._state(has_git=True, has_commits=True, classification="existing")
+        ok, _ = bootstrap.repo_expectation_gate(
+            existing, "fresh", non_interactive=False, interactive_tty=True, ask=lambda _: "y")
+        assert ok is True
+        ok, notes = bootstrap.repo_expectation_gate(
+            existing, "fresh", non_interactive=False, interactive_tty=True, ask=lambda _: "")
+        assert ok is False  # default answer is No
+        assert any("aborted" in n for n in notes)
+
+    def test_gate_explicit_expect_answers_the_prompt(self) -> None:
+        existing = self._state(has_commits=True, classification="existing")
+
+        def boom(_prompt: str) -> str:
+            raise AssertionError("must not prompt when the config matches")
+
+        ok, _ = bootstrap.repo_expectation_gate(
+            existing, "existing", non_interactive=False, interactive_tty=True, ask=boom)
+        assert ok is True
+        ok, _ = bootstrap.repo_expectation_gate(
+            existing, "any", non_interactive=False, interactive_tty=True, ask=boom)
+        assert ok is True
+
+    def test_gate_plain_mode_notes_and_proceeds(self) -> None:
+        existing = self._state(nonempty=True, classification="existing")
+        ok, notes = bootstrap.repo_expectation_gate(
+            existing, "fresh", non_interactive=False, interactive_tty=False)
+        assert ok is True
+        assert any("advisory" in n for n in notes)
+
+
+# ---------------------------------------------------------------- unit: child assets
+
+
+class TestChildAssets:
+    _TEMPLATE = {
+        "permissions": {"allow": ["Read(.claude/**)", "Bash(python3 .claude/hooks/*)"]},
+        "hooks": {
+            "SessionStart": [{"hooks": [
+                {"type": "command", "command": 'python3 "$CLAUDE_PROJECT_DIR/.claude/hooks/start_dispatcher.py"'}]}],
+            "PreToolUse": [{"matcher": "Bash", "hooks": [
+                {"type": "command", "command": 'python3 "$CLAUDE_PROJECT_DIR/.claude/hooks/dispatcher.py"'}]}],
+            "PostToolUse": [
+                {"matcher": "Bash", "hooks": [
+                    {"type": "command", "command": 'python3 "$CLAUDE_PROJECT_DIR/.claude/hooks/post_dispatcher.py"'}]},
+                {"matcher": "Edit|Write", "hooks": [
+                    {"type": "command", "command": 'python3 "$CLAUDE_PROJECT_DIR/.claude/hooks/post_dispatcher.py"'}]},
+            ],
+        },
+    }
+
+    def test_parent_rel_depth(self) -> None:
+        assert child_install.parent_rel_for_child("api") == ".."
+        assert child_install.parent_rel_for_child("services/api") == "../.."
+        assert child_install.parent_rel_for_child("./services/api/") == "../.."
+
+    def test_product_keeps_all_events_and_rewrites(self) -> None:
+        out = child_install.build_child_settings(self._TEMPLATE, "..", "product")
+        assert set(out["hooks"]) == {"SessionStart", "PreToolUse", "PostToolUse"}
+        cmds = [h["command"] for blocks in out["hooks"].values() for b in blocks for h in b["hooks"]]
+        assert all("$CLAUDE_PROJECT_DIR/../.claude/hooks/" in c for c in cmds)
+        # hook/lib permission rules point at the parent; child-local ones don't move
+        assert "Bash(python3 ../.claude/hooks/*)" in out["permissions"]["allow"]
+        assert "Read(.claude/**)" in out["permissions"]["allow"]
+        # the source template is untouched (pure function)
+        assert "$CLAUDE_PROJECT_DIR/.claude/" in json.dumps(self._TEMPLATE)
+
+    def test_infra_is_bash_only_subset(self) -> None:
+        out = child_install.build_child_settings(self._TEMPLATE, "../..", "infra")
+        assert set(out["hooks"]) == {"PreToolUse", "PostToolUse"}
+        for blocks in out["hooks"].values():
+            assert all(b.get("matcher") == "Bash" for b in blocks)
+        cmds = [h["command"] for blocks in out["hooks"].values() for b in blocks for h in b["hooks"]]
+        assert all("$CLAUDE_PROJECT_DIR/../../.claude/hooks/" in c for c in cmds)
+
+    def test_child_runtime_config_inherits_shared_sections(self) -> None:
+        parent = {"version": 1, "scm": {"owner": "acme"}, "identity": {"enforce": True},
+                  "policy": {"reviewers_required": 2}, "hooks": {"pre_bash": ["x"]},
+                  "paths": {"team": ".claude/team"}}
+        cfg = child_install.child_runtime_config(parent, "api", "..", "product")
+        assert cfg["project"] == {"name": "api", "model": "child", "parent": "..", "flavor": "product"}
+        assert cfg["scm"] == {"owner": "acme"}
+        assert cfg["policy"] == {"reviewers_required": 2}
+        assert "paths" not in cfg  # path layout is per-repo, not inherited
+        cfg["scm"]["owner"] = "other"
+        assert parent["scm"]["owner"] == "acme"  # deep copy, no aliasing
+
+    def test_interactive_multi_select(self, monkeypatch, tmp_path: Path) -> None:
+        for name in ("api", "web"):
+            _git_repo(tmp_path / name)
+        answers = iter(["2", "i"])  # pick #2 (web), flavor infra
+        monkeypatch.setattr("builtins.input", lambda _prompt: next(answers))
+        selected = bootstrap.select_children({"children": []}, set(), tmp_path, interactive_tty=True)
+        assert selected == [{"path": "web", "flavor": "infra"}]
+
+    def test_config_first_children_skip_prompt(self, tmp_path: Path) -> None:
+        _git_repo(tmp_path / "api")
+
+        # user_keys says children came from YAML — must not prompt (input would EOFError).
+        selected = bootstrap.select_children(
+            {"children": [{"path": "api", "flavor": "product"}]},
+            {"children"}, tmp_path, interactive_tty=True,
+        )
+        assert selected == [{"path": "api", "flavor": "product"}]
+
+    def test_write_child_claude_md_is_idempotent_with_backup(self, tmp_path: Path) -> None:
+        content = child_install.child_claude_md(
+            meta_name="meta", rel="..", flavor="product",
+            members=[("Tech Lead", "Staff", "Aria Okafor")],
+        )
+        assert "| Tech Lead | Staff | Aria Okafor |" in content
+        assert bootstrap.child_install.write_child_claude_md(tmp_path, content, dry_run=False) == "written"
+        assert child_install.write_child_claude_md(tmp_path, content, dry_run=False) == "up to date"
+        assert not (tmp_path / "CLAUDE.md.bak").exists()
+        (tmp_path / "CLAUDE.md").write_text("user content\n", encoding="utf-8")
+        status = child_install.write_child_claude_md(tmp_path, content, dry_run=False)
+        assert "preserved as CLAUDE.md.bak" in status
+        assert (tmp_path / "CLAUDE.md.bak").read_text(encoding="utf-8") == "user content\n"
+
+
+# ---------------------------------------------------------------- roster model
+
+
+def test_child_model_roster_has_no_org_artifacts(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
+    p = roster_gen.plan(
+        tmp_path, email_pattern="t+{First}.{Last}@e.com", declared_model="child", declared_repos=[]
+    )
+    assert p.intro.model == "child"
+    rep = roster_gen.write_roster(tmp_path / ".claude" / "team", p, force=False, dry_run=False)
+    assert any(w.endswith("roster.json") for w in rep["written"])
+    assert not (tmp_path / ".claude" / "team" / "trust_matrix.md").exists()
+    assert not (tmp_path / ".claude" / "team" / "feedback_log.md").exists()
+
+
+def test_declared_empty_repo_list_never_falls_back_to_detection(tmp_path: Path) -> None:
+    _git_repo(tmp_path / "stray")  # would be detected — must NOT be
+    intro = roster_gen.introspect(
+        tmp_path, declared_model="meta-and-children", declared_repos=[]
+    )
+    assert [r.name for r in intro.repos] == [tmp_path.name]
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
Closes #65. Depends on #64 (merged in #79) — implements the behavior behind the schema keys #64 parsed and carried (`project.model: meta|child`, `children`, `repo.expect`), plus the fresh-vs-existing gate.

## What's in here

### 1. Meta install (`project.model: meta`)
- **Non-interactive:** the YAML `children:` list is used **verbatim** — no detection surprises; a configured child path that doesn't exist is fatal with a clear message.
- **Interactive (TTY):** `detect_child_repos()` proposes candidates; multi-select ("all / none / numbers") plus a per-child flavor prompt (default `product`). Config-first: an explicit `children:` list answers the prompt.
- Each selected child gets: a flavor-appropriate `.claude/settings.json` (parent-relative commands), its own `framework.config.json`, a scoped `.claude/team/` roster subset (`roster.json` + cards; trust matrix/feedback log stay at the meta), and a child `CLAUDE.md` with backup-on-conflict (`.bak`, same non-clobbering pattern as the CLI's `_next_backup_path`). Children are recorded in the meta `framework.config.json` `project.repos` and in the install snapshot.

### 2. Child install (`project.model: child`)
First-class standalone-child mode: validates `parent.path` points at a repo with the framework installed (`framework.config.json` + `hooks/dispatcher.py`; clear error otherwise, nothing written) and lays the same child layout into the target. No hook/lib assets, charter, or ontology are laid at a child — those live once, at the parent.

### 3. Fresh-vs-existing gate
- Detection reports three signals on every install: git repo? has commits? non-framework files? (framework-owned `.claude/`, `CLAUDE.md*`, `ontology/` are excluded so our own artifacts never make a target "existing").
- **Non-interactive:** `repo.expect` mismatch is **fatal** with remediation guidance; `any` always proceeds. New `--expect {fresh,existing,any}` flag for automation.
- **Interactive:** explicit `[y/N]` confirmation before installing into an existing repo (an explicit `repo.expect: existing|any` from the operator answers the prompt — config-first).
- Plain mode (neither flag) stays advisory (back-compat with existing callers/tests); **idempotent re-runs** (framework already installed) skip the gate entirely.

## Design decisions

- **Child hook-command form:** `python3 "$CLAUDE_PROJECT_DIR/<rel>/.claude/hooks/dispatcher.py"` — anchored at the child's `$CLAUDE_PROJECT_DIR` plus a relative traversal derived from the child's configured path (`api` → `..`, `infra/tf` → `../..`). The source project used machine-absolute paths; we require portability. Trade-off: the relative form assumes the child keeps its position under the parent — exactly the meta-and-children contract — and in exchange the whole tree clones anywhere. Absolute `parent.path` / `children[].path` values are rejected at validation.
- **Runtime-model mapping (QA flag from #79):** the runtime schema enum is extended to `single-repo | meta-and-children | child`, with new `project.parent` (portable relative path) and `project.flavor` properties — a child repo is now fully recoverable *and locatable* from its runtime config. `RUNTIME_MODEL_MAP` maps `child → child`; `INSTALL_MODEL_MAP` gains the reverse. Of the three synced default copies only the schema needed content changes: `_framework_config._DEFAULTS` and bootstrap `_schema_defaults()` shadow *defaults*, and the default stays `single-repo` (comment added at `_DEFAULTS` documenting the enum).
- **Infra flavor contents:** the commit-safety + CI subset = only the **Bash-matched PreToolUse/PostToolUse dispatcher blocks** (identity/safety pre-bash gates + CI/pipe-mask post-bash). No SessionStart, no file-edit matchers — no ontology/session extras. `product` = the full `settings.template.json` wiring. Both flavors share `merge_settings`' idempotent merge (new optional `template` param), and both get a child runtime config inheriting `scm`/`identity`/`policy`/`hooks` from the parent so the identity gate's parent∪child union works.
- **Roster:** meta selection drives `roster_gen` exactly (declared repos = selected paths; `introspect` no longer falls back to detection when a list is declared, even empty). Child-model rosters are written without org artifacts. Child-only mode plans a child-scoped team; the union with the meta roster is reconstructed by the gate at validate time.

## Test evidence

- `python3 -m pytest framework/tests/ -q` → **176 passed** (26 new in `test_meta_child_install.py`)
- `cd python && PYTHONPATH=src python -m pytest -q` → **126 passed**
- `ruff check framework/` → clean
- New coverage: meta e2e with two fake child git repos (one nested `infra/tf`, flavors, **no absolute path anywhere in child settings/CLAUDE.md**), child-only mode e2e + parent-not-installed fatal + missing `parent.path` fatal + absolute-path rejection, expect-mismatch fatal both directions + `any`/`existing` proceed + dry-run never refuses, installed-marker re-run skips the gate, meta re-run idempotent (settings "already wired", CLAUDE.md "up to date", zero `.bak` churn), gate decision table incl. interactive confirm yes/no and config-answered prompt, interactive multi-select (stubbed input), CLAUDE.md backup-on-conflict.
- All e2e subprocess runs use **stdin closed** — any prompt would EOFError (zero-prompt guarantee).
- Manually verified the runtime chain in a scratch meta tree: bad identity blocked in a child (rc 2), child-roster member allowed, **meta org member allowed via the parent∪child merge**, SessionStart dispatcher fires through the parent path, and the nested infra child's dispatcher blocks `--no-verify` two levels up.

Two pre-existing tests updated for the now-enforced semantics (`repo.expect: existing` on an empty dir was asserting the old note-and-proceed behavior; meta `children` snapshot test now creates the child dirs it declares).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T1sHWTyKtu8DAExDn9DgLS
