### PR TITLE
chore(release): 0.4.0 — versions, notes, registry docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ cleanly when a subsystem isn't present:
 The runtime tier also ships **enriched versions of `retro`, `wave-start`, `plan-phase`, and
 `close-stale-issues`** that supersede the templated team-workflow versions when the runtime is
 installed — e.g. `/retro` becomes a lightweight mid-wave pulse (the end-of-wave scoring moves
-to `/wave-retro`), and `/wave-start` gains STOP-guards at its approval gates.
+to `/wave-retro`), and `/wave-start` gains STOP-guards before any branch work.
 
 ## Pre-push hook
 

--- a/README.md
+++ b/README.md
@@ -79,8 +79,10 @@ CLAUDE.md                # Team section, written at the project root
     review-pr.md         # PR review using charter format
     plan-phase.md        # Phase planning skill
     close-stale-issues.md
-    # with --with-hooks, also: session-start, handoff,
-    # wave-lifecycle, ontology-librarian, ontology-rebuild
+    # with --with-hooks, also the 13 runtime skills
+    # (session-start, handoff, wave-lifecycle, wave-retro,
+    #  phase-review, team-reset, wave-audit, ontology-*, ...
+    #  — see the Skills section)
 ```
 
 ## Commands
@@ -300,8 +302,8 @@ Templated per project and installed by every preset (the 6 listed in [Presets](#
 ### Runtime skills
 
 Config-driven and fail-open, installed alongside the hooks/libs runtime with
-`2real-team init --with-hooks`. They read `.claude/framework.config.json` and skip cleanly when
-a subsystem isn't present:
+`2real-team init --with-hooks` (13 skills). They read `.claude/framework.config.json` and skip
+cleanly when a subsystem isn't present:
 
 - `/session-start` — Run first in every session: loads memory, confirms the team, reads the
   last handoff, and reports git/PR/CI + lifecycle + ontology status in one table
@@ -309,10 +311,23 @@ a subsystem isn't present:
   lifecycle/wave status, and the context the next session needs to resume)
 - `/wave-lifecycle` — Drive one wave through its full lifecycle (allocate → start → scope →
   kickoff → work → wrapup → retro) on the deterministic `lifecycle.py` engine
+- `/wave-retro` — Full end-of-wave retrospective with mechanical, evidence-anchored trust
+  scoring (`trust_signals.py`), counter drift verification, feedback log, process proposals
+- `/phase-review` — Phase-level health check before scoping the next wave: phase-doc tracking
+  state, tech-debt ratio vs the configured exit threshold, owner revision checkpoint
+- `/team-reset` — Transparent agent reset: shut down unresponsive session agents and
+  re-orient the implicit team, reporting roster changes
+- `/wave-audit` — Audit open wave issues against merged PRs and close orphaned issues
+  (with proper comments; nothing closes without user confirmation)
 - `/ontology-librarian [query]` — Read-only ontology reference: checks staleness of both the
   hand-curated semantic overlay and the generated structural index, and retrieves context
 - `/ontology-rebuild [scope]` — Reconcile the semantic overlay: scan dirty checksums, update
   ontology files and auto-updatable docs from code, mark resolved
+
+The runtime tier also ships **enriched versions of `retro`, `wave-start`, `plan-phase`, and
+`close-stale-issues`** that supersede the templated team-workflow versions when the runtime is
+installed — e.g. `/retro` becomes a lightweight mid-wave pulse (the end-of-wave scoring moves
+to `/wave-retro`), and `/wave-start` gains STOP-guards at its approval gates.
 
 ## Pre-push hook
 

--- a/RELEASE_NOTES_0.4.0.md
+++ b/RELEASE_NOTES_0.4.0.md
@@ -45,13 +45,15 @@ asks (interactive) on a mismatch; idempotent re-runs skip the gate.
 
 - **Ontology at install** (#66) — `ontology.enabled: true` (default) seeds the
   two-layer ontology (semantic overlay + generated structural index) and
-  activates the ontology hooks during install, including meta/child trees.
+  activates the ontology hooks at install; for meta trees the ontology lives
+  at the meta root with cross-repo aggregation over the children.
 - **Pre-push hook installer** (#67) — `pre_push.mode: noop | enforce | none`.
   `enforce` runs `hooks.pre_push_commands` from `framework.config.json` at
   push time; existing non-framework hooks are preserved as `pre-push.bak`.
 - **Shipped permissions allowlist** (#68) — `settings.template.json` now
-  carries a genericized permissions allowlist so a fresh install prompts far
-  less for routine git/gh/test commands.
+  carries a genericized permissions allowlist so a fresh install doesn't
+  prompt for the framework's own runtime — `.claude/` file edits and
+  hook/lib invocations.
 - **Modular charter template** (#69) — the installed charter is a thin index
   over per-topic modules (`.claude/team/charter/*.md`), so teams evolve
   individual sections without merge pain.

--- a/RELEASE_NOTES_0.4.0.md
+++ b/RELEASE_NOTES_0.4.0.md
@@ -1,0 +1,87 @@
+# v0.4.0
+
+Feature release — one config file now drives a fully non-interactive install,
+including multi-repo (meta + child) layouts, and the runtime ships a much
+larger skills tier. Both CLIs (`pip install 2real-team-framework`,
+`npm install -g 2real-team-framework`) expose the same `init` contract.
+
+## Unified install config + non-interactive mode (#64)
+
+Every interactive decision point across both installers is now covered by a
+single `install.config.yaml` schema (precedence: CLI flags > user YAML >
+shipped defaults):
+
+```bash
+# Standalone framework installer (stdlib-only, zero prompts)
+python3 framework/install/bootstrap.py /path/to/repo \
+  --install-config my.install.yaml --non-interactive
+
+# CLI (same file, auto-detected)
+2real-team init --config my.install.yaml --non-interactive
+```
+
+With `--non-interactive` there are **zero prompts on any path**. The resolved
+config is recorded at `.claude/install.config.json` for downstream tooling. A
+fully commented reference lives at
+`framework/config/install.config.default.yaml`; the key table is in the README
+("Install configuration").
+
+## Meta-repo and child installs (#65)
+
+`project.model: standalone | meta | child` describes your repo shape:
+
+- **meta** — full framework at the meta root, plus a hook-less child layout in
+  each repo listed under `children:` (with per-child `flavor: product|infra`).
+  Children invoke the parent's dispatchers via portable parent-relative
+  commands — one copy of the hooks, the whole tree clones anywhere.
+- **child** — lay just the child layout, pointing at an already-bootstrapped
+  parent (`parent.path`, relative only).
+
+Installs are also gated by `repo.expect: fresh | existing | any` — the
+installer detects the target's actual state and refuses (non-interactive) or
+asks (interactive) on a mismatch; idempotent re-runs skip the gate.
+
+## More runtime, out of the box
+
+- **Ontology at install** (#66) — `ontology.enabled: true` (default) seeds the
+  two-layer ontology (semantic overlay + generated structural index) and
+  activates the ontology hooks during install, including meta/child trees.
+- **Pre-push hook installer** (#67) — `pre_push.mode: noop | enforce | none`.
+  `enforce` runs `hooks.pre_push_commands` from `framework.config.json` at
+  push time; existing non-framework hooks are preserved as `pre-push.bak`.
+- **Shipped permissions allowlist** (#68) — `settings.template.json` now
+  carries a genericized permissions allowlist so a fresh install prompts far
+  less for routine git/gh/test commands.
+- **Modular charter template** (#69) — the installed charter is a thin index
+  over per-topic modules (`.claude/team/charter/*.md`), so teams evolve
+  individual sections without merge pain.
+- **Agent/Stop dispatch + session hooks** (#87) — the dispatcher now covers
+  Agent and Stop events and ships `session_start` / `session_handoff` hooks;
+  also reconciled the config schema defaults drift (#84).
+
+## Skills tier grew: 13 runtime skills (#85, #86)
+
+New: `team-reset`, `wave-audit`, `wave-retro` (mechanical, evidence-anchored
+trust scoring), `phase-review`, plus STOP-guards in `wave-start`. Enriched
+runtime versions of `retro`, `wave-start`, `plan-phase`, and
+`close-stale-issues` supersede the templated ones when the runtime is
+installed. Full list in the README ("Skills").
+
+## Node CLI: full parity via the bundled Python bootstrap (#70)
+
+`npx 2real-team-framework init` now installs the framework runtime by bridging
+to the bundled Python bootstrapper (`python3` or `python` on PATH; team
+scaffolding still completes without one, with instructions to finish). The npm
+package has its own README, and the CLI version comes from `package.json` —
+no hardcoded version strings.
+
+## Proven on itself
+
+- CI now runs on PRs into `deployments/**` wave branches (#73).
+- This repo is bootstrapped through its own installer (#88) — the framework
+  dogfoods every hook, skill, and config path it ships.
+
+## Distribution
+
+- PyPI: 0.3.2 -> 0.4.0
+- npm:  0.3.2 -> 0.4.0

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "2real-team-framework",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "2real-team-framework",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.0.0",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "2real-team-framework",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Drop-in AI agent team framework for Claude Code projects",
   "license": "Apache-2.0",
   "type": "module",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "2real-team-framework"
-version = "0.3.2"
+version = "0.4.0"
 description = "Drop-in AI agent team framework for Claude Code projects"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.10"

--- a/python/src/real_team/__init__.py
+++ b/python/src/real_team/__init__.py
@@ -1,3 +1,3 @@
 """2real-team-framework — Drop-in AI agent team framework for Claude Code projects."""
 
-__version__ = "0.3.2"
+__version__ = "0.4.0"


### PR DESCRIPTION
Closes #95.

Final release-prep PR for the phase-3 wave. **No merge, tag, or GitHub Release here** — those are user-gated per the charter.

## What's in this PR

- **Version bumps 0.3.2 → 0.4.0**: `python/pyproject.toml`, `python/src/real_team/__init__.py`, `node/package.json`, `node/package-lock.json` (regenerated via `npm install --package-lock-only`). Grep confirms no other version hardcodes remain — the node CLI reads `package.json` at runtime since #70; the only other `0.3.2` hits are a `tinyexec` dependency in the lockfile and historical `.claude/memory/` notes.
- **`RELEASE_NOTES_0.4.0.md`** (draft inline below) — user-facing summary of the wave, following the v0.3.x release-body style.
- **README final pass**: runtime skills section updated from 5 to the 13 now shipped (adds `wave-retro`, `phase-review`, `team-reset`, `wave-audit`; documents the enriched `retro`/`wave-start`/`plan-phase`/`close-stale-issues` supersets); Quick Start tree comment updated. Install-configuration key table, pre-push section, and meta/child section verified current.
- **Registry wiring verified**: PyPI long description via `readme = "../README.md"` + sdist force-include (intact); npm page via `node/README.md` (mentions `--non-interactive`, unified YAML config, the Python-bootstrap bridge; links correct).
- **No CHANGELOG file exists** in the repo — release notes serve that role (not inventing one).

## Test evidence

- framework: `pytest framework/tests/` — 257 passed
- python: `PYTHONPATH=src pytest` — 126 passed
- node: `vitest --run` — 127 passed (4 files)
- `ruff check .` — clean

---

## Release notes draft (RELEASE_NOTES_0.4.0.md)

# v0.4.0

Feature release — one config file now drives a fully non-interactive install,
including multi-repo (meta + child) layouts, and the runtime ships a much
larger skills tier. Both CLIs (`pip install 2real-team-framework`,
`npm install -g 2real-team-framework`) expose the same `init` contract.

## Unified install config + non-interactive mode (#64)

Every interactive decision point across both installers is now covered by a
single `install.config.yaml` schema (precedence: CLI flags > user YAML >
shipped defaults):

```bash
# Standalone framework installer (stdlib-only, zero prompts)
python3 framework/install/bootstrap.py /path/to/repo \
  --install-config my.install.yaml --non-interactive

# CLI (same file, auto-detected)
2real-team init --config my.install.yaml --non-interactive
```

With `--non-interactive` there are **zero prompts on any path**. The resolved
config is recorded at `.claude/install.config.json` for downstream tooling. A
fully commented reference lives at
`framework/config/install.config.default.yaml`; the key table is in the README
("Install configuration").

## Meta-repo and child installs (#65)

`project.model: standalone | meta | child` describes your repo shape:

- **meta** — full framework at the meta root, plus a hook-less child layout in
  each repo listed under `children:` (with per-child `flavor: product|infra`).
  Children invoke the parent's dispatchers via portable parent-relative
  commands — one copy of the hooks, the whole tree clones anywhere.
- **child** — lay just the child layout, pointing at an already-bootstrapped
  parent (`parent.path`, relative only).

Installs are also gated by `repo.expect: fresh | existing | any` — the
installer detects the target's actual state and refuses (non-interactive) or
asks (interactive) on a mismatch; idempotent re-runs skip the gate.

## More runtime, out of the box

- **Ontology at install** (#66) — `ontology.enabled: true` (default) seeds the
  two-layer ontology (semantic overlay + generated structural index) and
  activates the ontology hooks at install; for meta trees the ontology lives
  at the meta root with cross-repo aggregation over the children.
- **Pre-push hook installer** (#67) — `pre_push.mode: noop | enforce | none`.
  `enforce` runs `hooks.pre_push_commands` from `framework.config.json` at
  push time; existing non-framework hooks are preserved as `pre-push.bak`.
- **Shipped permissions allowlist** (#68) — `settings.template.json` now
  carries a genericized permissions allowlist so a fresh install doesn't
  prompt for the framework's own runtime — `.claude/` file edits and
  hook/lib invocations.
- **Modular charter template** (#69) — the installed charter is a thin index
  over per-topic modules (`.claude/team/charter/*.md`), so teams evolve
  individual sections without merge pain.
- **Agent/Stop dispatch + session hooks** (#87) — the dispatcher now covers
  Agent and Stop events and ships `session_start` / `session_handoff` hooks;
  also reconciled the config schema defaults drift (#84).

## Skills tier grew: 13 runtime skills (#85, #86)

New: `team-reset`, `wave-audit`, `wave-retro` (mechanical, evidence-anchored
trust scoring), `phase-review`, plus STOP-guards in `wave-start`. Enriched
runtime versions of `retro`, `wave-start`, `plan-phase`, and
`close-stale-issues` supersede the templated ones when the runtime is
installed. Full list in the README ("Skills").

## Node CLI: full parity via the bundled Python bootstrap (#70)

`npx 2real-team-framework init` now installs the framework runtime by bridging
to the bundled Python bootstrapper (`python3` or `python` on PATH; team
scaffolding still completes without one, with instructions to finish). The npm
package has its own README, and the CLI version comes from `package.json` —
no hardcoded version strings.

## Proven on itself

- CI now runs on PRs into `deployments/**` wave branches (#73).
- This repo is bootstrapped through its own installer (#88) — the framework
  dogfoods every hook, skill, and config path it ships.

## Distribution

- PyPI: 0.3.2 -> 0.4.0
- npm:  0.3.2 -> 0.4.0
