### PR TITLE
fix(trust-signals): phase-aware branch.integration template (#100)

### DIFF
--- a/.claude/skills/retro/SKILL.md
+++ b/.claude/skills/retro/SKILL.md
@@ -33,8 +33,8 @@ LIB="$REPO_ROOT/.claude/lib"
 
 Read `current_wave` (call it `{W}`) from the state output, or ask the user. The wave label
 is `labels.wave` with `{id}` → `{W}`. The PR base branch is `branch.integration` (with
-`{wave}` → `{W}`) when the wave's merge model is `wave-branch`, otherwise the default
-branch.
+`{phase}` → the wave's phase and `{wave}` → `{W}`) when the wave's merge model is
+`wave-branch`, otherwise the default branch.
 
 ### 1. Collect progress data
 

--- a/.claude/skills/wave-retro/SKILL.md
+++ b/.claude/skills/wave-retro/SKILL.md
@@ -49,7 +49,7 @@ The PR base depends on the wave's merge model:
 
 ```bash
 MM="$(python3 "$LIB/lifecycle.py" merge-model get "{W}" 2>/dev/null || echo direct-to-main)"
-# wave-branch     → BASE = branch.integration template with {wave} → {W}
+# wave-branch     → BASE = branch.integration template ({phase} → wave's phase, {wave} → {W})
 # direct-to-main  → BASE = $DEFAULT_BRANCH, additionally filtered by the wave label
 gh pr list --state merged --base "{BASE}" --json number,title,author,body,mergedAt,reviews
 ```

--- a/framework/assets/lib/trust_signals.py
+++ b/framework/assets/lib/trust_signals.py
@@ -335,21 +335,63 @@ def _resolve_repos(cfg) -> list[str]:
     return [nwo] if nwo else []
 
 
-def _integration_base(cfg, wave: str) -> str:
+class _PartialTokens(dict):
+    """Format map that leaves unknown ``{token}`` placeholders literal.
+
+    Mirrors the shell skills' ``sed "s/{phase}/…/; s/{wave}/…/"`` behaviour:
+    known tokens are substituted, anything else is passed through verbatim
+    instead of raising ``KeyError``. Keeps template rendering fail-safe.
+    """
+
+    def __missing__(self, key: str) -> str:  # noqa: D105
+        return "{" + key + "}"
+
+
+def _render_branch_template(template: str, **tokens) -> str:
+    """Substitute *tokens* into *template*, leaving unknown placeholders literal."""
+    try:
+        return str(template).format_map(_PartialTokens(**tokens))
+    except (KeyError, IndexError, ValueError):
+        return str(template)
+
+
+def _phase_for_wave(wave: str, status_path: Path | None) -> str | int | None:
+    """The phase a wave belongs to (``wave_<id>_phase`` in state), or None.
+
+    PROJECT-COUPLING: keyed on a state-file entry named ``wave_<id>_phase``
+    stamped by the wave allocator (see ``lifecycle.py``). Absent in a generic
+    project (or when the state file is missing/unreadable) → None, so a template
+    that references ``{phase}`` degrades gracefully rather than crashing.
+    """
+    if status_path is None:
+        return None
+    try:
+        data = json.loads(Path(status_path).read_text())
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    val = data.get(f"wave_{wave}_phase")
+    return val if val is not None else None
+
+
+def _integration_base(cfg, wave: str, phase: str | int | None = None) -> str:
     """The merged-PR base branch for *wave*, from the integration-branch template.
 
     PROJECT-COUPLING: the original tool scoped the base to a phase+wave path
     (``deployments/phase-<P>/wave-<M>``). Here the base is derived generically
     from the configured ``branch.integration`` template (default
     ``deployments/wave-{wave}``) so it tracks whatever branching scheme a project
-    declares. A project whose merges target the default branch directly should
-    set ``branch.integration`` to that branch name.
+    declares. Both ``{phase}`` and ``{wave}`` tokens are substituted; a project
+    that namespaces waves by phase (``deployments/phase{phase}/wave-{wave}``) is
+    resolved correctly when *phase* is supplied (from ``wave_<id>_phase`` state).
+    A project whose merges target the default branch directly should set
+    ``branch.integration`` to that branch name. Unknown/unresolved tokens are
+    left literal rather than raising.
     """
     template = cfg.get("branch.integration", "deployments/wave-{wave}")
-    try:
-        return str(template).format(wave=wave)
-    except (KeyError, IndexError):
-        return str(template)
+    tokens: dict[str, str | int] = {"wave": wave}
+    if phase is not None:
+        tokens["phase"] = phase
+    return _render_branch_template(str(template), **tokens)
 
 
 def _kickoff_ts(wave: str, status_path: Path | None) -> str | None:
@@ -432,7 +474,7 @@ def merged_prs(
     """
     cfg = cfg or config()
     repos = _resolve_repos(cfg)
-    base = _integration_base(cfg, wave)
+    base = _integration_base(cfg, wave, phase=_phase_for_wave(wave, status_path))
     kickoff = _kickoff_ts(wave, status_path)
 
     out: list[dict] = []

--- a/framework/assets/skills/retro/SKILL.md
+++ b/framework/assets/skills/retro/SKILL.md
@@ -33,8 +33,8 @@ LIB="$REPO_ROOT/.claude/lib"
 
 Read `current_wave` (call it `{W}`) from the state output, or ask the user. The wave label
 is `labels.wave` with `{id}` → `{W}`. The PR base branch is `branch.integration` (with
-`{wave}` → `{W}`) when the wave's merge model is `wave-branch`, otherwise the default
-branch.
+`{phase}` → the wave's phase and `{wave}` → `{W}`) when the wave's merge model is
+`wave-branch`, otherwise the default branch.
 
 ### 1. Collect progress data
 

--- a/framework/assets/skills/wave-retro/SKILL.md
+++ b/framework/assets/skills/wave-retro/SKILL.md
@@ -49,7 +49,7 @@ The PR base depends on the wave's merge model:
 
 ```bash
 MM="$(python3 "$LIB/lifecycle.py" merge-model get "{W}" 2>/dev/null || echo direct-to-main)"
-# wave-branch     → BASE = branch.integration template with {wave} → {W}
+# wave-branch     → BASE = branch.integration template ({phase} → wave's phase, {wave} → {W})
 # direct-to-main  → BASE = $DEFAULT_BRANCH, additionally filtered by the wave label
 gh pr list --state merged --base "{BASE}" --json number,title,author,body,mergedAt,reviews
 ```

--- a/framework/tests/test_trust_signals.py
+++ b/framework/tests/test_trust_signals.py
@@ -1,19 +1,29 @@
-"""Tests for trust_signals.py verdict-vocabulary parsing (issue #98).
+"""Tests for trust_signals.py — verdict-vocabulary parsing (#98) and phase-aware
+integration-branch resolution (#100).
 
-The regression these tests pin: the extraction layer used to count a must-fix
-only when a verdict comment read ``RequestOrReplied: ChangesRequested``. This
-project's charter (``.claude/team/charter/issues.md``) instead writes
-``RequestOrReplied: Request | Replied`` and carries the review *severity* in the
-comment body as an enumerated ``Must-fix:`` list. Under the old vocabulary every
-real review read as zero. These tests assert the charter vocabulary now scores,
-the legacy machine token still scores, and clean reviews / replies do not.
+Two independent concerns share this module because they exercise the same lib:
 
-Fixtures are trimmed but shape-faithful to the real Phase 3 PR comments the
-issue names (#79, #78, #96, #93). Pure functions only — no gh, no I/O.
+* **Verdict vocabulary (#98)** — the extraction layer used to count a must-fix
+  only when a verdict comment read ``RequestOrReplied: ChangesRequested``. This
+  project's charter (``.claude/team/charter/issues.md``) instead writes
+  ``RequestOrReplied: Request | Replied`` and carries the review *severity* in
+  the comment body as an enumerated ``Must-fix:`` list. Under the old vocabulary
+  every real review read as zero. These tests assert the charter vocabulary now
+  scores, the legacy machine token still scores, and clean reviews / replies do
+  not. Fixtures are trimmed but shape-faithful to the real Phase 3 PR comments
+  the issue names (#79, #78, #96, #93). Pure functions only — no gh, no I/O.
+
+* **Integration-branch resolution (#100)** — the ``branch.integration`` template
+  that scopes the merged-PR set must substitute both ``{phase}`` and ``{wave}``;
+  phase is resolved from ``wave_<id>_phase`` in the state file, and
+  unknown/unresolved tokens degrade to a literal placeholder rather than raising.
+  No network (``_integration_base`` / ``_phase_for_wave`` are pure aside from an
+  optional state-file read).
 """
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -306,3 +316,106 @@ def test_score_delta_discriminates_clean_reviewer_from_blocked_author():
     author = ts.Signals(prs_merged=2, must_fix_received=1, rework_cycles=1)
     assert ts.score_delta(reviewer) >= 1
     assert ts.score_delta(author) <= 0
+
+
+# ===========================================================================
+# Integration-branch resolution (#100): phase-aware branch.integration template.
+# ===========================================================================
+
+
+class _Cfg:
+    """Minimal stand-in for the shared config object: dotted ``.get(key, default)``."""
+
+    def __init__(self, values: dict) -> None:
+        self._v = values
+
+    def get(self, key: str, default=None):
+        return self._v.get(key, default)
+
+
+# --------------------------------------------------------------- _render_branch_template
+
+
+def test_render_substitutes_both_tokens() -> None:
+    out = ts._render_branch_template(
+        "deployments/phase{phase}/wave-{wave}", phase=6, wave="1"
+    )
+    assert out == "deployments/phase6/wave-1"
+
+
+def test_render_leaves_unknown_token_literal() -> None:
+    # An unresolved token must not raise (mirrors the shell sed behaviour).
+    out = ts._render_branch_template("deployments/phase{phase}/wave-{wave}", wave="3")
+    assert out == "deployments/phase{phase}/wave-3"
+
+
+def test_render_wave_only_template() -> None:
+    out = ts._render_branch_template("deployments/wave-{wave}", wave="7", phase=2)
+    assert out == "deployments/wave-7"
+
+
+# --------------------------------------------------------------- _integration_base
+
+
+def test_integration_base_phase_aware() -> None:
+    cfg = _Cfg({"branch.integration": "deployments/phase{phase}/wave-{wave}"})
+    assert ts._integration_base(cfg, "1", phase=6) == "deployments/phase6/wave-1"
+
+
+def test_integration_base_phase_aware_phase4() -> None:
+    # Regression for issue #100: config unchanged between phases, phase drives the branch.
+    cfg = _Cfg({"branch.integration": "deployments/phase{phase}/wave-{wave}"})
+    assert ts._integration_base(cfg, "1", phase=4) == "deployments/phase4/wave-1"
+
+
+def test_integration_base_missing_phase_is_safe() -> None:
+    # No phase supplied for a phase-namespaced template → literal token, no KeyError.
+    cfg = _Cfg({"branch.integration": "deployments/phase{phase}/wave-{wave}"})
+    assert ts._integration_base(cfg, "2") == "deployments/phase{phase}/wave-2"
+
+
+def test_integration_base_generic_default() -> None:
+    # Empty config → generic wave-only default still resolves.
+    cfg = _Cfg({})
+    assert ts._integration_base(cfg, "9") == "deployments/wave-9"
+
+
+def test_integration_base_literal_default_branch() -> None:
+    # A project merging straight to a named branch (no tokens) passes through.
+    cfg = _Cfg({"branch.integration": "main"})
+    assert ts._integration_base(cfg, "5", phase=3) == "main"
+
+
+# --------------------------------------------------------------- _phase_for_wave
+
+
+def test_phase_for_wave_reads_state(tmp_path) -> None:
+    state = tmp_path / "state.json"
+    state.write_text(json.dumps({"wave_1_phase": 6, "wave_2_phase": 7}))
+    assert ts._phase_for_wave("1", state) == 6
+    assert ts._phase_for_wave("2", state) == 7
+
+
+def test_phase_for_wave_missing_key_is_none(tmp_path) -> None:
+    state = tmp_path / "state.json"
+    state.write_text(json.dumps({"wave_1_phase": 6}))
+    assert ts._phase_for_wave("9", state) is None
+
+
+def test_phase_for_wave_no_status_path_is_none() -> None:
+    assert ts._phase_for_wave("1", None) is None
+
+
+def test_phase_for_wave_unreadable_is_none(tmp_path) -> None:
+    assert ts._phase_for_wave("1", tmp_path / "does-not-exist.json") is None
+
+
+# --------------------------------------------------------------- end-to-end wiring
+
+
+def test_base_resolved_from_state_end_to_end(tmp_path) -> None:
+    state = tmp_path / "state.json"
+    state.write_text(json.dumps({"wave_1_phase": 4}))
+    cfg = _Cfg({"branch.integration": "deployments/phase{phase}/wave-{wave}"})
+    phase = ts._phase_for_wave("1", state)
+    assert ts._integration_base(cfg, "1", phase=phase) == "deployments/phase4/wave-1"


### PR DESCRIPTION
## Summary
Makes the `branch.integration` template **phase-aware** — the real treatment behind issue #100 (the Manager's config-value edit was only a stopgap).

`trust_signals._integration_base` resolved the merged-PR base via `template.format(wave=wave)`, so a `{phase}` token raised `KeyError` and fell back to the raw literal template — silently scoping the retro to zero PRs for phase-namespaced projects (`deployments/phase{phase}/wave-{wave}`).

## Changes
- **`framework/assets/lib/trust_signals.py`**
  - `_integration_base(cfg, wave, phase=None)` now substitutes **both** `{phase}` and `{wave}` through a partial format map (`_PartialTokens`) that leaves unknown/unresolved tokens literal instead of raising — mirrors the shell skills' `sed` behaviour.
  - New `_phase_for_wave(wave, status_path)` resolves phase from `wave_<id>_phase` in the state file (fail-open → None).
  - `merged_prs` wires the resolved phase into the base derivation.
- **retro / wave-retro skill guidance** — updated the `branch.integration` substitution note to include `{phase}` (canonical `framework/assets/skills/` **and** live `.claude/skills/` copies kept in sync — dual-deploy).
- **`framework/tests/test_trust_signals.py`** (new, 13 tests) — both-token substitution, safe unresolved-token fallback, generic wave-only default, literal named branch, and state-driven phase resolution end-to-end.

## Consumer audit (phase-token handling verified)
- `trust_signals._integration_base` — **fixed here**.
- `wave-start`, `wave-audit` skills — already phase-aware (`sed s/{phase}/…/; s/{wave}/…/`), default `deployments/phase{phase}/wave-{wave}`.
- `block_squash_wave_merge.py` hook — already maps `{phase}`/`{wave}` → `\d+`.
- Schema (`framework.config.schema.json`) already documents both tokens.
- Generic embedded defaults (`_framework_config.py`, schema, `bootstrap.py`) intentionally left as `deployments/wave-{wave}` — the phase-less default is correct for fresh non-phased projects; the substitution logic handles `{phase}` whenever a project opts into it.

## Verification
- `ruff check framework/` → clean.
- `pytest framework/tests/` → **270 passed** (13 new).

## Risks / decisions
- Unresolved `{phase}` (no state / generic project) degrades to a literal `{phase}` in the branch name rather than crashing — a visible, debuggable fail vs. the previous silent zero-PR result.
- Did not touch the archived intake candidate copy (`intake/.../candidates/lib/trust_signals.py`) — it is a frozen snapshot, not a live runtime path.

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTQxgBAcChxvdQJafKyMdX
