### PR TITLE
fix(trust): read charter Request+Must-fix verdict vocabulary (#98)

### DIFF
--- a/framework/assets/lib/trust_signals.py
+++ b/framework/assets/lib/trust_signals.py
@@ -10,8 +10,15 @@ Two cleanly separated layers:
   * **Extraction** (SCM-dependent) — :func:`extract_signals` builds a
     ``{engineer_name: Signals}`` map from the merged-PR set, reading the repo
     list and integration-branch convention from the framework config and parsing
-    each PR's verdict comments for the ``Requestor:`` / ``RequestOrReplied:``
-    review-verdict shape.
+    each PR's verdict comments for the charter's ``Requestor:`` /
+    ``Requestee:`` / ``RequestOrReplied:`` shape. The charter carries review
+    *severity* in the comment **body** — an enumerated ``Must-fix:`` list — not
+    in the verdict token, so a ``Request`` verdict whose body lists must-fix
+    items is the changes-requested signal, while ``Replied`` (and a ``Request``
+    with ``Must-fix: None`` / no must-fix section) is clean. The legacy
+    explicit-token vocabulary (``ChangesRequested`` / ``Approved``) is still
+    recognized so a project that emits a machine verdict token directly also
+    scores.
 
   * **Scoring** (pure, no I/O) — :func:`score_delta`, :func:`decay`,
     :func:`apply_distribution_discipline`, :func:`negative_signal_line`,
@@ -24,15 +31,18 @@ Signals per engineer (all integers, all countable from the merged-PR set):
   ===========================  ============================================
   prs_merged                   PRs merged this iteration with them as commit
                                author.
-  must_fix_received            ChangesRequested verdicts on PRs they
-                               authored (negative — author signal).
-  must_fix_caught              ChangesRequested verdicts they issued as the
+  must_fix_received            changes-requested verdicts on PRs they
+                               authored (negative — author signal). A
+                               changes-requested verdict is a ``Request`` with
+                               body must-fix items, or a legacy
+                               ``ChangesRequested`` token.
+  must_fix_caught              changes-requested verdicts they issued as the
                                Requestor/reviewer (positive — review
                                signal).
   ci_red_merges                PRs they authored that merged with a failing
                                required check (negative — hard ding).
   rework_cycles                PRs they authored that needed >=1 rework
-                               round (received >=1 ChangesRequested).
+                               round (received >=1 changes-requested verdict).
   review_false_positives       must-fix items they raised that were later
                                marked withdrawn/false-positive (negative —
                                review-quality signal).
@@ -98,6 +108,16 @@ _FALSE_POSITIVE_RE = re.compile(
     re.IGNORECASE,
 )
 
+# The charter carries review severity in the comment BODY, not the verdict token:
+# a ``Must-fix:`` label (optionally bold) introduces an enumerated list of
+# blocking findings. ``_MUST_FIX_LABEL_RE`` matches that label line and captures
+# any same-line remainder; ``_LIST_ITEM_RE`` recognizes an enumerated / bulleted
+# item; ``_EMPTY_MUST_FIX_RE`` recognizes an explicit "no findings" value
+# (``None`` / ``N/A`` / ``-`` / ``0``, e.g. ``Must-fix: None (all resolved)``).
+_MUST_FIX_LABEL_RE = re.compile(r"^\s*\**must[\s-]?fix\**:\s*(.*?)\s*$", re.IGNORECASE)
+_LIST_ITEM_RE = re.compile(r"^\s*(?:\d+[.)]|[-*+])\s+\S")
+_EMPTY_MUST_FIX_RE = re.compile(r"^(none|n/?a|-+|0)(?:\W|$)", re.IGNORECASE)
+
 
 def _strip_code_markup(text: str) -> str:
     """Remove fenced code blocks and inline code spans from *text*.
@@ -154,12 +174,75 @@ class Signals:
 
 @dataclass
 class Verdict:
-    """A parsed verdict comment: who reviewed whom, the call, and retraction."""
+    """A parsed verdict comment: who reviewed whom, the call, and retraction.
+
+    ``changes_requested`` is the resolved blocking-review signal — it is derived
+    at parse time from the verdict token *and* the comment body (the charter
+    keeps severity in the body, so the token alone is not enough). Downstream
+    scoring reads this flag, never the raw token.
+    """
 
     requestor: str | None
     requestee: str | None
     verdict: str | None
     false_positive: bool
+    changes_requested: bool = False
+
+
+def _has_must_fix_items(body: str) -> bool:
+    """True when *body* carries a ``Must-fix:`` section with >=1 real item.
+
+    The charter's review convention writes severity in the comment body: a
+    ``Must-fix:`` label (bare or bold) followed by an enumerated list of blocking
+    findings. An explicit empty value (``Must-fix: None`` / ``N/A`` / ``-`` /
+    ``0``, including ``Must-fix: None (all resolved)``) is NOT a must-fix. Code
+    spans / fenced blocks are stripped first so a ``must-fix`` token inside code
+    or a test name is never counted.
+    """
+    lines = _strip_code_markup(body).splitlines()
+    for i, line in enumerate(lines):
+        label_m = _MUST_FIX_LABEL_RE.match(line)
+        if not label_m:
+            continue
+        inline = label_m.group(1).strip()
+        if inline:
+            # Value on the label line itself: an item unless it's an explicit
+            # "no findings" marker.
+            if not _EMPTY_MUST_FIX_RE.match(inline):
+                return True
+            continue
+        # Bare label: the value is on the following line(s). Skip blank lines,
+        # then require the next non-blank line to be an enumerated/bulleted item.
+        j = i + 1
+        while j < len(lines) and not lines[j].strip():
+            j += 1
+        if j < len(lines) and _LIST_ITEM_RE.match(lines[j]):
+            return True
+    return False
+
+
+def _is_changes_requested(verdict: str | None, body: str = "") -> bool:
+    """True when a verdict comment represents a changes-requested / must-fix call.
+
+    Two accepted vocabularies:
+      * **charter convention** — a ``Request`` verdict whose *body* enumerates
+        one or more ``Must-fix:`` items. Severity lives in the body, so a
+        ``Request`` with ``Must-fix: None`` (or no must-fix section) is a clean
+        review, not a changes-requested.
+      * **legacy machine token** — a literal ``ChangesRequested`` verdict (the
+        GitHub review-state vocabulary), kept so a project that emits the token
+        directly still scores.
+
+    ``Replied`` / ``Approved`` are clean unless carrying the legacy token.
+    """
+    if verdict is None:
+        return False
+    token = verdict.strip().lower()
+    if token == "changesrequested":
+        return True
+    if token == "request":
+        return _has_must_fix_items(body)
+    return False
 
 
 def parse_verdicts(comment_bodies: list[str]) -> list[Verdict]:
@@ -167,7 +250,9 @@ def parse_verdicts(comment_bodies: list[str]) -> list[Verdict]:
 
     Pure function — no I/O. Accepts both the bare (``Requestor: Name``) and bold
     (``**Requestor:** Name``) forms. A comment with no ``RequestOrReplied`` line
-    is not a verdict and is skipped.
+    is not a verdict and is skipped. The blocking-review call is resolved here
+    (:func:`_is_changes_requested`) because the charter carries severity in the
+    body, not the verdict token.
     """
     out: list[Verdict] = []
     for body in comment_bodies:
@@ -177,6 +262,7 @@ def parse_verdicts(comment_bodies: list[str]) -> list[Verdict]:
         req_m = _FIELD_RE["requestor"].search(body)
         ree_m = _FIELD_RE["requestee"].search(body)
         verdict_str = verdict_m.group(1).strip()
+        changes_requested = _is_changes_requested(verdict_str, body)
         # A retraction only counts when the reviewer actually raised a
         # finding — approvals are never retractions.  Also strip code
         # spans and fenced blocks first so symbol/test names that contain
@@ -194,13 +280,10 @@ def parse_verdicts(comment_bodies: list[str]) -> list[Verdict]:
                 requestee=ree_m.group(1).strip() if ree_m else None,
                 verdict=verdict_str,
                 false_positive=is_false_positive,
+                changes_requested=changes_requested,
             )
         )
     return out
-
-
-def _is_changes_requested(verdict: str | None) -> bool:
-    return verdict is not None and verdict.lower() == "changesrequested"
 
 
 # ---------------------------------------------------------------------------
@@ -431,7 +514,7 @@ def extract_signals(
         verdicts = parse_verdicts(_pr_comment_bodies(repo, number))
         pr_had_changes_requested = False
         for v in verdicts:
-            if _is_changes_requested(v.verdict):
+            if v.changes_requested:
                 pr_had_changes_requested = True
                 author_sig.must_fix_received += 1
                 if v.requestor:

--- a/framework/tests/test_trust_signals.py
+++ b/framework/tests/test_trust_signals.py
@@ -1,0 +1,308 @@
+"""Tests for trust_signals.py verdict-vocabulary parsing (issue #98).
+
+The regression these tests pin: the extraction layer used to count a must-fix
+only when a verdict comment read ``RequestOrReplied: ChangesRequested``. This
+project's charter (``.claude/team/charter/issues.md``) instead writes
+``RequestOrReplied: Request | Replied`` and carries the review *severity* in the
+comment body as an enumerated ``Must-fix:`` list. Under the old vocabulary every
+real review read as zero. These tests assert the charter vocabulary now scores,
+the legacy machine token still scores, and clean reviews / replies do not.
+
+Fixtures are trimmed but shape-faithful to the real Phase 3 PR comments the
+issue names (#79, #78, #96, #93). Pure functions only — no gh, no I/O.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# trust_signals.py lives in the canonical framework asset tree; its scoring /
+# parsing half is pure. Put both the lib dir and its sibling hooks dir (the
+# module bridges to _framework_config at import time) on the path.
+_LIB = Path(__file__).resolve().parent.parent / "assets" / "lib"
+_HOOKS = Path(__file__).resolve().parent.parent / "assets" / "hooks"
+sys.path.insert(0, str(_HOOKS))
+sys.path.insert(0, str(_LIB))
+
+import trust_signals as ts  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Real-corpus fixtures (trimmed from the Phase 3 PRs the issue names).
+# ---------------------------------------------------------------------------
+
+# PR #79 — Tariq's blocking review: a `Request` with an enumerated Must-fix list.
+PR79_REQUEST = """Requestor: Tariq Morales (QA)
+Requestee: Paloma Gupta
+RequestOrReplied: Request
+
+**Review: issues (one must-fix — merge conflict with the moved base)**
+
+Must-fix:
+1. **Rebase required — PR is CONFLICTING against the base** (`mergeable: DIRTY`).
+   The base moved after you branched; resolve and re-run both suites.
+
+Tech-debt: None filed.
+"""
+
+# PR #79 — Paloma's reply. Mentions "must-fix" in prose but is a `Replied`, and
+# carries no Must-fix section of its own → clean, not a changes-requested.
+PR79_REPLY = """Requestor: Paloma Gupta (Principal SWE)
+Requestee: Tariq Morales (QA)
+RequestOrReplied: Replied
+
+**Rebase + semantic reconciliation done — ready for re-review.** How the #71
+overlap was resolved (semantic, per your must-fix): the ontology block is now
+gated on the resolved `ontology.enabled`. Suites green.
+"""
+
+# PR #96 — Tariq's blocking review: bare `Must-fix:` label, two enumerated items.
+PR96_REQUEST = """Requestor: Tariq Morales (QA)
+Requestee: Ibrahim El-Amin
+RequestOrReplied: Request
+
+Must-fix:
+1. **Permissions-allowlist claim is factually wrong.** Reword to match README.
+2. **Ontology meta/child wording overstates.** Children deliberately get none.
+
+Tech-debt: None.
+"""
+
+# PR #96 — Tariq's approval, posted as a `Replied` with an explicit empty
+# Must-fix value → clean.
+PR96_APPROVE = """Requestor: Tariq Morales (QA)
+Requestee: Ibrahim El-Amin
+RequestOrReplied: Replied
+
+**Review: LGTM — APPROVE.** Fix commit confirmed; CI 11/11 green.
+
+Must-fix: None (all resolved)
+Tech-debt: None
+"""
+
+# PR #93 — Nia's review: **bold** Must-fix label, one enumerated item.
+PR93_REQUEST = """Requestor: Nia.Rossi
+Requestee: Tariq.Morales
+RequestOrReplied: Request
+
+**Review: LGTM with one must-fix (PR-body record correction — no code change)**
+
+**Must-fix:**
+1. Edit the PR body's QA-evidence line to record the corrected pytest numbers.
+
+**Tech-debt:** filed as #94.
+"""
+
+
+# ---------------------------------------------------------------------------
+# _has_must_fix_items — the body-severity detector.
+# ---------------------------------------------------------------------------
+
+
+def test_must_fix_bare_label_with_numbered_list():
+    assert ts._has_must_fix_items("Must-fix:\n1. Do the thing") is True
+
+
+def test_must_fix_bold_label_with_numbered_list():
+    assert ts._has_must_fix_items("**Must-fix:**\n1. Do the thing") is True
+
+
+def test_must_fix_label_with_dash_bullet():
+    assert ts._has_must_fix_items("Must-fix:\n- fix this") is True
+
+
+def test_must_fix_inline_item():
+    assert ts._has_must_fix_items("Must-fix: rebase against the moved base") is True
+
+
+def test_must_fix_blank_line_before_list():
+    assert ts._has_must_fix_items("Must-fix:\n\n1. item after a blank line") is True
+
+
+def test_must_fix_none_inline_is_empty():
+    assert ts._has_must_fix_items("Must-fix: None") is False
+
+
+def test_must_fix_none_with_trailer_is_empty():
+    assert ts._has_must_fix_items("Must-fix: None (all resolved)") is False
+
+
+def test_must_fix_na_and_dash_and_zero_are_empty():
+    assert ts._has_must_fix_items("Must-fix: N/A") is False
+    assert ts._has_must_fix_items("Must-fix: -") is False
+    assert ts._has_must_fix_items("Must-fix: 0") is False
+
+
+def test_no_must_fix_label_at_all():
+    assert ts._has_must_fix_items("Just a plain comment, no findings here.") is False
+
+
+def test_must_fix_hyphen_and_space_spelling_variants():
+    assert ts._has_must_fix_items("Must fix:\n1. item") is True
+    assert ts._has_must_fix_items("mustfix:\n1. item") is True
+
+
+def test_must_fix_inside_code_span_is_ignored():
+    # A `Must-fix:` token that only appears inside a code span / fenced block is
+    # not a real finding.
+    assert ts._has_must_fix_items("See `Must-fix: None` in the grammar spec.") is False
+    assert (
+        ts._has_must_fix_items("```\nMust-fix:\n1. sample\n```\nAll good, no findings.")
+        is False
+    )
+
+
+# ---------------------------------------------------------------------------
+# _is_changes_requested — token + body resolution.
+# ---------------------------------------------------------------------------
+
+
+def test_request_with_must_fix_is_changes_requested():
+    assert ts._is_changes_requested("Request", "Must-fix:\n1. fix it") is True
+
+
+def test_request_without_must_fix_is_clean():
+    assert ts._is_changes_requested("Request", "Must-fix: None") is False
+    assert ts._is_changes_requested("Request", "looks good, shipping") is False
+
+
+def test_replied_is_never_changes_requested_even_with_must_fix_prose():
+    # A reply is the response turn — the must-fix was raised in the paired
+    # Request, not here.
+    assert ts._is_changes_requested("Replied", "resolved your must-fix items") is False
+    assert ts._is_changes_requested("Replied", "Must-fix: None (all resolved)") is False
+
+
+def test_legacy_changesrequested_token_still_scores():
+    assert ts._is_changes_requested("ChangesRequested", "") is True
+    assert ts._is_changes_requested("changesrequested", "") is True
+
+
+def test_legacy_approved_token_is_clean():
+    assert ts._is_changes_requested("Approved", "") is False
+
+
+def test_none_verdict_is_clean():
+    assert ts._is_changes_requested(None, "Must-fix:\n1. x") is False
+
+
+# ---------------------------------------------------------------------------
+# parse_verdicts over the real-corpus shapes.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_blocking_request_sets_changes_requested():
+    (v,) = ts.parse_verdicts([PR79_REQUEST])
+    assert v.requestor == "Tariq Morales (QA)"
+    assert v.requestee == "Paloma Gupta"
+    assert v.verdict == "Request"
+    assert v.changes_requested is True
+    assert v.false_positive is False
+
+
+def test_parse_reply_is_not_changes_requested():
+    (v,) = ts.parse_verdicts([PR79_REPLY])
+    assert v.verdict == "Replied"
+    assert v.changes_requested is False
+
+
+def test_parse_bold_label_request():
+    (v,) = ts.parse_verdicts([PR93_REQUEST])
+    assert v.verdict == "Request"
+    assert v.changes_requested is True
+
+
+def test_parse_approval_reply_is_clean():
+    (v,) = ts.parse_verdicts([PR96_APPROVE])
+    assert v.verdict == "Replied"
+    assert v.changes_requested is False
+
+
+def test_parse_skips_non_verdict_comments():
+    assert ts.parse_verdicts(["just a plain comment with no verdict line"]) == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end accounting: the per-PR loop extract_signals runs, exercised on the
+# real corpus without touching gh. Proves review signals now score non-zero.
+# ---------------------------------------------------------------------------
+
+
+def _account(pr_comment_sets: dict[str, tuple[str, list[str]]]) -> dict[str, ts.Signals]:
+    """Mirror extract_signals' per-PR verdict accounting, pure (no gh).
+
+    ``pr_comment_sets`` maps pr-id -> (author_name, [comment_bodies]).
+    """
+    signals: dict[str, ts.Signals] = {}
+
+    def bucket(name: str) -> ts.Signals:
+        return signals.setdefault(name, ts.Signals())
+
+    for _pr, (author, bodies) in pr_comment_sets.items():
+        author_sig = bucket(author)
+        author_sig.prs_merged += 1
+        had_cr = False
+        for v in ts.parse_verdicts(bodies):
+            if v.changes_requested:
+                had_cr = True
+                author_sig.must_fix_received += 1
+                if v.requestor:
+                    bucket(v.requestor).must_fix_caught += 1
+            if v.false_positive and v.requestor:
+                bucket(v.requestor).review_false_positives += 1
+        if had_cr:
+            author_sig.rework_cycles += 1
+    return signals
+
+
+def test_real_corpus_scores_review_signals_non_zero():
+    sigs = _account(
+        {
+            "79": ("Paloma Gupta", [PR79_REQUEST, PR79_REPLY]),
+            "96": ("Ibrahim El-Amin", [PR96_REQUEST, PR96_APPROVE]),
+            "93": ("Tariq.Morales", [PR93_REQUEST]),
+        }
+    )
+
+    # The whole point of the fix: the review-quality half is no longer dark.
+    total_received = sum(s.must_fix_received for s in sigs.values())
+    total_caught = sum(s.must_fix_caught for s in sigs.values())
+    total_rework = sum(s.rework_cycles for s in sigs.values())
+    assert total_received > 0
+    assert total_caught > 0
+    assert total_rework > 0
+
+    # Authors of blocked PRs carry the negative author signal + a rework cycle.
+    assert sigs["Paloma Gupta"].must_fix_received == 1
+    assert sigs["Paloma Gupta"].rework_cycles == 1
+    assert sigs["Ibrahim El-Amin"].must_fix_received == 1
+
+    # Reviewers who raised the must-fix carry the positive review signal.
+    assert sigs["Tariq Morales (QA)"].must_fix_caught == 2  # caught on #79 and #96
+    assert sigs["Nia.Rossi"].must_fix_caught == 1
+
+
+def test_old_vocabulary_would_have_scored_zero():
+    """Guards the regression direction: the legacy token-only rule (verdict ==
+    'ChangesRequested') matches none of the charter corpus, so every review
+    signal would read zero — which is exactly the #98 bug."""
+    for body in (PR79_REQUEST, PR79_REPLY, PR96_REQUEST, PR96_APPROVE, PR93_REQUEST):
+        (v,) = ts.parse_verdicts([body])
+        # None of these carry the literal machine token.
+        assert v.verdict.lower() != "changesrequested"
+    # Yet under the new body-aware rule, the blocking ones do resolve.
+    assert ts.parse_verdicts([PR79_REQUEST])[0].changes_requested is True
+
+
+# ---------------------------------------------------------------------------
+# Scoring composition — a blocked author is not handed a uniform +1.
+# ---------------------------------------------------------------------------
+
+
+def test_score_delta_discriminates_clean_reviewer_from_blocked_author():
+    # Clean reviewer with 2 catches and 2 clean PRs → +1 (or better).
+    reviewer = ts.Signals(prs_merged=2, must_fix_caught=2)
+    # Author who took must-fixes is not "clean" → no positive bump.
+    author = ts.Signals(prs_merged=2, must_fix_received=1, rework_cycles=1)
+    assert ts.score_delta(reviewer) >= 1
+    assert ts.score_delta(author) <= 0


### PR DESCRIPTION
## Summary
- `trust_signals.py` only counted a must-fix on a literal `RequestOrReplied: ChangesRequested` token, but this project's charter (`.claude/team/charter/issues.md`) writes `RequestOrReplied: Request | Replied` with severity carried in the comment **body** as an enumerated `Must-fix:` list. Result: `must_fix_received` / `must_fix_caught` / `rework_cycles` read **zero** for everyone, so `score_delta` proposed a uniform +1 (surfaced in the Phase 3 retro, which fell back to a manual `Must-fix:` tally).
- Now the changes-requested call is resolved from the verdict token **and** the body: a `Request` whose body enumerates `Must-fix:` items = changes-requested; `Replied` and a `Request` with `Must-fix: None` (or no section) = clean. The legacy `ChangesRequested` machine token is still recognized for repos that emit it directly.
- Severity detection strips code spans/fences and treats explicit empty markers (`None` / `N/A` / `-` / `0`, incl. `None (all resolved)`) as no findings; accepts bare and **bold** `Must-fix:` labels and inline / list-item values.

## Vocab mapping settled on
| Comment shape | changes_requested |
|---|---|
| `RequestOrReplied: Request` + body `Must-fix:` with >=1 enumerated item | **True** |
| `RequestOrReplied: Request` + `Must-fix: None` / no must-fix section | False |
| `RequestOrReplied: Replied` (any body, incl. "must-fix" prose) | False |
| legacy `RequestOrReplied: ChangesRequested` token | **True** |
| legacy `RequestOrReplied: Approved` token | False |

## Tests
`framework/tests/test_trust_signals.py` — 25 tests over the real Phase 3 comment shapes (#79, #78, #96, #93): must-fix body detection (label variants, empty markers, code-span suppression), token+body resolution, `parse_verdicts` on the corpus, an end-to-end accounting mirror proving review signals now score non-zero (reviewers get `must_fix_caught`, blocked authors get `must_fix_received` + `rework_cycles`), a regression guard that the old token-only rule would have scored zero, and a scoring-discrimination check. Local: **25 passed**; full framework suite **282 passed**; `ruff check framework/` clean.

## Dual-deploy
Canonical copy under `framework/assets/lib/` — deploys to installed repos. No live `.claude/lib/` runtime copy exists in this repo to sync (the `intake/.../candidates/lib/` copy is an unrelated upstream snapshot, left untouched).

## #111 coupling risk
Tariq's #111 (`validate_review_comment_format`) defines the canonical verdict-comment grammar this parser targets. Aligned to the charter's documented convention (`Requestor:` / `Requestee:` / `RequestOrReplied: Request|Replied` + body `Must-fix:`). If #111 finalizes a stricter grammar (e.g. a required machine token), the `_MUST_FIX_LABEL_RE` / `_is_changes_requested` recognition set should be reconciled against it at review — both accept the same bare/bold field forms today, so drift is low-risk.

## Related Issues
Closes #98

## Review Checklist
- [ ] Reviewed by another team member
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)
