### PR TITLE
feat(hooks): validate_review_comment_format — enforce charter verdict-comment grammar (#111)

### DIFF
--- a/.claude/framework.config.json
+++ b/.claude/framework.config.json
@@ -42,6 +42,7 @@
       "no_worktree_self_delete",
       "warn_zsh_wordsplit",
       "validate_labels",
+      "validate_review_comment_format",
       "validate_workflow_paths_coverage",
       "validate_pr_ci_status",
       "block_squash_wave_merge"

--- a/.claude/team/charter/hooks.md
+++ b/.claude/team/charter/hooks.md
@@ -19,6 +19,7 @@ stdlib-only and fail open — a broken hook never blocks unrelated work.
 | Don't merge red CI ([pull-requests.md](pull-requests.md)) | `validate_pr_ci_status` | PreToolUse (Bash) | Blocks `gh pr merge` when any status check is failing/pending |
 | Identity survives the merge ([commits.md](commits.md)) | `block_squash_wave_merge` | PreToolUse (Bash) | Blocks `gh pr merge --squash` into an integration branch when identity is enforced (squash rewrites the author) |
 | Labels must exist ([issues.md](issues.md)) | `validate_labels` | PreToolUse (Bash) | Validates `--label` values before `gh issue create` |
+| Verdict-comment grammar ([issues.md](issues.md)) | `validate_review_comment_format` | PreToolUse (Bash) | Blocks a `gh pr comment` / `gh issue comment` whose body attempts the charter header but is malformed (missing field or unknown `RequestOrReplied` token) — keeps the shape `trust_signals.py` parses reliable (#98) |
 | CI covers what a PR touches ([pull-requests.md](pull-requests.md)) | `validate_workflow_paths_coverage` | PreToolUse (Bash) | Blocks `gh pr create` when changed workflow-relevant paths escape every CI `paths:` filter |
 | Push unpiped ([pull-requests.md](pull-requests.md)) | `warn_pipe_mask_rc` | PostToolUse (Bash) | Flags `git push` / `gh pr merge` piped through rc-masking commands |
 | Shell safety | `warn_zsh_wordsplit` | PreToolUse (Bash) | Advisory on bash-isms under zsh (when `shell: zsh`) |

--- a/.claude/team/charter/issues.md
+++ b/.claude/team/charter/issues.md
@@ -68,6 +68,46 @@ RequestOrReplied: Request
 - **Requestee** = the person being asked (`N/A` for general status updates).
 - **RequestOrReplied** = `Request` when posting, `Replied` when responding.
 
+### Verdict-Comment Grammar (machine-parsed — single source of truth)
+
+PR **review verdicts** use the same three-line header, and additionally carry the
+review outcome in the **body** via two severity markers:
+
+```
+Requestor: Firstname.Lastname
+Requestee: Firstname.Lastname
+RequestOrReplied: Request
+
+**Review: <one-line summary>**
+Must-fix: <enumerated items, or None>
+Tech-debt: <items, or None>
+```
+
+This shape is a **machine grammar**, not just a convention — two tools read it and
+must agree on the vocabulary:
+
+- **`validate_review_comment_format`** (a PreToolUse hook) *enforces* it: a
+  `gh pr comment` / `gh issue comment` whose body attempts the header but is
+  malformed (a missing/mistyped field, an unknown verdict token) is blocked at
+  write time.
+- **`trust_signals.py`** *parses* it to score review quality (issue #98): the
+  `Requestor:` line is the reviewer identity, `RequestOrReplied:` is the verdict
+  state, and the body `Must-fix:` tally is the severity.
+
+Canonical vocabulary (both tools bind to these exact tokens):
+
+| Element | Label | Allowed values | Meaning |
+|---------|-------|----------------|---------|
+| Header | `Requestor:` | a name (bare or `**bold**`) | comment author / reviewer |
+| Header | `Requestee:` | a name, or `N/A` | who is addressed / the PR author |
+| Header | `RequestOrReplied:` | **`Request`** \| **`Replied`** | posting a verdict / replying |
+| Body | `Must-fix:` | enumerated items, or `None` | enumerated ⇒ **changes requested** (blocks merge); `None` ⇒ clean |
+| Body | `Tech-debt:` | items, or `None` | non-blocking; tracked as issues |
+
+Severity lives in the **body** (`Must-fix:`), never in the verdict token — do not
+write `RequestOrReplied: Approved` or `ChangesRequested`. Both the bare
+(`Requestor: Name`) and bold (`**Requestor:** Name`) header forms are accepted.
+
 ## Reply Protocol
 
 When tagged as **Requestee** on a `Request` comment, respond on the same issue with

--- a/framework/assets/hooks/_framework_config.py
+++ b/framework/assets/hooks/_framework_config.py
@@ -93,6 +93,7 @@ _DEFAULTS: dict[str, Any] = {
             "no_worktree_self_delete",
             "warn_zsh_wordsplit",
             "validate_labels",
+            "validate_review_comment_format",
             "validate_workflow_paths_coverage",
             "validate_pr_ci_status",
             "block_squash_wave_merge",

--- a/framework/assets/hooks/validate_review_comment_format.py
+++ b/framework/assets/hooks/validate_review_comment_format.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: enforce the charter verdict-comment grammar on gh comments.
+
+Gates ``gh pr comment`` / ``gh issue comment`` invocations. When the comment
+body is *attempting* the charter verdict-comment shape (it carries at least one
+of the header labels) but the shape is malformed, the command is blocked with an
+actionable message. A comment that carries none of the header labels is a plain
+free-form comment and passes untouched.
+
+Why this exists (companion to #98)
+==================================
+
+``trust_signals.py`` scores review quality by parsing the verdict-comment shape
+out of a PR's comment bodies: the ``Requestor:`` line (reviewer identity), the
+``RequestOrReplied:`` line (the verdict state), and the body ``Must-fix:`` tally
+(severity). If a reviewer posts a comment whose header is malformed — a missing
+``RequestOrReplied:`` line, a mistyped verdict token, an empty field — the parser
+silently skips it and the whole review-quality half of trust scoring reads as
+**zero** (#98). This gate makes the format reliable at write time so those
+signals cannot silently go dark.
+
+Canonical verdict-comment grammar (the vocabulary #98 parses)
+=============================================================
+
+The single source of truth is ``.claude/team/charter/issues.md`` § Comment
+Format / § Verdict-Comment Grammar. Restated here as the enforced contract:
+
+  Header block — all three lines required, bare OR ``**bold**`` form accepted::
+
+      Requestor: Firstname.Lastname          # the comment author (the reviewer)
+      Requestee: Firstname.Lastname          # who is addressed (N/A for status)
+      RequestOrReplied: Request              # Request (posting) | Replied (reply)
+
+  Body severity markers — where the *severity* lives (NOT in the verdict token)::
+
+      Must-fix: <enumerated items, or None>   # enumerated => changes requested
+      Tech-debt: <items, or None>             # non-blocking
+
+Vocabulary constants exported for #98 to align against:
+
+  * ``HEADER_FIELDS``   — the three required header labels, in order.
+  * ``VERDICT_STATES``  — the recognized ``RequestOrReplied`` tokens
+    (``request`` | ``replied``, compared lower-cased).
+  * ``SEVERITY_MARKERS`` — the body severity labels; a ``Must-fix:`` line with
+    enumerated items is the "changes requested" signal, ``None`` / absent is the
+    clean signal.
+
+The header-extraction regexes in ``_STRICT_FIELD_RE`` are kept **byte-identical**
+to ``trust_signals._FIELD_RE`` so this gate enforces exactly what the scorer
+parses. ``test_validate_review_comment_format`` pins that equality.
+
+Fail-open posture (matches the dispatcher)
+==========================================
+
+The check is pure grammar — it needs no config, roster, or network, so it
+trivially works whether or not those are present. It returns ``None`` (allow) on
+every ambiguous edge: not a comment command, no extractable body, an unreadable
+``--body-file``, or a body with no header labels at all. Only a genuine,
+attempted-but-malformed charter comment is blocked.
+
+Exit codes:
+  0 — allow (not a comment command, no body, free-form comment, or well-formed)
+  2 — block (a charter verdict-comment attempt whose header grammar is malformed)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from _framework_log import log_pretooluse_block  # noqa: E402
+from _shell_parse import (  # noqa: E402
+    find_gh_subcommand,
+    iter_command_segments,
+    resolve_tool_cwd,
+    strip_heredocs,
+    tokenize,
+    walk_flag_values,
+)
+
+# --------------------------------------------------------------------------- #
+# Canonical grammar — the vocabulary #98 aligns against.
+# --------------------------------------------------------------------------- #
+
+#: The three required header labels, in charter order.
+HEADER_FIELDS = ("Requestor", "Requestee", "RequestOrReplied")
+
+#: Recognized ``RequestOrReplied`` tokens (compared lower-cased). Severity does
+#: NOT live here — no ``Approved`` / ``ChangesRequested``; that goes in the body.
+VERDICT_STATES = frozenset({"request", "replied"})
+
+#: Body severity labels. ``Must-fix:`` with enumerated items => changes
+#: requested; ``None`` / absent => clean. ``Tech-debt:`` is non-blocking.
+SEVERITY_MARKERS = ("Must-fix", "Tech-debt")
+
+# The shared header grammar — byte-identical to trust_signals._FIELD_RE. This is
+# what the SCORER (#98) parses; the coupling test pins the equality so the two
+# never drift. Note the ``\s*`` after the colon can span a newline, so an *empty*
+# field silently swallows the next line — which is exactly the "reads as zero"
+# failure mode this gate exists to prevent. The gate therefore validates with the
+# stricter, newline-safe ``_LINE_FIELD_RE`` below (a superset of the scorer's
+# requirements: everything the gate accepts, the scorer also parses).
+_STRICT_FIELD_RE = {
+    "Requestor": re.compile(r"^\**Requestor\**:\**\s*(.+?)\**\s*$", re.MULTILINE),
+    "Requestee": re.compile(r"^\**Requestee\**:\**\s*(.+?)\**\s*$", re.MULTILINE),
+    "RequestOrReplied": re.compile(r"^\**RequestOrReplied\**:\**\s*(\w+)", re.MULTILINE),
+}
+
+# Newline-safe enforcement matcher (gate side). Each field must appear on its OWN
+# line with a **non-empty same-line value** — ``[ \t]`` (never ``\s``) around the
+# colon so the value capture cannot cross into the next line, and ``(\S.*?)``
+# requires at least one non-space character. Bare and ``**bold**`` forms both
+# accepted.
+_LINE_FIELD_RE = {
+    name: re.compile(rf"^\**{name}\**:\**[ \t]*(\S.*?)\s*$", re.MULTILINE)
+    for name in HEADER_FIELDS
+}
+
+# Fuzzy trigger — case-insensitive detection of an *attempted* header line, so a
+# near-miss (wrong casing, missing field) still trips validation rather than
+# slipping through as "not a charter comment". `\b` after the label keeps the
+# `Requestor` alternative from matching inside `RequestOrReplied`.
+_TRIGGER_RE = re.compile(
+    r"^\s*\**\s*(?:Requestor|Requestee|RequestOrReplied)\b\s*\**\s*:",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+# Heredoc body: `<<EOF ... EOF` (and the quoted / `<<-` variants). Group 2 is the
+# body between the opener line and the closing delimiter.
+_HEREDOC_BODY_RE = re.compile(
+    r"<<-?\s*['\"]?(\w+)['\"]?[^\n]*\n(.*?)\n[ \t]*\1\b",
+    re.DOTALL,
+)
+
+_BODY_FLAGS = {"--body", "-b"}
+_BODY_FILE_FLAGS = {"--body-file", "-F"}
+
+
+# --------------------------------------------------------------------------- #
+# Command / body extraction.
+# --------------------------------------------------------------------------- #
+
+
+def is_comment_command(command: str) -> bool:
+    """True if *command* invokes ``gh pr comment`` or ``gh issue comment``."""
+    tokens = tokenize(strip_heredocs(command))
+    if tokens is None:
+        # Malformed quoting defeated the tokenizer — fall back to a conservative
+        # regex so a heredoc-heavy command is still recognized.
+        return bool(re.search(r"\bgh\s+(?:pr|issue)\s+comment\b", command))
+    for seg in iter_command_segments(tokens):
+        gh = find_gh_subcommand(seg)
+        if gh is None:
+            continue
+        _globals, rest = gh
+        if rest[:2] in (["pr", "comment"], ["issue", "comment"]):
+            return True
+    return False
+
+
+def _read_body_file(path_str: str, input_data: dict | None) -> str | None:
+    """Best-effort read of a ``--body-file`` path. None on any failure (fail-open).
+
+    A relative path is resolved against the tool's working directory so a
+    comment posted with ``--body-file relative/path.md`` is still inspectable.
+    """
+    try:
+        p = Path(path_str)
+        if not p.is_absolute() and input_data is not None:
+            cwd = resolve_tool_cwd(input_data)
+            if cwd:
+                p = Path(cwd) / p
+        return p.read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return None
+
+
+def extract_comment_body(command: str, input_data: dict | None = None) -> str | None:
+    """Extract the comment body from a ``gh ... comment`` command, or None.
+
+    Resolution order: a heredoc body (``--body "$(cat <<'EOF' ... EOF)"`` and
+    friends) first, then an inline ``--body``/``-b`` value, then a best-effort
+    read of a ``--body-file``/``-F`` path. Returns None when nothing is
+    extractable — the caller fails open.
+    """
+    heredoc = _HEREDOC_BODY_RE.search(command)
+    if heredoc:
+        return heredoc.group(2)
+
+    tokens = tokenize(command)
+    if tokens is not None:
+        inline = walk_flag_values(tokens, _BODY_FLAGS)
+        if inline:
+            return inline[0]
+        files = walk_flag_values(tokens, _BODY_FILE_FLAGS)
+        if files:
+            return _read_body_file(files[0], input_data)
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Grammar validation (pure).
+# --------------------------------------------------------------------------- #
+
+
+def looks_like_charter_comment(body: str) -> bool:
+    """True if *body* carries at least one (fuzzy) header label — i.e. it is an
+    *attempt* at the charter verdict-comment shape."""
+    return bool(_TRIGGER_RE.search(body))
+
+
+_MISSING_REASON = (
+    "BLOCKED: charter verdict-comment is malformed — missing or misformatted "
+    "header field(s): {fields}.\n\n"
+    "Every PR/issue verdict comment MUST open with all three header lines "
+    "(bare or **bold** form both accepted):\n\n"
+    "  Requestor: Firstname.Lastname        # the reviewer (comment author)\n"
+    "  Requestee: Firstname.Lastname        # the PR author (N/A for status)\n"
+    "  RequestOrReplied: Request            # Request (posting) | Replied (reply)\n\n"
+    "Severity is carried in the BODY, not the verdict token:\n"
+    "  Must-fix: <enumerated items, or None>   # enumerated = changes requested\n"
+    "  Tech-debt: <items, or None>             # non-blocking\n\n"
+    "trust_signals.py (#98) parses this exact shape to score review quality; a "
+    "malformed header makes those signals read as zero."
+)
+
+_VERDICT_REASON = (
+    "BLOCKED: RequestOrReplied value {got!r} is not a recognized verdict state.\n"
+    "Use exactly one of:  Request  (posting)  |  Replied  (responding).\n\n"
+    "Do NOT put severity in the verdict token (no 'Approved' / "
+    "'ChangesRequested') — severity belongs in the body as 'Must-fix:' items "
+    "(enumerated = changes requested, 'None' = clean). trust_signals.py (#98) "
+    "reads Request/Replied plus the body Must-fix tally; an unrecognized token "
+    "makes the review signals read as zero."
+)
+
+
+def validate_grammar(body: str) -> str | None:
+    """Return a block reason if the charter comment is malformed, else None."""
+    matches = {name: _LINE_FIELD_RE[name].search(body) for name in HEADER_FIELDS}
+    missing = [name for name in HEADER_FIELDS if not matches[name]]
+    if missing:
+        return _MISSING_REASON.format(fields=", ".join(missing))
+
+    # The verdict value may carry a trailing annotation (e.g. "Request (re-review)");
+    # the token is the first word.
+    verdict = matches["RequestOrReplied"].group(1).split()[0].strip("*").strip()
+    if verdict.lower() not in VERDICT_STATES:
+        return _VERDICT_REASON.format(got=verdict)
+
+    return None
+
+
+def check(input_data: dict) -> dict | None:
+    """Block result dict if a malformed charter verdict-comment is detected, else
+    None. Fails open on every ambiguous edge (see module docstring)."""
+    if input_data.get("tool_name") != "Bash":
+        return None
+
+    command = input_data.get("tool_input", {}).get("command", "")
+    if not is_comment_command(command):
+        return None
+
+    body = extract_comment_body(command, input_data)
+    if not body:
+        return None  # nothing inspectable (e.g. unreadable --body-file) → allow
+
+    if not looks_like_charter_comment(body):
+        return None  # free-form comment, not a charter verdict-comment attempt
+
+    reason = validate_grammar(body)
+    if reason is None:
+        return None
+
+    log_pretooluse_block(
+        "validate_review_comment_format", command, reason, input_data=input_data
+    )
+    return {"decision": "block", "reason": reason}
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+
+    result = check(input_data)
+    if result and result.get("decision") == "block":
+        print(json.dumps(result))
+        sys.exit(2)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/framework/assets/team/charter/hooks.md
+++ b/framework/assets/team/charter/hooks.md
@@ -19,6 +19,7 @@ stdlib-only and fail open — a broken hook never blocks unrelated work.
 | Don't merge red CI ([pull-requests.md](pull-requests.md)) | `validate_pr_ci_status` | PreToolUse (Bash) | Blocks `gh pr merge` when any status check is failing/pending |
 | Identity survives the merge ([commits.md](commits.md)) | `block_squash_wave_merge` | PreToolUse (Bash) | Blocks `gh pr merge --squash` into an integration branch when identity is enforced (squash rewrites the author) |
 | Labels must exist ([issues.md](issues.md)) | `validate_labels` | PreToolUse (Bash) | Validates `--label` values before `gh issue create` |
+| Verdict-comment grammar ([issues.md](issues.md)) | `validate_review_comment_format` | PreToolUse (Bash) | Blocks a `gh pr comment` / `gh issue comment` whose body attempts the charter header but is malformed (missing field or unknown `RequestOrReplied` token) — keeps the shape `trust_signals.py` parses reliable (#98) |
 | CI covers what a PR touches ([pull-requests.md](pull-requests.md)) | `validate_workflow_paths_coverage` | PreToolUse (Bash) | Blocks `gh pr create` when changed workflow-relevant paths escape every CI `paths:` filter |
 | Push unpiped ([pull-requests.md](pull-requests.md)) | `warn_pipe_mask_rc` | PostToolUse (Bash) | Flags `git push` / `gh pr merge` piped through rc-masking commands |
 | Shell safety | `warn_zsh_wordsplit` | PreToolUse (Bash) | Advisory on bash-isms under zsh (when `shell: zsh`) |

--- a/framework/assets/team/charter/issues.md
+++ b/framework/assets/team/charter/issues.md
@@ -68,6 +68,46 @@ RequestOrReplied: Request
 - **Requestee** = the person being asked (`N/A` for general status updates).
 - **RequestOrReplied** = `Request` when posting, `Replied` when responding.
 
+### Verdict-Comment Grammar (machine-parsed — single source of truth)
+
+PR **review verdicts** use the same three-line header, and additionally carry the
+review outcome in the **body** via two severity markers:
+
+```
+Requestor: Firstname.Lastname
+Requestee: Firstname.Lastname
+RequestOrReplied: Request
+
+**Review: <one-line summary>**
+Must-fix: <enumerated items, or None>
+Tech-debt: <items, or None>
+```
+
+This shape is a **machine grammar**, not just a convention — two tools read it and
+must agree on the vocabulary:
+
+- **`validate_review_comment_format`** (a PreToolUse hook) *enforces* it: a
+  `gh pr comment` / `gh issue comment` whose body attempts the header but is
+  malformed (a missing/mistyped field, an unknown verdict token) is blocked at
+  write time.
+- **`trust_signals.py`** *parses* it to score review quality (issue #98): the
+  `Requestor:` line is the reviewer identity, `RequestOrReplied:` is the verdict
+  state, and the body `Must-fix:` tally is the severity.
+
+Canonical vocabulary (both tools bind to these exact tokens):
+
+| Element | Label | Allowed values | Meaning |
+|---------|-------|----------------|---------|
+| Header | `Requestor:` | a name (bare or `**bold**`) | comment author / reviewer |
+| Header | `Requestee:` | a name, or `N/A` | who is addressed / the PR author |
+| Header | `RequestOrReplied:` | **`Request`** \| **`Replied`** | posting a verdict / replying |
+| Body | `Must-fix:` | enumerated items, or `None` | enumerated ⇒ **changes requested** (blocks merge); `None` ⇒ clean |
+| Body | `Tech-debt:` | items, or `None` | non-blocking; tracked as issues |
+
+Severity lives in the **body** (`Must-fix:`), never in the verdict token — do not
+write `RequestOrReplied: Approved` or `ChangesRequested`. Both the bare
+(`Requestor: Name`) and bold (`**Requestor:** Name`) header forms are accepted.
+
 ## Reply Protocol
 
 When tagged as **Requestee** on a `Request` comment, respond on the same issue with

--- a/framework/config/framework.config.example.json
+++ b/framework/config/framework.config.example.json
@@ -64,6 +64,7 @@
       "no_worktree_self_delete",
       "warn_zsh_wordsplit",
       "validate_labels",
+      "validate_review_comment_format",
       "validate_workflow_paths_coverage",
       "validate_pr_ci_status",
       "block_squash_wave_merge"

--- a/framework/config/framework.config.schema.json
+++ b/framework/config/framework.config.schema.json
@@ -172,7 +172,7 @@
         "pre_bash": {
           "type": "array",
           "items": { "type": "string" },
-          "default": ["block_no_verify", "block_git_config", "no_worktree_self_delete", "warn_zsh_wordsplit", "validate_labels", "validate_workflow_paths_coverage", "validate_pr_ci_status", "block_squash_wave_merge"],
+          "default": ["block_no_verify", "block_git_config", "no_worktree_self_delete", "warn_zsh_wordsplit", "validate_labels", "validate_review_comment_format", "validate_workflow_paths_coverage", "validate_pr_ci_status", "block_squash_wave_merge"],
           "description": "Ordered PreToolUse/Bash checks. Cheap/local first, network-calling (gh) last. First block wins."
         },
         "post_bash": {

--- a/framework/install/bootstrap.py
+++ b/framework/install/bootstrap.py
@@ -127,6 +127,7 @@ def _schema_defaults() -> dict:
                 "no_worktree_self_delete",
                 "warn_zsh_wordsplit",
                 "validate_labels",
+                "validate_review_comment_format",
                 "validate_workflow_paths_coverage",
                 "validate_pr_ci_status",
                 "block_squash_wave_merge",

--- a/framework/tests/test_validate_review_comment_format.py
+++ b/framework/tests/test_validate_review_comment_format.py
@@ -1,0 +1,299 @@
+"""Tests for validate_review_comment_format (issue #111).
+
+The hook enforces the charter verdict-comment grammar on ``gh pr comment`` /
+``gh issue comment`` invocations. Tests cover:
+
+* the pure grammar validator over the **real Phase 3 comment corpus** (PRs #96,
+  #93, #79 — accepted verbatim) plus a Reply and the bold header form;
+* malformed attempts (missing field, empty field, unknown verdict token) — all
+  rejected with an actionable reason;
+* body extraction from heredoc / ``--body`` / ``--body-file`` command shapes;
+* command detection and the fail-open edges (non-comment command, no body,
+  unreadable body-file, free-form comment with no header);
+* a coupling guard pinning the header-extraction grammar to
+  ``trust_signals._FIELD_RE`` so the gate (#111) and the scorer (#98) never
+  drift apart.
+
+Stdlib + pytest only.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_FRAMEWORK_ROOT / "assets" / "hooks"))
+sys.path.insert(0, str(_FRAMEWORK_ROOT / "assets" / "lib"))
+
+import trust_signals as ts  # noqa: E402
+import validate_review_comment_format as hook  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Real Phase 3 corpus (headers verbatim; bodies trimmed). These MUST all pass.
+# --------------------------------------------------------------------------- #
+
+CORPUS_PR96 = """Requestor: Tariq Morales (QA)
+Requestee: Ibrahim El-Amin
+RequestOrReplied: Request
+
+**Review: issues — two release-notes wording corrections; everything else is release-ready**
+
+Must-fix:
+1. **Permissions-allowlist claim is factually wrong.** ...
+2. **Ontology meta/child wording overstates.** ...
+
+Tech-debt: None."""
+
+CORPUS_PR93 = """Requestor: Nia.Rossi
+Requestee: Tariq.Morales
+RequestOrReplied: Request
+
+**Review: LGTM with one must-fix (PR-body record correction)**
+
+**Must-fix:**
+1. Edit the PR body's QA-evidence line ...
+
+**Tech-debt:** filed as #94 ..."""
+
+CORPUS_PR79 = """Requestor: Tariq Morales (QA)
+Requestee: Paloma Gupta
+RequestOrReplied: Request
+
+**Review: issues (one must-fix — merge conflict with the moved base)**
+
+Must-fix:
+1. **Rebase required — PR is CONFLICTING against the base** ...
+
+Tech-debt: None filed."""
+
+CORPUS_REPLY = """Requestor: Ibrahim El-Amin
+Requestee: Nia.Rossi
+RequestOrReplied: Replied
+
+Rebased and pushed; conflicts resolved semantically per your note."""
+
+BOLD_FORM = """**Requestor:** Nia.Rossi
+**Requestee:** Tariq.Morales
+**RequestOrReplied:** Request
+
+**Review: LGTM**
+Must-fix: None
+Tech-debt: None"""
+
+VALID_BODIES = {
+    "pr96": CORPUS_PR96,
+    "pr93": CORPUS_PR93,
+    "pr79": CORPUS_PR79,
+    "reply": CORPUS_REPLY,
+    "bold": BOLD_FORM,
+}
+
+
+def _bash(command: str, cwd: str | None = None) -> dict:
+    d: dict = {"tool_name": "Bash", "tool_input": {"command": command}}
+    if cwd is not None:
+        d["cwd"] = cwd
+    return d
+
+
+def _comment_cmd(body: str, pr: int = 1, sub: str = "pr") -> str:
+    """A ``gh <sub> comment`` command carrying *body* via a heredoc (quote-safe)."""
+    return f"gh {sub} comment {pr} --body \"$(cat <<'EOF'\n{body}\nEOF\n)\""
+
+
+# --------------------------------------------------------------------------- #
+# Pure grammar: the real corpus is accepted.
+# --------------------------------------------------------------------------- #
+
+
+def test_grammar_accepts_every_real_corpus_body() -> None:
+    for name, body in VALID_BODIES.items():
+        assert hook.validate_grammar(body) is None, f"{name} should be well-formed"
+        assert hook.looks_like_charter_comment(body) is True
+
+
+def test_check_accepts_real_corpus_through_command() -> None:
+    for name, body in VALID_BODIES.items():
+        assert hook.check(_bash(_comment_cmd(body))) is None, name
+
+
+def test_check_accepts_issue_comment_subcommand() -> None:
+    assert hook.check(_bash(_comment_cmd(CORPUS_REPLY, sub="issue"))) is None
+
+
+# --------------------------------------------------------------------------- #
+# Pure grammar: malformed attempts are rejected.
+# --------------------------------------------------------------------------- #
+
+
+def test_missing_requestorreplied_blocks() -> None:
+    body = "Requestor: A.One\nRequestee: B.Two\n\nsome review text"
+    reason = hook.validate_grammar(body)
+    assert reason and "RequestOrReplied" in reason
+
+
+def test_missing_requestor_blocks() -> None:
+    body = "Requestee: B.Two\nRequestOrReplied: Request\n\ntext"
+    reason = hook.validate_grammar(body)
+    assert reason and "Requestor" in reason
+
+
+def test_empty_field_value_blocks() -> None:
+    body = "Requestor:\nRequestee: B.Two\nRequestOrReplied: Request"
+    reason = hook.validate_grammar(body)
+    assert reason and "Requestor" in reason
+
+
+def test_lowercase_label_blocks_with_casing_guidance() -> None:
+    # Fuzzy trigger fires (case-insensitive) but the strict, trust_signals-aligned
+    # matcher is case-sensitive, so a lowercase label is a real malformation:
+    # trust_signals would not parse it either.
+    body = "requestor: A.One\nRequestee: B.Two\nRequestOrReplied: Request"
+    assert hook.looks_like_charter_comment(body) is True
+    reason = hook.validate_grammar(body)
+    assert reason and "Requestor" in reason
+
+
+def test_unknown_verdict_token_blocks() -> None:
+    for bad in ("Approved", "ChangesRequested", "Requst", "Done"):
+        body = f"Requestor: A.One\nRequestee: B.Two\nRequestOrReplied: {bad}"
+        reason = hook.validate_grammar(body)
+        assert reason and "verdict state" in reason, bad
+        assert bad in reason
+
+
+def test_check_blocks_malformed_through_command() -> None:
+    body = "Requestor: A.One\nRequestee: B.Two\nRequestOrReplied: Approved"
+    result = hook.check(_bash(_comment_cmd(body)))
+    assert result and result["decision"] == "block"
+    assert "Request" in result["reason"] and "Replied" in result["reason"]
+
+
+# --------------------------------------------------------------------------- #
+# Fail-open edges.
+# --------------------------------------------------------------------------- #
+
+
+def test_free_form_comment_with_no_header_is_allowed() -> None:
+    assert hook.check(_bash(_comment_cmd("LGTM, merging now."))) is None
+
+
+def test_non_comment_commands_ignored() -> None:
+    assert hook.check(_bash("gh pr view 5 --json headRefName")) is None
+    assert hook.check(_bash("git commit -m 'RequestOrReplied: nope'")) is None
+    assert hook.check(_bash("gh pr merge 5 --merge")) is None
+
+
+def test_non_bash_tool_ignored() -> None:
+    assert hook.check({"tool_name": "Agent", "tool_input": {}}) is None
+
+
+def test_prose_mentioning_label_not_treated_as_header() -> None:
+    # "the Requestor is ..." — label not at a line-start-then-colon position.
+    body = "Reminder: the Requestor is always the reviewer, never the author."
+    assert hook.looks_like_charter_comment(body) is False
+
+
+def test_requestor_alternative_does_not_match_inside_requestorreplied() -> None:
+    # A comment with ONLY the RequestOrReplied header (no Requestor/Requestee)
+    # must still trigger — and then fail as missing the other two.
+    body = "RequestOrReplied: Request\n\ntext"
+    assert hook.looks_like_charter_comment(body) is True
+    reason = hook.validate_grammar(body)
+    assert reason and "Requestor" in reason and "Requestee" in reason
+
+
+# --------------------------------------------------------------------------- #
+# Body extraction: heredoc / --body / -F.
+# --------------------------------------------------------------------------- #
+
+
+def test_extract_body_heredoc() -> None:
+    cmd = _comment_cmd(CORPUS_REPLY)
+    assert hook.extract_comment_body(cmd) == CORPUS_REPLY
+
+
+def test_extract_body_inline_flag() -> None:
+    cmd = "gh pr comment 3 --body 'Requestor: A.One'"
+    assert hook.extract_comment_body(cmd) == "Requestor: A.One"
+
+
+def test_extract_body_short_flag() -> None:
+    cmd = "gh pr comment 3 -b 'hello world'"
+    assert hook.extract_comment_body(cmd) == "hello world"
+
+
+def test_extract_body_file_readable(tmp_path: Path) -> None:
+    f = tmp_path / "body.md"
+    f.write_text(CORPUS_PR93, encoding="utf-8")
+    cmd = f"gh pr comment 3 --body-file {f}"
+    assert hook.extract_comment_body(cmd) == CORPUS_PR93
+
+
+def test_body_file_malformed_blocks(tmp_path: Path) -> None:
+    f = tmp_path / "body.md"
+    f.write_text("Requestor: A.One\nRequestee: B.Two\nRequestOrReplied: Nope", encoding="utf-8")
+    cmd = f"gh pr comment 3 --body-file {f}"
+    result = hook.check(_bash(cmd))
+    assert result and result["decision"] == "block"
+
+
+def test_body_file_readable_valid_allowed(tmp_path: Path) -> None:
+    f = tmp_path / "body.md"
+    f.write_text(CORPUS_PR96, encoding="utf-8")
+    cmd = f"gh pr comment 3 -F {f}"
+    assert hook.check(_bash(cmd)) is None
+
+
+def test_unreadable_body_file_fails_open() -> None:
+    cmd = "gh pr comment 3 --body-file /nonexistent/path/does/not/exist.md"
+    assert hook.extract_comment_body(cmd) is None
+    assert hook.check(_bash(cmd)) is None
+
+
+def test_body_file_relative_resolved_against_cwd(tmp_path: Path) -> None:
+    (tmp_path / "note.md").write_text(CORPUS_PR79, encoding="utf-8")
+    cmd = "gh pr comment 3 --body-file note.md"
+    assert hook.extract_comment_body(cmd, {"cwd": str(tmp_path)}) == CORPUS_PR79
+
+
+# --------------------------------------------------------------------------- #
+# Command detection.
+# --------------------------------------------------------------------------- #
+
+
+def test_is_comment_command_variants() -> None:
+    assert hook.is_comment_command("gh pr comment 5 --body x") is True
+    assert hook.is_comment_command("gh issue comment 5 --body x") is True
+    assert hook.is_comment_command("cd repo && gh pr comment 5 -b x") is True
+    assert hook.is_comment_command("gh pr view 5") is False
+    assert hook.is_comment_command("gh pr create --title x") is False
+    # `gh` not at command position (inside echo) is precisely NOT a comment command.
+    assert hook.is_comment_command("echo gh pr comment") is False
+
+
+# --------------------------------------------------------------------------- #
+# Coupling guard: the header grammar is shared with trust_signals (#98).
+# --------------------------------------------------------------------------- #
+
+
+def test_field_regexes_match_trust_signals() -> None:
+    """The gate (#111) must enforce EXACTLY what the scorer (#98) parses."""
+    assert hook._STRICT_FIELD_RE["Requestor"].pattern == ts._FIELD_RE["requestor"].pattern
+    assert hook._STRICT_FIELD_RE["Requestee"].pattern == ts._FIELD_RE["requestee"].pattern
+    assert hook._STRICT_FIELD_RE["RequestOrReplied"].pattern == ts._FIELD_RE["verdict"].pattern
+
+
+def test_exported_vocabulary_constants() -> None:
+    assert hook.HEADER_FIELDS == ("Requestor", "Requestee", "RequestOrReplied")
+    assert hook.VERDICT_STATES == frozenset({"request", "replied"})
+    assert hook.SEVERITY_MARKERS == ("Must-fix", "Tech-debt")
+
+
+def test_wired_into_pre_bash_defaults() -> None:
+    import _framework_config
+
+    pre_bash = _framework_config._DEFAULTS["hooks"]["pre_bash"]
+    assert "validate_review_comment_format" in pre_bash


### PR DESCRIPTION
## Summary
- Adds `validate_review_comment_format` — a PreToolUse gate on `gh pr comment` / `gh issue comment` that blocks a comment whose body **attempts** the charter verdict-comment header but is malformed (missing/empty field, or an unknown `RequestOrReplied` token). Free-form comments with no header pass untouched.
- Makes the charter's review-comment shape reliable at write time so `trust_signals.py` stops silently reading review signals as **zero** — the failure #98 fixes on the parsing side. **This PR defines the vocabulary #98 parses.**
- Narrow pull from the deferred review-gate tranche (NOT the full N-reviewer gate).

## Canonical verdict-comment grammar (the vocab #98 must align to)
Documented in `.claude/team/charter/issues.md` § Verdict-Comment Grammar (and the canonical `framework/assets/` copy):

| Element | Label | Allowed values | Meaning |
|---|---|---|---|
| Header | `Requestor:` | name (bare or `**bold**`) | comment author / reviewer |
| Header | `Requestee:` | name, or `N/A` | addressee / PR author |
| Header | `RequestOrReplied:` | **`Request`** \| **`Replied`** | posting a verdict / replying |
| Body | `Must-fix:` | enumerated items, or `None` | enumerated ⇒ changes requested (blocks merge); `None` ⇒ clean |
| Body | `Tech-debt:` | items, or `None` | non-blocking |

Severity lives in the **body** (`Must-fix:`), never in the verdict token (no `Approved` / `ChangesRequested`). Both bare and bold header forms accepted.

**Coupling with #98:** the hook's `_STRICT_FIELD_RE` is byte-identical to `trust_signals._FIELD_RE`, and `test_field_regexes_match_trust_signals` pins that equality so the gate and the scorer cannot drift. Exported constants `HEADER_FIELDS` / `VERDICT_STATES` / `SEVERITY_MARKERS` are the machine vocab for #98 to bind to.

## Changes
- `framework/assets/hooks/validate_review_comment_format.py` — the hook (pure grammar, fail-open, stdlib + shared `_shell_parse`/`_framework_log`).
- Wired into `hooks.pre_bash` in all synced copies: schema, `_framework_config._DEFAULTS`, `bootstrap._schema_defaults()`, example config, and live dogfood config.
- Charter docs: `issues.md` (grammar spec) + `hooks.md` (enforcement row) — canonical **and** dogfood copies (dual-deploy).
- `framework/tests/test_validate_review_comment_format.py` — real Phase 3 corpus (#96/#93/#79) accepted verbatim, malformed cases blocked, body extraction (heredoc / `--body` / `--body-file`), fail-open edges, coupling guard.

## Verification
- `ruff check framework/` — clean.
- `pytest framework/tests/` — **283 passed** (257 baseline + 26 new).
- Drove the live dispatcher end-to-end: malformed comment → rc 2 (block JSON); valid comment → rc 0.

## Related Issues
Closes #111

## Review Checklist
- [ ] Reviewed by another team member
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTQxgBAcChxvdQJafKyMdX
