### PR TITLE
fix(trust_signals): render {wave} as phase-local ordinal, not global seq (#117)

### DIFF
--- a/framework/assets/lib/trust_signals.py
+++ b/framework/assets/lib/trust_signals.py
@@ -373,7 +373,34 @@ def _phase_for_wave(wave: str, status_path: Path | None) -> str | int | None:
     return val if val is not None else None
 
 
-def _integration_base(cfg, wave: str, phase: str | int | None = None) -> str:
+def _wave_ordinal_for_wave(wave: str, status_path: Path | None) -> str | int | None:
+    """The phase-local ordinal of a wave (``wave_<id>_phase_ordinal``), or None.
+
+    PROJECT-COUPLING: keyed on a state-file entry named
+    ``wave_<id>_phase_ordinal`` stamped by the wave allocator alongside
+    ``wave_<id>_phase`` (see ``lifecycle.py``). A phase-namespaced project numbers
+    its integration branches by the position of the wave *within its phase*
+    (``deployments/phase4/wave-1`` is the first wave of phase 4), not by the
+    monotonic global wave id, so the ``{wave}`` token must resolve to this
+    ordinal. Absent in a generic (non-phased) project — or when the state file is
+    missing/unreadable — → None, and the caller falls back to the global wave id.
+    """
+    if status_path is None:
+        return None
+    try:
+        data = json.loads(Path(status_path).read_text())
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    val = data.get(f"wave_{wave}_phase_ordinal")
+    return val if val is not None else None
+
+
+def _integration_base(
+    cfg,
+    wave: str,
+    phase: str | int | None = None,
+    wave_ordinal: str | int | None = None,
+) -> str:
     """The merged-PR base branch for *wave*, from the integration-branch template.
 
     PROJECT-COUPLING: the original tool scoped the base to a phase+wave path
@@ -383,12 +410,21 @@ def _integration_base(cfg, wave: str, phase: str | int | None = None) -> str:
     declares. Both ``{phase}`` and ``{wave}`` tokens are substituted; a project
     that namespaces waves by phase (``deployments/phase{phase}/wave-{wave}``) is
     resolved correctly when *phase* is supplied (from ``wave_<id>_phase`` state).
+
+    The ``{wave}`` token resolves to the **phase-local ordinal** when
+    *wave_ordinal* is supplied (from ``wave_<id>_phase_ordinal`` state), NOT the
+    global wave id: a phase-namespaced project names its first phase-4 branch
+    ``deployments/phase4/wave-1`` even when that is global wave 2. Falling back to
+    the global *wave* id keeps generic (non-phased) projects — which do not stamp
+    an ordinal — rendering ``deployments/wave-<id>`` unchanged.
+
     A project whose merges target the default branch directly should set
     ``branch.integration`` to that branch name. Unknown/unresolved tokens are
     left literal rather than raising.
     """
     template = cfg.get("branch.integration", "deployments/wave-{wave}")
-    tokens: dict[str, str | int] = {"wave": wave}
+    wave_token = wave_ordinal if wave_ordinal is not None else wave
+    tokens: dict[str, str | int] = {"wave": wave_token}
     if phase is not None:
         tokens["phase"] = phase
     return _render_branch_template(str(template), **tokens)
@@ -474,7 +510,12 @@ def merged_prs(
     """
     cfg = cfg or config()
     repos = _resolve_repos(cfg)
-    base = _integration_base(cfg, wave, phase=_phase_for_wave(wave, status_path))
+    base = _integration_base(
+        cfg,
+        wave,
+        phase=_phase_for_wave(wave, status_path),
+        wave_ordinal=_wave_ordinal_for_wave(wave, status_path),
+    )
     kickoff = _kickoff_ts(wave, status_path)
 
     out: list[dict] = []

--- a/framework/tests/test_trust_signals.py
+++ b/framework/tests/test_trust_signals.py
@@ -410,6 +410,62 @@ def test_phase_for_wave_unreadable_is_none(tmp_path) -> None:
     assert ts._phase_for_wave("1", tmp_path / "does-not-exist.json") is None
 
 
+# ===========================================================================
+# Phase-local wave ordinal (#117): the {wave} token must render the phase-local
+# ordinal (wave_<id>_phase_ordinal), not the global wave seq. The sibling of
+# #100 one layer down — #100 fixed {phase}, this fixes {wave}.
+# ===========================================================================
+
+
+# --------------------------------------------------------------- _wave_ordinal_for_wave
+
+
+def test_wave_ordinal_reads_state(tmp_path) -> None:
+    state = tmp_path / "state.json"
+    # Global wave 2 is the FIRST wave of phase 4 (ordinal 1); global wave 3 the
+    # second (ordinal 2) — the exact Phase 4 shape the retro tripped over.
+    state.write_text(
+        json.dumps({"wave_2_phase_ordinal": 1, "wave_3_phase_ordinal": 2})
+    )
+    assert ts._wave_ordinal_for_wave("2", state) == 1
+    assert ts._wave_ordinal_for_wave("3", state) == 2
+
+
+def test_wave_ordinal_missing_key_is_none(tmp_path) -> None:
+    state = tmp_path / "state.json"
+    state.write_text(json.dumps({"wave_2_phase_ordinal": 1}))
+    assert ts._wave_ordinal_for_wave("9", state) is None
+
+
+def test_wave_ordinal_no_status_path_is_none() -> None:
+    assert ts._wave_ordinal_for_wave("2", None) is None
+
+
+def test_wave_ordinal_unreadable_is_none(tmp_path) -> None:
+    assert ts._wave_ordinal_for_wave("2", tmp_path / "does-not-exist.json") is None
+
+
+# --------------------------------------------------------------- _integration_base ordinal
+
+
+def test_integration_base_uses_phase_local_ordinal() -> None:
+    # THE #117 bug: global wave id 2 is phase 4 ordinal 1 → the branch is
+    # deployments/phase4/wave-1, NOT deployments/phase4/wave-2 (the global id).
+    cfg = _Cfg({"branch.integration": "deployments/phase{phase}/wave-{wave}"})
+    assert (
+        ts._integration_base(cfg, "2", phase=4, wave_ordinal=1)
+        == "deployments/phase4/wave-1"
+    )
+
+
+def test_integration_base_ordinal_falls_back_to_wave_id() -> None:
+    # Generic (non-phased) project: no ordinal stamped → the global wave id fills
+    # {wave}, so deployments/wave-9 still renders for wave 9.
+    cfg = _Cfg({})
+    assert ts._integration_base(cfg, "9") == "deployments/wave-9"
+    assert ts._integration_base(cfg, "9", wave_ordinal=None) == "deployments/wave-9"
+
+
 # --------------------------------------------------------------- end-to-end wiring
 
 
@@ -419,3 +475,36 @@ def test_base_resolved_from_state_end_to_end(tmp_path) -> None:
     cfg = _Cfg({"branch.integration": "deployments/phase{phase}/wave-{wave}"})
     phase = ts._phase_for_wave("1", state)
     assert ts._integration_base(cfg, "1", phase=phase) == "deployments/phase4/wave-1"
+
+
+def test_base_resolves_phase4_wave1_from_global_wave_2(tmp_path) -> None:
+    """The confirmed regression, end to end: scoring global wave 2 (Phase 4 Wave
+    1) must target deployments/phase4/wave-1 — resolving BOTH tokens from state
+    (phase=4, ordinal=1) — so the retro finds the wave's PRs with no override."""
+    state = tmp_path / "state.json"
+    state.write_text(
+        json.dumps(
+            {
+                "wave_2_phase": 4,
+                "wave_2_phase_ordinal": 1,
+                "wave_3_phase": 4,
+                "wave_3_phase_ordinal": 2,
+            }
+        )
+    )
+    cfg = _Cfg({"branch.integration": "deployments/phase{phase}/wave-{wave}"})
+    base = ts._integration_base(
+        cfg,
+        "2",
+        phase=ts._phase_for_wave("2", state),
+        wave_ordinal=ts._wave_ordinal_for_wave("2", state),
+    )
+    assert base == "deployments/phase4/wave-1"
+    # And the current wave (global 3) is the second phase-4 branch.
+    base3 = ts._integration_base(
+        cfg,
+        "3",
+        phase=ts._phase_for_wave("3", state),
+        wave_ordinal=ts._wave_ordinal_for_wave("3", state),
+    )
+    assert base3 == "deployments/phase4/wave-2"


### PR DESCRIPTION
## Issue
Closes #117.

`trust_signals._integration_base` filled the `{wave}` token with the **global wave sequence** id, but a phase-namespaced integration branch is named by the wave's **phase-local ordinal**. Scoring Phase 4 Wave 1 (global wave 2 / phase 4 / ordinal 1) rendered `deployments/phase4/wave-2`, so `gh pr list --base` matched **0 PRs** and the retro scored every engineer empty. This is the sibling of #100 one layer down: #100 made `{phase}` substitutable; `{wave}` was still fed the wrong number.

## Fix
- Add `_wave_ordinal_for_wave(wave, status_path)` mirroring `_phase_for_wave`, reading `wave_<id>_phase_ordinal` from state (stamped by `lifecycle.py` alongside `wave_<id>_phase`).
- `_integration_base` now resolves `{wave}` to the phase-local ordinal when supplied, **falling back to the global wave id** for generic (non-phased) projects that stamp no ordinal.
- `merged_prs` passes the ordinal alongside the phase.

## Verification
- `ruff check framework/` clean; `pytest framework/tests/test_trust_signals.py` → 45 passed.
- New tests: `_wave_ordinal_for_wave` state reader (+ missing-key / no-path / unreadable), phase-ordinal substitution in `_integration_base`, generic fallback, and the end-to-end global-2 → `deployments/phase4/wave-1` wiring.
- **Live proof (no override):** `python3 framework/assets/lib/trust_signals.py extract 2 --status .claude/state.json` from a `deployments/phase4/wave-2` checkout now resolves `deployments/phase4/wave-1` and finds the 4 Wave 1 PRs (#112–#115). Before the fix it found 0. Wave 1 self-scores.

## Dual-deploy (#116)
Canonical `framework/assets/lib/trust_signals.py` edited. There is no live `.claude/lib/trust_signals.py` today (skills fall back to the asset copy), so **no reinstall is needed now**; once #116's reinstall mechanism lands, this change must be reinstalled onto the repo.

## Sequencing vs #119
Independent PR; the diffs are disjoint — this PR touches `_wave_ordinal_for_wave` / `_integration_base` / `merged_prs` (+ tests in the integration-branch section); #119 touches `extract_signals` + new roster helpers (+ tests in a separate section). Verified conflict-free by a local test-merge of both branches: both files auto-merge and the combined `test_trust_signals` suite is 52 green. Both branch off `deployments/phase4/wave-2` and merge in either order.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTQxgBAcChxvdQJafKyMdX

