### PR TITLE
fix(wave-audit): zero-pad issue number in branch fallback match (#90)

### DIFF
--- a/.claude/skills/wave-audit/SKILL.md
+++ b/.claude/skills/wave-audit/SKILL.md
@@ -67,7 +67,11 @@ An orphan is an open issue that:
 Cross-reference the two lists. Also check for issues that were implemented but whose PR forgot
 the `Closes` reference — match by feature-branch name (config `branch.feature`, default
 `{FirstInitial}.{LastName}/{IIII}-{slug}`): a merged PR whose `headRefName` contains
-`/{ISSUE_NUMBER}-` implements that issue.
+`/{ISSUE_NUMBER}-` implements that issue. Match the issue number **zero-padded per the
+`{IIII}` branch grammar** — real branches pad, so issue 65's branch is
+`P.Gupta/0065-meta-child-install`, which contains `/0065-`, not `/65-`. Use `0*{ISSUE}-`
+as the regex (e.g. `0*74-` hits both `/74-` and `/0074-`) so an executor matching the raw
+number verbatim does not miss every padded branch.
 
 ### 5. Report findings to user — MANDATORY confirmation gate
 

--- a/framework/assets/skills/wave-audit/SKILL.md
+++ b/framework/assets/skills/wave-audit/SKILL.md
@@ -67,7 +67,11 @@ An orphan is an open issue that:
 Cross-reference the two lists. Also check for issues that were implemented but whose PR forgot
 the `Closes` reference — match by feature-branch name (config `branch.feature`, default
 `{FirstInitial}.{LastName}/{IIII}-{slug}`): a merged PR whose `headRefName` contains
-`/{ISSUE_NUMBER}-` implements that issue.
+`/{ISSUE_NUMBER}-` implements that issue. Match the issue number **zero-padded per the
+`{IIII}` branch grammar** — real branches pad, so issue 65's branch is
+`P.Gupta/0065-meta-child-install`, which contains `/0065-`, not `/65-`. Use `0*{ISSUE}-`
+as the regex (e.g. `0*74-` hits both `/74-` and `/0074-`) so an executor matching the raw
+number verbatim does not miss every padded branch.
 
 ### 5. Report findings to user — MANDATORY confirmation gate
 


### PR DESCRIPTION
Closes #90.

## Problem
`wave-audit` step 4's no-`Closes`-reference fallback matched a merged PR's
`headRefName` against `/{ISSUE_NUMBER}-` using the raw issue number. Real branches
zero-pad to the `{IIII}` grammar — issue 65 → `P.Gupta/0065-meta-child-install`
(contains `/0065-`, not `/65-`) — so a verbatim match misses every real branch.

## Fix
One-paragraph precision edit to the skill: spell out that the number is zero-padded per
the `{IIII}` grammar and give the `0*{ISSUE}-` regex (matches both `/74-` and `/0074-`).

Canonical `framework/assets/skills/wave-audit/SKILL.md` and live
`.claude/skills/wave-audit/SKILL.md` kept byte-identical (skill-parity test green).

## Tests
`pytest framework/tests/test_skill_parity.py` → 30 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
