### PR TITLE
fix(trust_signals): normalize reviewer/author names against roster (#119)

### DIFF
--- a/framework/assets/lib/trust_signals.py
+++ b/framework/assets/lib/trust_signals.py
@@ -520,6 +520,64 @@ def merged_prs(
     return out
 
 
+# A trailing role/annotation parenthetical on a captured name, e.g. the
+# ``(QA)`` in ``Tariq Morales (QA)`` or ``(Principal SWE)``. Stripped before a
+# name is matched against the roster so the role does not fork the identity.
+_ROLE_SUFFIX_RE = re.compile(r"\s*\([^)]*\)\s*$")
+
+
+def _name_key(name: str) -> str:
+    """Fold a captured name to a roster-match key.
+
+    Collapses the ways one person's name is written across a wave's PRs and
+    verdict comments to a single key: a trailing role parenthetical is dropped
+    (``Tariq Morales (QA)`` → ``Tariq Morales``), dotted separators become spaces
+    (``Tariq.Morales`` → ``Tariq Morales``) while hyphens are preserved
+    (``Ibrahim.El-Amin`` → ``Ibrahim El-Amin``), interior whitespace is collapsed,
+    and the result is lower-cased. Pure — no I/O.
+    """
+    name = _ROLE_SUFFIX_RE.sub("", name)
+    name = name.replace(".", " ")
+    return re.sub(r"\s+", " ", name).strip().lower()
+
+
+def _roster_names(cfg) -> list[str]:
+    """Canonical team names (the roster JSON's keys), or ``[]`` if unavailable.
+
+    Reads ``identity.roster_source`` (default ``.claude/team/roster.json``)
+    relative to the repo root (``cfg.path.parent.parent`` — the config lives at
+    ``<repo>/.claude/framework.config.json``). Fail-open: a missing/unreadable or
+    non-object roster yields ``[]`` so normalization simply passes names through.
+    """
+    if getattr(cfg, "path", None) is None:
+        return []
+    roster_source = cfg.get("identity.roster_source", ".claude/team/roster.json")
+    roster_path = cfg.path.parent.parent / roster_source
+    try:
+        data = json.loads(roster_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return []
+    if not isinstance(data, dict):
+        return []
+    return [str(k) for k in data]
+
+
+def _canonicalizer(cfg):
+    """Return a ``name -> canonical_name`` mapper keyed off the roster.
+
+    Builds ``{_name_key(roster_name): roster_name}`` once, then returns a closure
+    that maps any captured name to its canonical roster identity via
+    :func:`_name_key`. A name absent from the roster is returned unchanged
+    (fail-open) — never dropped, never crashes.
+    """
+    canon_by_key = {_name_key(n): n for n in _roster_names(cfg)}
+
+    def canon(name: str) -> str:
+        return canon_by_key.get(_name_key(name), name)
+
+    return canon
+
+
 def extract_signals(
     wave: str,
     status_path: Path | None = None,
@@ -533,13 +591,20 @@ def extract_signals(
     Reviewer identity is the ``Requestor:`` field of the verdict comment, because
     the SCM principal that posts the comment is typically the orchestrator, not
     the reviewer.
+
+    Both identities are normalized against the roster before bucketing
+    (:func:`_canonicalizer`): a person written ``Tariq.Morales`` in one comment,
+    ``Tariq Morales`` in another, and ``Tariq Morales (QA)`` in a third folds to a
+    single ledger entry instead of splitting their signals across variants. A
+    name absent from the roster passes through unchanged (fail-open).
     """
     cfg = cfg or config()
     prs = merged_prs(wave, status_path, label=label, cfg=cfg)
+    canon = _canonicalizer(cfg)
     signals: dict[str, Signals] = {}
 
     def _bucket(name: str) -> Signals:
-        return signals.setdefault(name, Signals())
+        return signals.setdefault(canon(name), Signals())
 
     for pr in prs:
         author = pr.get("commit_author_name") or "(unknown)"

--- a/framework/tests/test_trust_signals.py
+++ b/framework/tests/test_trust_signals.py
@@ -319,6 +319,153 @@ def test_score_delta_discriminates_clean_reviewer_from_blocked_author():
 
 
 # ===========================================================================
+# Roster name normalization (#119): identity captured as `First.Last`,
+# `First Last`, and `First Last (Role)` must fold to one canonical roster
+# identity before bucketing; a name absent from the roster passes through.
+# ===========================================================================
+
+
+class _RosterCfg:
+    """Config stub with a `.path` so `_roster_names` can resolve the roster file.
+
+    The real config lives at `<repo>/.claude/framework.config.json`, so
+    `cfg.path.parent.parent` is the repo root. Mirrors that layout under tmp.
+    """
+
+    def __init__(self, path: Path, values: dict | None = None) -> None:
+        self.path = path
+        self._v = values or {}
+
+    def get(self, key: str, default=None):
+        return self._v.get(key, default)
+
+
+def _roster_cfg(tmp_path: Path, roster: dict[str, str]) -> _RosterCfg:
+    """Write a roster at the default `identity.roster_source` and return a cfg."""
+    claude = tmp_path / ".claude"
+    (claude / "team").mkdir(parents=True)
+    (claude / "team" / "roster.json").write_text(json.dumps(roster))
+    return _RosterCfg(claude / "framework.config.json")
+
+
+_ROSTER = {
+    "Tariq Morales": "Tariq.Morales@example.com",
+    "Ibrahim El-Amin": "Ibrahim.El-Amin@example.com",
+    "Nia Rossi": "Nia.Rossi@example.com",
+}
+
+
+# --------------------------------------------------------------- _name_key
+
+
+def test_name_key_folds_dotted_spaced_and_role_variants() -> None:
+    # The exact three variants issue #119 names collapse to one key.
+    assert (
+        ts._name_key("Tariq.Morales")
+        == ts._name_key("Tariq Morales")
+        == ts._name_key("Tariq Morales (QA)")
+        == "tariq morales"
+    )
+
+
+def test_name_key_preserves_hyphen_but_folds_dot() -> None:
+    # A dotted first/last separator becomes a space; the hyphen inside a
+    # surname is preserved (Ibrahim.El-Amin -> "ibrahim el-amin").
+    assert ts._name_key("Ibrahim.El-Amin") == "ibrahim el-amin"
+    assert ts._name_key("Ibrahim El-Amin (Senior SWE)") == "ibrahim el-amin"
+
+
+# --------------------------------------------------------------- _canonicalizer
+
+
+def test_canonicalizer_maps_all_variants_to_roster_identity(tmp_path) -> None:
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    for variant in ("Tariq.Morales", "Tariq Morales", "Tariq Morales (QA)"):
+        assert canon(variant) == "Tariq Morales"
+    assert canon("Ibrahim.El-Amin") == "Ibrahim El-Amin"
+
+
+def test_canonicalizer_passes_absent_name_through(tmp_path) -> None:
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    # A name not on the roster is returned verbatim — never dropped, never raised.
+    assert canon("Some Contractor") == "Some Contractor"
+    assert canon("dependabot[bot]") == "dependabot[bot]"
+
+
+def test_canonicalizer_fails_open_without_roster(tmp_path) -> None:
+    # No roster file at all (and cfg with no path) → every name passes through.
+    missing_cfg = _RosterCfg(tmp_path / ".claude" / "framework.config.json")
+    canon = ts._canonicalizer(missing_cfg)
+    assert canon("Tariq.Morales") == "Tariq.Morales"
+    assert ts._canonicalizer(_Cfg({}))("Tariq.Morales") == "Tariq.Morales"
+
+
+# --------------------------------------------------------------- end-to-end bucketing
+
+
+def _account_canon(
+    canon, pr_sets: dict[str, tuple[str, list[str]]]
+) -> dict[str, ts.Signals]:
+    """extract_signals' per-PR accounting with the roster canonicalizer applied
+    to both author and requestor identity — pure (no gh)."""
+    signals: dict[str, ts.Signals] = {}
+
+    def bucket(name: str) -> ts.Signals:
+        return signals.setdefault(canon(name), ts.Signals())
+
+    for _pr, (author, bodies) in pr_sets.items():
+        author_sig = bucket(author)
+        author_sig.prs_merged += 1
+        had_cr = False
+        for v in ts.parse_verdicts(bodies):
+            if v.changes_requested:
+                had_cr = True
+                author_sig.must_fix_received += 1
+                if v.requestor:
+                    bucket(v.requestor).must_fix_caught += 1
+            if v.false_positive and v.requestor:
+                bucket(v.requestor).review_false_positives += 1
+        if had_cr:
+            author_sig.rework_cycles += 1
+    return signals
+
+
+def test_variants_bucket_to_single_engineer_end_to_end(tmp_path) -> None:
+    """The #119 defect, end to end: Tariq reviewing as `Tariq Morales (QA)` on one
+    PR and `Tariq.Morales` on another must land in ONE ledger entry, not split."""
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    # PR96: Tariq (as "(QA)") catches a must-fix on Ibrahim's PR.
+    # PR93: Tariq (as dotted "Tariq.Morales") catches a must-fix on Nia's PR.
+    pr93_by_nia = """Requestor: Tariq.Morales
+Requestee: Nia Rossi
+RequestOrReplied: Request
+
+**Must-fix:**
+1. Correct the recorded numbers.
+"""
+    sigs = _account_canon(
+        canon,
+        {
+            "96": ("Ibrahim El-Amin", [PR96_REQUEST]),
+            "93": ("Nia Rossi", [pr93_by_nia]),
+        },
+    )
+    # Exactly one Tariq bucket — no phantom `Tariq.Morales` split.
+    tariq_keys = [k for k in sigs if "tariq" in k.lower()]
+    assert tariq_keys == ["Tariq Morales"]
+    assert sigs["Tariq Morales"].must_fix_caught == 2
+
+
+def test_absent_reviewer_still_buckets_without_roster(tmp_path) -> None:
+    # Fail-open path: with no roster, the dotted and (Role) forms remain distinct
+    # (unchanged legacy behavior) but nothing crashes or is dropped.
+    canon = ts._canonicalizer(_RosterCfg(tmp_path / ".claude" / "cfg.json"))
+    sigs = _account_canon(canon, {"96": ("Ibrahim El-Amin", [PR96_REQUEST])})
+    assert sigs["Ibrahim El-Amin"].must_fix_received == 1
+    assert sigs["Tariq Morales (QA)"].must_fix_caught == 1
+
+
+# ===========================================================================
 # Integration-branch resolution (#100): phase-aware branch.integration template.
 # ===========================================================================
 


### PR DESCRIPTION
## Issue
Closes #119.

`trust_signals.extract_signals` bucketed reviewer/author identity by the **literal** `Requestor:` string and the head-commit author name, so one person written `Tariq.Morales` (dotted) in one comment, `Tariq Morales` (spaced) in another, and `Tariq Morales (QA)` in a third split across separate ledger entries — the phantom `Tariq.Morales` reviewer the Phase 4 Wave 1 retro surfaced (pre-flagged by Tariq in the #113 review).

## Fix
- `_name_key` folds a captured name to a match key: drop a trailing role parenthetical (`(QA)`), dotted separators → spaces (`Tariq.Morales` → `Tariq Morales`) while **hyphens are preserved** (`Ibrahim.El-Amin` → `Ibrahim El-Amin`), collapse whitespace, lower-case.
- `_canonicalizer(cfg)` builds `{key: roster_name}` from `identity.roster_source` (default `.claude/team/roster.json`, resolved at `cfg.path.parent.parent` = repo root) and maps any name to its canonical roster identity. Applied inside `_bucket`, so **both author and requestor** are normalized.
- **Fail-open:** a name absent from the roster passes through unchanged (never dropped, never crashes); a missing/unreadable/non-object roster degrades to identity passthrough (legacy behavior).

## Verification
- `ruff check framework/` clean; `pytest framework/tests/test_trust_signals.py` → 45 passed.
- New tests: the three variants fold to one key; hyphen preservation; canonicalizer maps all variants to the roster identity; roster-absent passthrough (incl. `dependabot[bot]`); no-roster fail-open; and end-to-end the two Tariq variants land in a single `Tariq Morales` bucket (`must_fix_caught == 2`), with the no-roster path keeping them distinct without crashing.
- **Live proof:** against the real Phase 4 Wave 1 PR set, the phantom `Tariq.Morales` bucket collapses into a single `Tariq Morales` entry.

## Dual-deploy (#116)
Canonical `framework/assets/lib/trust_signals.py` edited. There is no live `.claude/lib/trust_signals.py` today (skills fall back to the asset copy), so **no reinstall is needed now**; once #116's reinstall mechanism lands, this change must be reinstalled onto the repo.

## Sequencing vs #117
Independent PR; the diffs are disjoint — this PR touches `extract_signals` + new roster helpers (+ tests in a dedicated roster section), while #117 touches `_wave_ordinal_for_wave` / `_integration_base` / `merged_prs`. Verified conflict-free by a local test-merge of both branches: both files auto-merge and the combined `test_trust_signals` suite is 52 green. Both branch off `deployments/phase4/wave-2` and merge in either order. Note: a full live re-score of Wave 1 needs **both** #117 (finds the PRs) and #119 (merges the identities); this PR was proven live by pointing extraction at the Wave-1 base directly.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTQxgBAcChxvdQJafKyMdX

