### PR TITLE
fix(ontology-gen): exclude installed framework runtime in consumer repos (#74)

### DIFF
--- a/framework/assets/lib/ontology_gen/generate.py
+++ b/framework/assets/lib/ontology_gen/generate.py
@@ -52,10 +52,30 @@ _IGNORE_DIRS = frozenset(
 )
 # Always skipped even under git discovery (scratch checkouts of other branches).
 _ALWAYS_SKIP_PREFIXES = (".claude/worktrees/",)
+# The framework's OWN installed runtime in a consumer repo (issue #74). A bootstrap install
+# lays ~35 framework internals under .claude/hooks/ + .claude/lib/; indexing them floods a
+# target repo's structural index with framework noise instead of the user's code. Skipped in
+# consumer repos only — the framework SOURCE repo's .claude/ is a live dogfood copy worth
+# indexing, so it keeps the current behaviour (see _is_framework_source_repo).
+_INSTALLED_RUNTIME_PREFIX = ".claude/"
 # Vendored deps / build output — skipped in BOTH discovery modes, even when committed.
 # git ls-files trusts tracked files, so repos that commit node_modules/dist/coverage would
 # otherwise flood the index with thousands of vendored/generated files.
 _ALWAYS_SKIP_DIRS = frozenset({"node_modules", "dist", "build", "coverage"})
+
+
+def _is_framework_source_repo(repo_root: Path) -> bool:
+    """True when ``repo_root`` is the framework SOURCE checkout, not a consumer install.
+
+    The source repo ships the canonical install dirs (``framework/assets`` +
+    ``framework/install``); a repo that merely *installed* the framework has a populated
+    ``.claude/`` but none of that source tree. This gate decides whether the installed
+    ``.claude/`` runtime is the framework's own dogfood (index it) or deployed noise in a
+    consumer repo (skip it — issue #74).
+    """
+    return (repo_root / "framework" / "assets").is_dir() and (
+        repo_root / "framework" / "install"
+    ).is_dir()
 
 
 def _git_listed_files(repo_root: Path) -> list[str] | None:
@@ -89,9 +109,13 @@ def discover(repo_root: Path) -> list[str]:
     """Repo-relative POSIX paths of supported source files, sorted, dedup-stable."""
     listed = _git_listed_files(repo_root)
     candidates = listed if listed is not None else _walk_files(repo_root)
+    skip_prefixes = _ALWAYS_SKIP_PREFIXES
+    if not _is_framework_source_repo(repo_root):
+        # Consumer repo: drop the framework's own installed .claude/ runtime (#74).
+        skip_prefixes = skip_prefixes + (_INSTALLED_RUNTIME_PREFIX,)
     out: list[str] = []
     for rel in candidates:
-        if rel.startswith(_ALWAYS_SKIP_PREFIXES):
+        if rel.startswith(skip_prefixes):
             continue
         # Exclude vendored/build dirs at any depth, even when git-tracked.
         if any(part in _ALWAYS_SKIP_DIRS for part in rel.split("/")[:-1]):

--- a/framework/tests/test_ontology_gen.py
+++ b/framework/tests/test_ontology_gen.py
@@ -67,6 +67,45 @@ def test_generate_skips_committed_vendored_dirs(tmp_path: Path) -> None:
     assert "node_modules" not in llms and "/dist/" not in llms
 
 
+def test_generate_skips_installed_runtime_in_consumer_repo(tmp_path: Path) -> None:
+    """Issue #74: a target repo's index must exclude the framework's installed .claude/ runtime."""
+    _git_init(tmp_path)
+    (tmp_path / "app.py").write_text("def main():\n    return 0\n")
+    # The framework install lays ~35 internals under .claude/hooks + .claude/lib.
+    for rel in ("hooks/dispatcher.py", "lib/ontology_gen/generate.py"):
+        f = tmp_path / ".claude" / rel
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text("def _framework_internal():\n    return 1\n")
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+
+    counts = generate(tmp_path, tmp_path / "out", "demo")
+
+    assert counts["files"] == 1  # only app.py — the installed runtime is skipped
+    llms = (tmp_path / "out" / "llms.txt").read_text()
+    assert "## app.py [python]" in llms
+    assert ".claude/hooks" not in llms and ".claude/lib" not in llms
+
+
+def test_generate_indexes_dogfood_claude_in_framework_source_repo(tmp_path: Path) -> None:
+    """The framework SOURCE repo's own .claude/ is a live dogfood copy — keep indexing it (#74)."""
+    _git_init(tmp_path)
+    (tmp_path / "app.py").write_text("def main():\n    return 0\n")
+    # Marker of the source checkout: the canonical install dirs it ships.
+    for src_dir in ("framework/assets", "framework/install"):
+        (tmp_path / src_dir).mkdir(parents=True, exist_ok=True)
+    (tmp_path / "framework" / "install" / "bootstrap.py").write_text("def main():\n    return 0\n")
+    dogfood = tmp_path / ".claude" / "hooks" / "dispatcher.py"
+    dogfood.parent.mkdir(parents=True, exist_ok=True)
+    dogfood.write_text("def dispatch():\n    return 1\n")
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+
+    counts = generate(tmp_path, tmp_path / "out", "demo")
+
+    llms = (tmp_path / "out" / "llms.txt").read_text()
+    assert "## .claude/hooks/dispatcher.py [python]" in llms  # dogfood copy indexed
+    assert counts["files"] == 3  # app.py + bootstrap.py + the dogfood hook
+
+
 def test_generate_import_edge_resolves(tmp_path: Path) -> None:
     _git_init(tmp_path)
     (tmp_path / "a.py").write_text("import b\n")


### PR DESCRIPTION
Closes #74.

## Problem
In a fresh target repo the generated structural index was dominated by the framework's
own installed runtime. A bootstrap install lays ~35 internals under `.claude/hooks/` +
`.claude/lib/`, and `discover()` only skipped `.claude/worktrees/` — so a scratch install
with a single `app.py` produced 36 indexed files, 35 of them framework internals.

## Fix
`ontology_gen.generate.discover()` now excludes the whole installed `.claude/` tree in
**consumer** repos. The framework **source** checkout is detected by the canonical install
dirs it ships (`framework/assets` + `framework/install`); there `.claude/` is a live dogfood
copy and stays indexed (current behaviour preserved). Zero-config — no new config keys.

## Tests (`framework/tests/test_ontology_gen.py`)
- `test_generate_skips_installed_runtime_in_consumer_repo` — consumer repo with
  `.claude/hooks` + `.claude/lib` indexes only `app.py`.
- `test_generate_indexes_dogfood_claude_in_framework_source_repo` — source-marked repo
  still indexes its `.claude/` dogfood copy.

`pytest framework/tests/test_ontology_gen.py` → 18 passed. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
