### PR TITLE
feat(hooks): verdict-comment semantic warn tier + charter clarity (#118)

### DIFF
--- a/.claude/team/charter/issues.md
+++ b/.claude/team/charter/issues.md
@@ -108,6 +108,62 @@ Severity lives in the **body** (`Must-fix:`), never in the verdict token — do 
 write `RequestOrReplied: Approved` or `ChangesRequested`. Both the bare
 (`Requestor: Name`) and bold (`**Requestor:** Name`) header forms are accepted.
 
+Use roster-canonical `Firstname.Lastname` in the `Requestor:` / `Requestee:`
+fields (the exact form the roster carries) — `trust_signals.py` keys reviewer
+identity off that field, so a nickname or role suffix (`Tariq (QA)`) attributes
+the signal to the wrong (or no) engineer.
+
+### Request vs. Replied, Must-fix vs. Tech-debt (semantics)
+
+The tokens carry meaning beyond their shape. `validate_review_comment_format`
+enforces the **shape** (a malformed header is *blocked*) and — since #118 —
+*warns* (fail-open, never blocks) when the **semantics** below are misused:
+
+- **`RequestOrReplied: Request`** — a turn that **carries blocking findings**:
+  the body's `Must-fix:` section enumerates ≥1 item that must be resolved before
+  merge. Use `Request` when you are asking for changes.
+- **`RequestOrReplied: Replied`** — a **response or approval** turn: a reply to a
+  `Request`, or a review that clears the PR with no blocking items. An approving
+  review whose `Must-fix:` is `None` should be `Replied`, **not** `Request`.
+- **`Must-fix:` is blocking-only** — every item under it is counted by
+  `trust_signals.py` as a blocking `must_fix_received` signal against the author.
+  Put **only** items that must hold the merge here.
+- **`Tech-debt:` for everything non-blocking** — nits, follow-ups, "accept
+  as-is" notes, reviewer-name corrections, anything you would *not* hold the
+  merge for. Tracked as issues; never scored as blocking.
+
+Two Phase-4-Wave-1 misuses the warn tier now flags (each surfaced a phantom
+blocking signal that flattened the trust matrix):
+
+| Misuse | Why it's wrong | Fix |
+|--------|----------------|-----|
+| Approval filed as `Request` with `Must-fix: None` | `Request` implies blocking findings; there are none | use `Replied` |
+| A non-blocking note under `Must-fix:` ("non-blocking", "do not hold", "accept as-is") | scored as a blocking `must_fix_received` | move it to `Tech-debt:` |
+
+Examples — an approval and a changes-requested review:
+
+```
+Requestor: Nia.Rossi
+Requestee: Ibrahim.El-Amin
+RequestOrReplied: Replied          # approval, no blocking items → Replied
+
+**Review: LGTM — ships as-is**
+Must-fix: None
+Tech-debt: None
+```
+
+```
+Requestor: Tariq.Morales
+Requestee: Paloma.Gupta
+RequestOrReplied: Request          # carries a blocking item → Request
+
+**Review: one must-fix**
+Must-fix:
+1. Rebase — the branch is CONFLICTING against the moved base.
+Tech-debt:
+1. Reviewer-name string reads "Tariq (QA)"; prefer canonical `Tariq.Morales` (non-blocking).
+```
+
 ## Reply Protocol
 
 When tagged as **Requestee** on a `Request` comment, respond on the same issue with

--- a/framework/assets/hooks/validate_review_comment_format.py
+++ b/framework/assets/hooks/validate_review_comment_format.py
@@ -49,6 +49,34 @@ The header-extraction regexes in ``_STRICT_FIELD_RE`` are kept **byte-identical*
 to ``trust_signals._FIELD_RE`` so this gate enforces exactly what the scorer
 parses. ``test_validate_review_comment_format`` pins that equality.
 
+Two tiers: block (grammar) vs warn (semantics) — issue #118
+===========================================================
+
+The gate separates a *structural* failure (which blocks) from a *semantic*
+misuse (which only warns, fail-open):
+
+  * **Block** — a malformed header (missing/mistyped field, unknown verdict
+    token). The comment cannot be parsed by the scorer at all, so it is stopped
+    at write time. This is the #111 contract, unchanged.
+
+  * **Warn** — the header is well-formed but the Request-vs-Replied /
+    Must-fix-vs-Tech-debt *semantics* are misused. Phase 4 Wave 1 surfaced two
+    patterns that contaminated trust deltas (issue #118):
+
+      1. ``RequestOrReplied: Request`` with an empty/``None`` Must-fix — an
+         approval filed as a posting turn. It reads clean to the scorer, but the
+         charter reserves ``Request`` for a turn that carries blocking findings;
+         an approval with none should be ``Replied``.
+      2. A ``Must-fix:`` item phrased as *non-blocking* ("non-blocking", "do not
+         hold", "accept as-is", …) — a Tech-debt note filed under the blocking
+         label. ``trust_signals.py`` counts it as ``must_fix_received``, a
+         phantom negative signal.
+
+    Both only *warn* (``{"decision": "allow", "systemMessage": ...}``): the
+    author's intent may be legitimate, and blocking a well-formed comment over a
+    phrasing judgment would be too aggressive. The dispatcher surfaces the
+    systemMessage and still allows the command.
+
 Fail-open posture (matches the dispatcher)
 ==========================================
 
@@ -56,10 +84,12 @@ The check is pure grammar — it needs no config, roster, or network, so it
 trivially works whether or not those are present. It returns ``None`` (allow) on
 every ambiguous edge: not a comment command, no extractable body, an unreadable
 ``--body-file``, or a body with no header labels at all. Only a genuine,
-attempted-but-malformed charter comment is blocked.
+attempted-but-malformed charter comment is blocked; a well-formed comment with a
+semantic misuse is *warned*, never blocked.
 
 Exit codes:
-  0 — allow (not a comment command, no body, free-form comment, or well-formed)
+  0 — allow (not a comment command, no body, free-form comment, well-formed, or
+      a well-formed comment carrying only a semantic warning)
   2 — block (a charter verdict-comment attempt whose header grammar is malformed)
 """
 
@@ -97,6 +127,46 @@ VERDICT_STATES = frozenset({"request", "replied"})
 #: Body severity labels. ``Must-fix:`` with enumerated items => changes
 #: requested; ``None`` / absent => clean. ``Tech-debt:`` is non-blocking.
 SEVERITY_MARKERS = ("Must-fix", "Tech-debt")
+
+# --------------------------------------------------------------------------- #
+# Body-severity parsing for the SEMANTIC warn tier (#118).
+#
+# These mirror ``trust_signals._has_must_fix_items`` byte-for-byte (the coupling
+# test pins the equality) so the gate's warn aligns with exactly what the scorer
+# counts as a Must-fix. They are re-declared here rather than imported so the
+# hook keeps its zero-dependency, fail-open posture: ``trust_signals`` lives in
+# ``assets/lib`` which is not on the hook runtime's ``sys.path``, and importing
+# it would make the gate crash (and silently skip) in a real install.
+# --------------------------------------------------------------------------- #
+
+#: The ``Must-fix:`` label line; group 1 captures any same-line remainder.
+_MUST_FIX_LABEL_RE = re.compile(r"^\s*\**must[\s-]?fix\**:\s*(.*?)\s*$", re.IGNORECASE)
+#: An enumerated / bulleted list item (``1.`` / ``2)`` / ``-`` / ``*`` / ``+``).
+_LIST_ITEM_RE = re.compile(r"^\s*(?:\d+[.)]|[-*+])\s+\S")
+#: An explicit "no findings" value (``None`` / ``N/A`` / ``-`` / ``0``).
+_EMPTY_MUST_FIX_RE = re.compile(r"^(none|n/?a|-+|0)(?:\W|$)", re.IGNORECASE)
+
+#: Non-blocking phrasing that does NOT belong under ``Must-fix:`` — it belongs
+#: under ``Tech-debt:``. A ``Must-fix`` item carrying any of these is the Wave-1
+#: misuse pattern that produced a phantom ``must_fix_received``.
+_NON_BLOCKING_PHRASE_RE = re.compile(
+    r"\bnon[\s-]?blocking\b"
+    r"|\bnot\s+(?:a\s+)?block(?:er|ing)?\b"
+    r"|\bdo(?:es)?\s*n['’o]?t\s+(?:block|hold)\b"
+    r"|\bdon['’]t\s+(?:block|hold)\b"
+    r"|\bno\s+need\s+to\s+(?:block|hold)\b"
+    r"|\bwo?n['’]?t\s+(?:block|hold)\b"
+    r"|\bwill\s+not\s+(?:block|hold)\b"
+    r"|\baccept\s+as[\s-]?is\b"
+    r"|\bnot\s+a\s+merge\s+blocker\b",
+    re.IGNORECASE,
+)
+
+#: Fenced / inline code stripping, so the ``must-fix`` token or the non-blocking
+#: vocabulary inside a code span or test name is never counted (mirrors
+#: ``trust_signals._strip_code_markup``).
+_FENCED_CODE_RE = re.compile(r"```.*?```|~~~.*?~~~", re.DOTALL)
+_INLINE_CODE_RE = re.compile(r"`[^`\n]+`")
 
 # The shared header grammar — byte-identical to trust_signals._FIELD_RE. This is
 # what the SCORER (#98) parses; the coupling test pins the equality so the two
@@ -256,8 +326,111 @@ def validate_grammar(body: str) -> str | None:
     return None
 
 
+# --------------------------------------------------------------------------- #
+# Semantic warnings (pure) — the WARN tier (#118). Fail-open: never blocks.
+# --------------------------------------------------------------------------- #
+
+
+def _strip_code_markup(text: str) -> str:
+    """Blank out fenced blocks and inline code spans (positions preserved)."""
+    text = _FENCED_CODE_RE.sub(lambda m: " " * len(m.group()), text)
+    text = _INLINE_CODE_RE.sub(lambda m: " " * len(m.group()), text)
+    return text
+
+
+def _must_fix_items(body: str) -> list[str]:
+    """Return the text of each ``Must-fix:`` item, or ``[]`` when the section is
+    empty / ``None`` / absent.
+
+    Mirrors ``trust_signals._has_must_fix_items``: an inline value on the label
+    line counts as one item (unless it's an explicit "no findings" marker); a
+    bare label takes the following enumerated/bulleted lines. Code spans are
+    stripped first. Only the first ``Must-fix:`` section is read.
+    """
+    lines = _strip_code_markup(body).splitlines()
+    for i, line in enumerate(lines):
+        label_m = _MUST_FIX_LABEL_RE.match(line)
+        if not label_m:
+            continue
+        items: list[str] = []
+        inline = label_m.group(1).strip()
+        if inline and not _EMPTY_MUST_FIX_RE.match(inline):
+            items.append(inline)
+        # Collect following enumerated/bulleted item lines (skipping blanks).
+        j = i + 1
+        while j < len(lines):
+            nxt = lines[j]
+            if not nxt.strip():
+                j += 1
+                continue
+            if _LIST_ITEM_RE.match(nxt):
+                items.append(nxt.strip())
+                j += 1
+                continue
+            break
+        return items
+    return []
+
+
+_WARN_REQUEST_NO_MUSTFIX = (
+    "WARNING (not blocking): RequestOrReplied is `Request` but there are no "
+    "blocking `Must-fix:` items ({detail}). The charter reserves `Request` for a "
+    "turn that carries blocking findings; an approval / response with no "
+    "must-fix should be `RequestOrReplied: Replied` (or add the blocking items "
+    "under `Must-fix:`). Filed as `Request`, trust_signals reads this as a clean "
+    "posting — harmless to the score, but it muddies the Request/Replied "
+    "distinction the charter draws."
+)
+
+_WARN_NONBLOCKING_MUSTFIX = (
+    "WARNING (not blocking): a `Must-fix:` item is phrased as non-blocking "
+    "({quoted}). `Must-fix:` is blocking-only — anything you would NOT hold the "
+    "merge for belongs under `Tech-debt:`. trust_signals counts every Must-fix "
+    "item as a `must_fix_received` negative signal against the author, so a "
+    "non-blocking note filed here becomes a phantom blocking signal (the exact "
+    "Wave-1 contamination this gate now flags)."
+)
+
+
+def semantic_warnings(body: str) -> str | None:
+    """Return a fail-open advisory for a well-formed comment whose Request/Replied
+    or Must-fix/Tech-debt *semantics* are misused, else None.
+
+    Precondition: the header grammar is already valid (``validate_grammar``
+    returned None), so the verdict token parses cleanly. Two patterns warn:
+
+      1. ``Request`` + empty/``None`` Must-fix  -> should be ``Replied``.
+      2. a ``Must-fix:`` item phrased non-blocking -> should be ``Tech-debt:``.
+
+    The two are effectively mutually exclusive (pattern 1 needs an empty
+    Must-fix, pattern 2 needs an item present); the join is kept as a defensive
+    no-op so adding a future pattern needs no rewiring.
+    """
+    verdict_m = _LINE_FIELD_RE["RequestOrReplied"].search(body)
+    if verdict_m is None:  # defensive — grammar was validated upstream
+        return None
+    verdict = verdict_m.group(1).split()[0].strip("*").strip().lower()
+
+    items = _must_fix_items(body)
+    warnings: list[str] = []
+
+    if verdict == "request" and not items:
+        detail = "the `Must-fix:` section is `None`/empty or absent"
+        warnings.append(_WARN_REQUEST_NO_MUSTFIX.format(detail=detail))
+
+    non_blocking = [it for it in items if _NON_BLOCKING_PHRASE_RE.search(it)]
+    if non_blocking:
+        quoted = "; ".join(f'"{it[:80]}"' for it in non_blocking)
+        warnings.append(_WARN_NONBLOCKING_MUSTFIX.format(quoted=quoted))
+
+    if not warnings:
+        return None
+    return "\n\n".join(warnings)
+
+
 def check(input_data: dict) -> dict | None:
-    """Block result dict if a malformed charter verdict-comment is detected, else
+    """Block result dict if a malformed charter verdict-comment is detected, an
+    allow+warning dict if it is well-formed but semantically misused (#118), else
     None. Fails open on every ambiguous edge (see module docstring)."""
     if input_data.get("tool_name") != "Bash":
         return None
@@ -274,13 +447,19 @@ def check(input_data: dict) -> dict | None:
         return None  # free-form comment, not a charter verdict-comment attempt
 
     reason = validate_grammar(body)
-    if reason is None:
-        return None
+    if reason is not None:
+        log_pretooluse_block(
+            "validate_review_comment_format", command, reason, input_data=input_data
+        )
+        return {"decision": "block", "reason": reason}
 
-    log_pretooluse_block(
-        "validate_review_comment_format", command, reason, input_data=input_data
-    )
-    return {"decision": "block", "reason": reason}
+    # Grammar is well-formed. Evaluate the SEMANTIC warn tier (#118): never
+    # blocks, only surfaces an advisory the dispatcher relays.
+    warning = semantic_warnings(body)
+    if warning is not None:
+        return {"decision": "allow", "systemMessage": warning}
+
+    return None
 
 
 def main() -> None:
@@ -293,6 +472,10 @@ def main() -> None:
     if result and result.get("decision") == "block":
         print(json.dumps(result))
         sys.exit(2)
+    if result and result.get("systemMessage"):
+        # Well-formed but semantically misused (#118): surface the advisory and
+        # still allow (fail-open) — matches the dispatcher's warn contract.
+        print(json.dumps(result))
     sys.exit(0)
 
 

--- a/framework/assets/team/charter/issues.md
+++ b/framework/assets/team/charter/issues.md
@@ -108,6 +108,62 @@ Severity lives in the **body** (`Must-fix:`), never in the verdict token — do 
 write `RequestOrReplied: Approved` or `ChangesRequested`. Both the bare
 (`Requestor: Name`) and bold (`**Requestor:** Name`) header forms are accepted.
 
+Use roster-canonical `Firstname.Lastname` in the `Requestor:` / `Requestee:`
+fields (the exact form the roster carries) — `trust_signals.py` keys reviewer
+identity off that field, so a nickname or role suffix (`Tariq (QA)`) attributes
+the signal to the wrong (or no) engineer.
+
+### Request vs. Replied, Must-fix vs. Tech-debt (semantics)
+
+The tokens carry meaning beyond their shape. `validate_review_comment_format`
+enforces the **shape** (a malformed header is *blocked*) and — since #118 —
+*warns* (fail-open, never blocks) when the **semantics** below are misused:
+
+- **`RequestOrReplied: Request`** — a turn that **carries blocking findings**:
+  the body's `Must-fix:` section enumerates ≥1 item that must be resolved before
+  merge. Use `Request` when you are asking for changes.
+- **`RequestOrReplied: Replied`** — a **response or approval** turn: a reply to a
+  `Request`, or a review that clears the PR with no blocking items. An approving
+  review whose `Must-fix:` is `None` should be `Replied`, **not** `Request`.
+- **`Must-fix:` is blocking-only** — every item under it is counted by
+  `trust_signals.py` as a blocking `must_fix_received` signal against the author.
+  Put **only** items that must hold the merge here.
+- **`Tech-debt:` for everything non-blocking** — nits, follow-ups, "accept
+  as-is" notes, reviewer-name corrections, anything you would *not* hold the
+  merge for. Tracked as issues; never scored as blocking.
+
+Two Phase-4-Wave-1 misuses the warn tier now flags (each surfaced a phantom
+blocking signal that flattened the trust matrix):
+
+| Misuse | Why it's wrong | Fix |
+|--------|----------------|-----|
+| Approval filed as `Request` with `Must-fix: None` | `Request` implies blocking findings; there are none | use `Replied` |
+| A non-blocking note under `Must-fix:` ("non-blocking", "do not hold", "accept as-is") | scored as a blocking `must_fix_received` | move it to `Tech-debt:` |
+
+Examples — an approval and a changes-requested review:
+
+```
+Requestor: Nia.Rossi
+Requestee: Ibrahim.El-Amin
+RequestOrReplied: Replied          # approval, no blocking items → Replied
+
+**Review: LGTM — ships as-is**
+Must-fix: None
+Tech-debt: None
+```
+
+```
+Requestor: Tariq.Morales
+Requestee: Paloma.Gupta
+RequestOrReplied: Request          # carries a blocking item → Request
+
+**Review: one must-fix**
+Must-fix:
+1. Rebase — the branch is CONFLICTING against the moved base.
+Tech-debt:
+1. Reviewer-name string reads "Tariq (QA)"; prefer canonical `Tariq.Morales` (non-blocking).
+```
+
 ## Reply Protocol
 
 When tagged as **Requestee** on a `Request` comment, respond on the same issue with

--- a/framework/tests/test_validate_review_comment_format.py
+++ b/framework/tests/test_validate_review_comment_format.py
@@ -90,6 +90,17 @@ VALID_BODIES = {
     "bold": BOLD_FORM,
 }
 
+# Semantically CLEAN bodies: well-formed AND correct Request/Replied +
+# Must-fix/Tech-debt usage, so ``check`` returns None (no block, no warn).
+# BOLD_FORM is intentionally excluded — it is a `Request` with `Must-fix: None`
+# (an approval filed as a posting turn), which the #118 warn tier now flags.
+CLEAN_BODIES = {
+    "pr96": CORPUS_PR96,
+    "pr93": CORPUS_PR93,
+    "pr79": CORPUS_PR79,
+    "reply": CORPUS_REPLY,
+}
+
 
 def _bash(command: str, cwd: str | None = None) -> dict:
     d: dict = {"tool_name": "Bash", "tool_input": {"command": command}}
@@ -114,8 +125,9 @@ def test_grammar_accepts_every_real_corpus_body() -> None:
         assert hook.looks_like_charter_comment(body) is True
 
 
-def test_check_accepts_real_corpus_through_command() -> None:
-    for name, body in VALID_BODIES.items():
+def test_check_accepts_clean_corpus_through_command() -> None:
+    # Semantically clean, well-formed comments pass with no block and no warn.
+    for name, body in CLEAN_BODIES.items():
         assert hook.check(_bash(_comment_cmd(body))) is None, name
 
 
@@ -169,6 +181,110 @@ def test_check_blocks_malformed_through_command() -> None:
     result = hook.check(_bash(_comment_cmd(body)))
     assert result and result["decision"] == "block"
     assert "Request" in result["reason"] and "Replied" in result["reason"]
+
+
+# --------------------------------------------------------------------------- #
+# Semantic WARN tier (#118) — the two Phase 4 Wave 1 misuse patterns. All warn
+# (fail-open) rather than block: a well-formed comment is never stopped.
+# --------------------------------------------------------------------------- #
+
+# WAVE-1 MISUSE #1: an approving reviewer filed the verdict as `Request` with no
+# blocking Must-fix (three Wave-1 approvers did this → phantom clean-Request).
+WAVE1_APPROVAL_AS_REQUEST = """Requestor: Nia.Rossi
+Requestee: Ibrahim.El-Amin
+RequestOrReplied: Request
+
+**Review: LGTM — ships as-is**
+Must-fix: None
+Tech-debt: None"""
+
+# WAVE-1 MISUSE #2: a non-blocking observation filed under `Must-fix:` instead of
+# `Tech-debt:` (→ phantom must_fix_received / review_false_positive in Wave 1).
+WAVE1_NONBLOCKING_UNDER_MUSTFIX = """Requestor: Tariq.Morales
+Requestee: Paloma.Gupta
+RequestOrReplied: Request
+
+**Review: one note**
+Must-fix:
+1. Reviewer-name reads "Tariq (QA)" not the canonical form — non-blocking, do not hold the merge.
+
+Tech-debt: None"""
+
+
+def _warn(body: str) -> str | None:
+    result = hook.check(_bash(_comment_cmd(body)))
+    if result is None:
+        return None
+    assert result["decision"] == "allow", "semantic misuse must WARN, never block"
+    return result["systemMessage"]
+
+
+def test_wave1_approval_as_request_warns_should_be_replied() -> None:
+    msg = _warn(WAVE1_APPROVAL_AS_REQUEST)
+    assert msg is not None, "Request + Must-fix:None must warn"
+    assert "Replied" in msg
+    # It must NOT block: grammar is valid.
+    assert hook.validate_grammar(WAVE1_APPROVAL_AS_REQUEST) is None
+
+
+def test_wave1_nonblocking_under_mustfix_warns_should_be_tech_debt() -> None:
+    msg = _warn(WAVE1_NONBLOCKING_UNDER_MUSTFIX)
+    assert msg is not None, "non-blocking item under Must-fix must warn"
+    assert "Tech-debt" in msg
+    assert hook.validate_grammar(WAVE1_NONBLOCKING_UNDER_MUSTFIX) is None
+
+
+def test_bold_request_with_none_mustfix_warns() -> None:
+    # BOLD_FORM is a bold-header `Request` + `Must-fix: None` — same misuse #1.
+    msg = _warn(BOLD_FORM)
+    assert msg is not None and "Replied" in msg
+
+
+def test_request_with_real_mustfix_does_not_warn() -> None:
+    # The correct use of `Request`: it carries blocking items. No warn.
+    for name in ("pr96", "pr93", "pr79"):
+        assert hook.semantic_warnings(VALID_BODIES[name]) is None, name
+
+
+def test_replied_with_none_mustfix_does_not_warn() -> None:
+    # A `Replied` turn with no must-fix is exactly correct — no warn.
+    assert hook.semantic_warnings(CORPUS_REPLY) is None
+
+
+def test_multiple_nonblocking_phrasings_flagged() -> None:
+    for phrase in ("non-blocking", "do not hold", "accept as-is", "not a blocker",
+                   "won't block", "no need to block"):
+        body = (
+            "Requestor: A.One\nRequestee: B.Two\nRequestOrReplied: Request\n\n"
+            f"Must-fix:\n1. Some note — {phrase}, just tracking it.\n"
+        )
+        assert hook.semantic_warnings(body), phrase
+
+
+def test_must_fix_items_parsing() -> None:
+    assert hook._must_fix_items("Must-fix: None") == []
+    assert hook._must_fix_items("Must-fix: N/A (all resolved)") == []
+    assert hook._must_fix_items("Must-fix:\n1. real item\n2. another") == [
+        "1. real item",
+        "2. another",
+    ]
+    assert hook._must_fix_items("Must-fix: an inline blocking item") == [
+        "an inline blocking item"
+    ]
+    # Code spans are stripped, so a `must-fix` token in code is not a section.
+    assert hook._must_fix_items("see `Must-fix: None` in the parser") == []
+
+
+def test_semantic_code_span_not_flagged() -> None:
+    # Non-blocking vocabulary inside a code span must not trip the warn.
+    body = (
+        "Requestor: A.One\nRequestee: B.Two\nRequestOrReplied: Request\n\n"
+        "Must-fix:\n1. Rename `do_not_hold_flag` to a clearer name.\n"
+    )
+    # The only 'do not hold' is inside a code span → not a non-blocking phrase;
+    # the item itself is a real blocking rename, so no non-blocking warn.
+    msg = hook.semantic_warnings(body)
+    assert msg is None or "Tech-debt" not in msg
 
 
 # --------------------------------------------------------------------------- #
@@ -284,6 +400,14 @@ def test_field_regexes_match_trust_signals() -> None:
     assert hook._STRICT_FIELD_RE["Requestor"].pattern == ts._FIELD_RE["requestor"].pattern
     assert hook._STRICT_FIELD_RE["Requestee"].pattern == ts._FIELD_RE["requestee"].pattern
     assert hook._STRICT_FIELD_RE["RequestOrReplied"].pattern == ts._FIELD_RE["verdict"].pattern
+
+
+def test_must_fix_regexes_match_trust_signals() -> None:
+    """The gate's Must-fix parsing (#118 warn tier) must mirror the scorer's, so
+    the gate warns about exactly what trust_signals counts."""
+    assert hook._MUST_FIX_LABEL_RE.pattern == ts._MUST_FIX_LABEL_RE.pattern
+    assert hook._LIST_ITEM_RE.pattern == ts._LIST_ITEM_RE.pattern
+    assert hook._EMPTY_MUST_FIX_RE.pattern == ts._EMPTY_MUST_FIX_RE.pattern
 
 
 def test_exported_vocabulary_constants() -> None:


### PR DESCRIPTION
## Issue
Closes #118 — verdict-comment grammar: enforce Request-vs-Replied + Must-fix-vs-Tech-debt semantics.

## Problem
The #111 gate (which I authored) enforces verdict-comment **structure** but not **semantics**. In Phase 4 Wave 1 all three approving reviewers wrote `RequestOrReplied: Request` on approvals with no blocking findings, and non-blocking notes were filed under `Must-fix:`. The scorer (correctly) read those as blocking → phantom `must_fix_received` / `review_false_positive` → flat trust matrix.

## Fix (two parts)

**1. Charter clarity** (`team/charter/issues.md`, canonical + live mirror)
New "Request vs. Replied, Must-fix vs. Tech-debt (semantics)" subsection spelling out:
- `Request` ⇒ a turn that **carries blocking Must-fix items**.
- `Replied` ⇒ a **response/approval** turn (approval with `Must-fix: None` → `Replied`, not `Request`).
- `Must-fix:` is **blocking-only**; everything non-blocking → `Tech-debt:`.
- Misuse table (the two Wave-1 patterns) + an approval/changes-requested example pair.
- Roster-canonical `Firstname.Lastname` note for `Requestor:`/`Requestee:` (aligns with #119).

**2. Gate enhancement** (`validate_review_comment_format`) — fail-open WARN tier, never blocks:
- **Warn condition A:** `RequestOrReplied: Request` + empty/`None`/absent `Must-fix:` → suggests `Replied`.
- **Warn condition B:** a `Must-fix:` item phrased non-blocking (`non-blocking`, `not blocking`, `do/does not block|hold`, `don't hold`, `no need to block|hold`, `won't block|hold`, `accept as-is`, `not a (merge) blocker`) → suggests `Tech-debt:`.
- Emits `{"decision":"allow","systemMessage":...}` (the dispatcher's warn contract); the #111 malformed-header **block** path is unchanged.
- Must-fix parsing regexes mirror `trust_signals._has_must_fix_items` byte-for-byte (new coupling test); code spans stripped so a `must-fix` token / non-blocking word inside code or a test name is never counted. Re-declared, not imported, to keep the hook zero-dependency and fail-open (trust_signals isn't on the hook runtime's sys.path).

## Tests
`framework/tests/test_validate_review_comment_format.py` — added the two Wave-1 misuse patterns as explicit cases, bold-form warn, clean-corpus no-warn, non-blocking-phrasing variants, code-span guards, must-fix parsing, and the trust_signals coupling. **35 gate tests pass; full framework suite 340 pass; `ruff check framework/` clean.** Verified end-to-end through the real `dispatcher.py`: misuse-1 → warn(allow), misuse-2 → warn(allow), malformed verdict → block(exit 2).

## Coordination flags
- **#116 (Ibrahim, installer/hook wiring):** this touches `validate_review_comment_format.py` (hook surface) but **not** config/schema/`_framework_config` — no overlap with the wiring surface. It does need the reinstall #116 delivers (see below).
- **#119 (Paloma, reviewer-name normalization):** charter now instructs roster-canonical `Firstname.Lastname` in `Requestor:`/`Requestee:` — aligned with the normalization #119 performs.
- **#94 (mine):** touches a different charter file (`pull-requests.md`); kept coherent.

## Dual-deploy + reinstall (#116)
The hook runs from `framework/assets/hooks/` via `$CLAUDE_PROJECT_DIR` in this repo (there is no `.claude/hooks/` mirror here), so the canonical edit is live for dogfood immediately. The charter edit is mirrored to `.claude/team/charter/issues.md`. **Deployed/existing repos need a reinstall** (`bootstrap --force` / re-`init --with-hooks`) to pick up the new gate behavior — tracked under #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTQxgBAcChxvdQJafKyMdX
