### PR TITLE
fix(node): refresh stale framework bundle on prepack instead of skip-if-exists (#82)

### DIFF
--- a/node/scripts/copy-shared.js
+++ b/node/scripts/copy-shared.js
@@ -17,7 +17,7 @@
  * __pycache__/ or tool cache directories.
  */
 
-import { cpSync, existsSync, mkdirSync } from "node:fs";
+import { cpSync, existsSync, lstatSync, mkdirSync, rmSync } from "node:fs";
 import { resolve, dirname, basename } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -48,9 +48,20 @@ for (const dir of DIRS) {
     continue;
   }
 
-  if (existsSync(dest)) {
-    // Already copied or symlinked — skip
+  // Symlink escape hatch: a developer may symlink e.g. node/framework -> ../framework
+  // for a live checkout. Never clobber that — leave the link in place.
+  const link = lstatSync(dest, { throwIfNoEntry: false });
+  if (link && link.isSymbolicLink()) {
+    console.log(`Skipped ${dest} (symlink — live checkout)`);
     continue;
+  }
+
+  // A real directory left over from an earlier local pack is a STALE snapshot:
+  // these bundled trees (framework/ in particular) change every wave, and a
+  // skip-if-exists would silently re-publish the old copy (issue #82). Remove and
+  // recopy so every prepack ships the current tree.
+  if (existsSync(dest)) {
+    rmSync(dest, { recursive: true, force: true });
   }
 
   mkdirSync(dest, { recursive: true });

--- a/node/tests/copy-shared.test.ts
+++ b/node/tests/copy-shared.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for scripts/copy-shared.js — the prepack bundler that copies the shared
+ * data trees (templates/, presets/, skills/, framework/) into the node package so
+ * they ship in the npm tarball.
+ *
+ * Regression focus (issue #82): a real destination directory left over from an
+ * earlier local `npm pack` is a STALE snapshot and must be refreshed on the next
+ * prepack (framework/ changes every wave), NOT silently skipped. A *symlinked*
+ * destination is a deliberate live-checkout escape hatch and must be preserved.
+ *
+ * Black-box: the real script is copied into a throwaway package layout and run
+ * with `node`, so its `__dirname/../..` REPO_ROOT resolution is exercised for real.
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REAL_SCRIPT = resolve(__dirname, "../scripts/copy-shared.js");
+const SHARED_DIRS = ["templates", "presets", "skills", "framework"];
+
+let root: string; // fake REPO_ROOT
+let pkg: string; // fake PKG_ROOT (root/node)
+
+/** Build a fake repo: <root>/{templates,presets,skills,framework} + <root>/node/scripts/copy-shared.js */
+beforeEach(() => {
+  root = mkdtempSync(resolve(tmpdir(), "copy-shared-"));
+  pkg = resolve(root, "node");
+  mkdirSync(resolve(pkg, "scripts"), { recursive: true });
+  cpSync(REAL_SCRIPT, resolve(pkg, "scripts", "copy-shared.js"));
+  // The real script is ESM and runs under node/package.json's "type":"module".
+  // Reproduce that so the copy loads as ESM on every Node (18 has no syntax
+  // auto-detection — without this it would parse as CommonJS and throw).
+  writeFileSync(resolve(pkg, "package.json"), JSON.stringify({ type: "module" }) + "\n");
+  for (const d of SHARED_DIRS) {
+    mkdirSync(resolve(root, d), { recursive: true });
+    writeFileSync(resolve(root, d, "marker.txt"), `${d}: v1\n`);
+  }
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+function runBundler(): string {
+  return execFileSync("node", [resolve(pkg, "scripts", "copy-shared.js")], {
+    encoding: "utf-8",
+  });
+}
+
+function bundled(dir: string): string {
+  return readFileSync(resolve(pkg, dir, "marker.txt"), "utf-8");
+}
+
+describe("copy-shared prepack bundler", () => {
+  it("copies every shared dir into the package on a first pack", () => {
+    runBundler();
+    for (const d of SHARED_DIRS) expect(bundled(d)).toBe(`${d}: v1\n`);
+  });
+
+  it("refreshes a stale bundle instead of skipping it (issue #82)", () => {
+    runBundler(); // first pack captures v1
+    // Source moves forward a wave…
+    for (const d of SHARED_DIRS) writeFileSync(resolve(root, d, "marker.txt"), `${d}: v2\n`);
+    runBundler(); // second local pack
+    for (const d of SHARED_DIRS) {
+      expect(bundled(d)).toBe(`${d}: v2\n`); // NOT the stale v1
+    }
+  });
+
+  it("drops bundled files no longer in source on refresh (full re-sync, no leftovers)", () => {
+    runBundler();
+    // A leftover in the BUNDLE that the source never had (e.g. a file removed
+    // upstream between packs). rm+recopy must clear it.
+    writeFileSync(resolve(pkg, "framework", "stale-only.txt"), "leftover from an old pack\n");
+    runBundler();
+    expect(() => readFileSync(resolve(pkg, "framework", "stale-only.txt"), "utf-8")).toThrow();
+  });
+
+  it("preserves a symlinked destination (live-checkout escape hatch)", () => {
+    // Developer symlinks node/framework -> ../framework for live dev.
+    symlinkSync(resolve(root, "framework"), resolve(pkg, "framework"), "dir");
+    writeFileSync(resolve(root, "framework", "marker.txt"), "framework: live\n");
+    const out = runBundler();
+    // The symlink is left in place (reads straight through to the live source)…
+    expect(bundled("framework")).toBe("framework: live\n");
+    expect(out).toMatch(/symlink/i);
+    // …and the source tree was not clobbered by a copy-onto-itself.
+    expect(readFileSync(resolve(root, "framework", "marker.txt"), "utf-8")).toBe(
+      "framework: live\n",
+    );
+  });
+
+  it("excludes tests/ and __pycache__ subtrees from the bundle", () => {
+    mkdirSync(resolve(root, "framework", "tests"), { recursive: true });
+    writeFileSync(resolve(root, "framework", "tests", "test_x.py"), "x\n");
+    mkdirSync(resolve(root, "framework", "__pycache__"), { recursive: true });
+    writeFileSync(resolve(root, "framework", "__pycache__", "x.pyc"), "bytecode\n");
+    runBundler();
+    expect(() =>
+      readFileSync(resolve(pkg, "framework", "tests", "test_x.py"), "utf-8"),
+    ).toThrow();
+    expect(() =>
+      readFileSync(resolve(pkg, "framework", "__pycache__", "x.pyc"), "utf-8"),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Issue #82 — `copy-shared.js` skip-if-exists can publish a stale `node/framework/` bundle

`node/scripts/copy-shared.js` (the `npm run prepack` bundler) skipped any destination directory that already existed. `templates/`/`presets/`/`skills/` are stable, but `framework/` — the config-driven runtime — changes **every wave**. A developer who ran `npm pack` once locally kept re-publishing that first snapshot on every subsequent local pack, shipping an outdated runtime. CI publishes from a fresh checkout (OIDC), so released tarballs were always safe; this was a local footgun only, but a real one.

### Fix
Replace skip-if-exists with **rm+recopy for every non-symlink destination**, so each prepack ships the current tree:
- A destination that is a **symlink** (e.g. `node/framework -> ../framework` for live dev) is detected via `lstat` and left untouched — the escape hatch the original skip was likely protecting. Never clobbered, never copied onto itself.
- A destination that is a **real directory** (a leftover snapshot from an earlier pack) is removed and recopied, guaranteeing freshness and clearing files dropped upstream.
- `tests/` / `__pycache__` / `.pyc` exclusions unchanged.

### Verify
- New `node/tests/copy-shared.test.ts` (5 cases) copies the **real** script into a throwaway package layout and runs it with `node`, exercising `__dirname/../..` REPO_ROOT resolution for real: first-pack copy, **stale-bundle refresh (v1→v2)**, leftover-file drop on re-sync, **symlink preservation**, and dev-subtree exclusion.
- Full node suite `vitest run` = **132 passing**.

### TL cross-issue note (#82 ↔ #116)
#116 (Ibrahim, reinstall) may re-run the node install path. This fix makes the local pack path deterministic and self-refreshing, so a reinstall that re-packs will always pick up the current `framework/` runtime rather than a cached snapshot — no interaction needed beyond "reinstall benefits from this being fixed." No shared files touched with #116.

Files: `node/scripts/copy-shared.js`, `node/tests/copy-shared.test.ts`.

Base: `deployments/phase4/wave-2`. Do not merge without owner approval.
