### PR TITLE
feat(self-host): reinstall-on-change rule + command + CI enforcement (#116)

### DIFF
--- a/.claude/team/charter/hooks.md
+++ b/.claude/team/charter/hooks.md
@@ -25,6 +25,12 @@ stdlib-only and fail open — a broken hook never blocks unrelated work.
 | Shell safety | `warn_zsh_wordsplit` | PreToolUse (Bash) | Advisory on bash-isms under zsh (when `shell: zsh`) |
 | Ontology stays fresh | `ontology_tracker` / `ontology_refresh` | PostToolUse / SessionStart | Tracks semantic-overlay drift; regenerates the structural index (inert until an ontology dir exists) |
 
+Not every gate is a runtime hook. Some charter rules are enforced by the CI test suite
+(`framework/tests/`) instead — notably **reinstall-on-change**
+([pull-requests.md](pull-requests.md)): `test_reinstall_parity.py` fails a PR that edits a
+canonical mirrored Claude asset (`framework/assets/**`) without regenerating its live
+`.claude/**` copy via `python3 framework/install/reinstall.py` (#116).
+
 ## Changing Enforcement
 
 - **Enable/disable a check:** edit the relevant `hooks.pre_bash` / `hooks.post_bash`

--- a/.claude/team/charter/pull-requests.md
+++ b/.claude/team/charter/pull-requests.md
@@ -89,6 +89,37 @@ confirms every claimed file is in the diff (and nothing unexpected is), and that
 PR body carries the `Closes #N` lines for every issue it claims to resolve. A "done"
 report that fails its own reconciliation is not done — fix it first, don't caveat it.
 
+### Claude Assets: Reinstall on Change
+
+A repo that is both the framework **source** and a live **consumer** of it (this repo)
+keeps Claude-related assets in two trees that must not drift:
+
+- **Canonical / install source** — `framework/assets/**` (+ `framework/config/**`,
+  `framework/install/**`): what deploys to target repos.
+- **Live runtime** — `.claude/**`: what this repo actually loads.
+
+A change touching any Claude asset (skills, hooks, libs, charter, config, settings) is
+**not done** until (1) it exists in the canonical/install dir, (2) the live `.claude/**`
+copy has been regenerated from it, and (3) the two are verified in sync (byte-identical
+where a parity test applies).
+
+Reinstall command (this repo):
+
+```bash
+python3 framework/install/reinstall.py           # regenerate .claude/ from framework/assets/
+python3 framework/install/reinstall.py --check    # verify in sync (CI gate; exit 1 on drift)
+```
+
+Deploying into another repo uses the same installer via the published CLI
+(`real-team init --with-hooks --force`, i.e. the bundled bootstrap).
+
+Not every asset needs a copy step: **hooks/** + **lib/** are wired in place (settings.json
+points the dispatchers at `framework/assets/hooks/`, so they run canonical directly and
+cannot drift), and **team/charter/** is rendered with per-repo substitution and is
+hand-evolvable. The byte-mirrored trees (today: `skills/`) are the ones `reinstall.py`
+manages and `test_reinstall_parity.py` enforces in CI — a PR that edits a canonical
+mirrored asset (or its live copy) without reinstalling fails that check.
+
 ## Wave Merge PR
 
 At the end of a wave/phase, the Manager creates a PR from the integration branch

--- a/framework/assets/team/charter/hooks.md
+++ b/framework/assets/team/charter/hooks.md
@@ -25,6 +25,12 @@ stdlib-only and fail open — a broken hook never blocks unrelated work.
 | Shell safety | `warn_zsh_wordsplit` | PreToolUse (Bash) | Advisory on bash-isms under zsh (when `shell: zsh`) |
 | Ontology stays fresh | `ontology_tracker` / `ontology_refresh` | PostToolUse / SessionStart | Tracks semantic-overlay drift; regenerates the structural index (inert until an ontology dir exists) |
 
+Not every gate is a runtime hook. Some charter rules are enforced by the CI test suite
+(`framework/tests/`) instead — notably **reinstall-on-change**
+([pull-requests.md](pull-requests.md)): `test_reinstall_parity.py` fails a PR that edits a
+canonical mirrored Claude asset (`framework/assets/**`) without regenerating its live
+`.claude/**` copy via `python3 framework/install/reinstall.py` (#116).
+
 ## Changing Enforcement
 
 - **Enable/disable a check:** edit the relevant `hooks.pre_bash` / `hooks.post_bash`

--- a/framework/assets/team/charter/pull-requests.md
+++ b/framework/assets/team/charter/pull-requests.md
@@ -89,6 +89,37 @@ confirms every claimed file is in the diff (and nothing unexpected is), and that
 PR body carries the `Closes #N` lines for every issue it claims to resolve. A "done"
 report that fails its own reconciliation is not done — fix it first, don't caveat it.
 
+### Claude Assets: Reinstall on Change
+
+A repo that is both the framework **source** and a live **consumer** of it (this repo)
+keeps Claude-related assets in two trees that must not drift:
+
+- **Canonical / install source** — `framework/assets/**` (+ `framework/config/**`,
+  `framework/install/**`): what deploys to target repos.
+- **Live runtime** — `.claude/**`: what this repo actually loads.
+
+A change touching any Claude asset (skills, hooks, libs, charter, config, settings) is
+**not done** until (1) it exists in the canonical/install dir, (2) the live `.claude/**`
+copy has been regenerated from it, and (3) the two are verified in sync (byte-identical
+where a parity test applies).
+
+Reinstall command (this repo):
+
+```bash
+python3 framework/install/reinstall.py           # regenerate .claude/ from framework/assets/
+python3 framework/install/reinstall.py --check    # verify in sync (CI gate; exit 1 on drift)
+```
+
+Deploying into another repo uses the same installer via the published CLI
+(`real-team init --with-hooks --force`, i.e. the bundled bootstrap).
+
+Not every asset needs a copy step: **hooks/** + **lib/** are wired in place (settings.json
+points the dispatchers at `framework/assets/hooks/`, so they run canonical directly and
+cannot drift), and **team/charter/** is rendered with per-repo substitution and is
+hand-evolvable. The byte-mirrored trees (today: `skills/`) are the ones `reinstall.py`
+manages and `test_reinstall_parity.py` enforces in CI — a PR that edits a canonical
+mirrored asset (or its live copy) without reinstalling fails that check.
+
 ## Wave Merge PR
 
 At the end of a wave/phase, the Manager creates a PR from the integration branch

--- a/framework/install/reinstall.py
+++ b/framework/install/reinstall.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Reinstall this repo's mirrored Claude assets from the canonical install source.
+
+Self-hosting rule (#116). This repo is BOTH the framework source AND a live consumer of
+it (dogfood). Claude-related assets therefore live in two trees:
+
+* **Canonical / install source** — ``framework/assets/**`` (what deploys to target repos).
+* **Live runtime** — ``.claude/**`` (what this repo actually loads).
+
+The dual-deploy requirement says the canonical copy is authoritative; this command is its
+missing second half: after you edit a canonical asset, run this so the live ``.claude/**``
+copy is regenerated from it and the two never drift.
+
+Scope — what is "reinstalled" here
+==================================
+Only the asset classes Claude Code loads *from* ``.claude/`` and that are byte-copied
+verbatim from canonical are managed (today: ``skills/``). The other Claude assets do not
+need a copy-and-sync step:
+
+* **hooks/ + lib/** are wired IN PLACE — ``.claude/settings.json`` points the dispatchers at
+  ``$CLAUDE_PROJECT_DIR/framework/assets/hooks/*``. The repo runs the canonical files
+  directly, so they are canonical-by-reference and cannot drift.
+* **team/charter/** is rendered from a template with per-repo ``{{...}}`` substitution and is
+  intentionally hand-evolvable (bootstrap installs it skip-if-exists), so it is not a
+  byte-mirror.
+
+Live-only assets (a ``.claude/skills/`` entry with no canonical counterpart, e.g. a
+repo-local skill) are left untouched — reinstall only pushes canonical → live, it never
+deletes.
+
+Usage
+=====
+  python3 framework/install/reinstall.py           # refresh .claude/ from canonical
+  python3 framework/install/reinstall.py --check    # report drift, write nothing (exit 1 if any)
+
+Stdlib only; no deps. Pairs with the ``test_reinstall_parity.py`` CI gate, which fails a PR
+that edits a canonical asset (or its live copy) without running this command.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+
+# framework/install/reinstall.py -> framework/
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+_REPO_ROOT = _FRAMEWORK_ROOT.parent
+_ASSETS = _FRAMEWORK_ROOT / "assets"
+
+#: (canonical subdir under framework/assets, live subdir under .claude) copied byte-for-byte.
+#: Add a tuple here to bring another byte-mirrored asset class under reinstall enforcement.
+_MANAGED_TREES = (("skills", "skills"),)
+
+
+def _iter_tree(base: Path):
+    """Yield repo-relative Paths of every file under ``base`` (skipping ``__pycache__``)."""
+    if not base.is_dir():
+        return
+    for p in sorted(base.rglob("*")):
+        if p.is_file() and "__pycache__" not in p.parts:
+            yield p.relative_to(base)
+
+
+def plan(assets_root: Path = _ASSETS, claude_root: Path = _REPO_ROOT / ".claude") -> list[str]:
+    """Live ``.claude/`` paths whose bytes differ from canonical (missing or drifted).
+
+    A non-empty result means the live copy is out of sync with the canonical source in
+    either direction (canonical edited without reinstall, or the live copy hand-edited) —
+    both are drift the reinstall must reconcile.
+    """
+    drift: list[str] = []
+    for canon_sub, live_sub in _MANAGED_TREES:
+        canon = assets_root / canon_sub
+        live = claude_root / live_sub
+        for rel in _iter_tree(canon):
+            src = canon / rel
+            dst = live / rel
+            if not dst.is_file() or dst.read_bytes() != src.read_bytes():
+                drift.append(f".claude/{live_sub}/{rel.as_posix()}")
+    return drift
+
+
+def apply(assets_root: Path = _ASSETS, claude_root: Path = _REPO_ROOT / ".claude") -> list[str]:
+    """Copy every managed canonical file over its live counterpart. Returns paths written."""
+    written: list[str] = []
+    for canon_sub, live_sub in _MANAGED_TREES:
+        canon = assets_root / canon_sub
+        live = claude_root / live_sub
+        for rel in _iter_tree(canon):
+            src = canon / rel
+            dst = live / rel
+            if dst.is_file() and dst.read_bytes() == src.read_bytes():
+                continue
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+            written.append(f".claude/{live_sub}/{rel.as_posix()}")
+    return written
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Reinstall this repo's mirrored Claude assets from framework/assets/.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument(
+        "--check",
+        action="store_true",
+        help="Report drift and write nothing; exit 1 if any live copy differs from canonical.",
+    )
+    args = ap.parse_args(argv)
+
+    if args.check:
+        drift = plan()
+        if drift:
+            print("reinstall: DRIFT — these live copies differ from canonical framework/assets/:")
+            for d in drift:
+                print(f"  {d}")
+            print("Run: python3 framework/install/reinstall.py")
+            return 1
+        print("reinstall: .claude/ is in sync with canonical framework/assets/.")
+        return 0
+
+    written = apply()
+    if written:
+        print(f"reinstall: refreshed {len(written)} file(s) from canonical:")
+        for w in written:
+            print(f"  {w}")
+    else:
+        print("reinstall: already in sync — nothing to do.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/framework/tests/test_reinstall_parity.py
+++ b/framework/tests/test_reinstall_parity.py
@@ -1,0 +1,91 @@
+"""Reinstall-on-change enforcement (issue #116).
+
+This repo is both the framework SOURCE and a live consumer of it. When a Claude asset is
+edited in the canonical install source (``framework/assets/**``), the live ``.claude/**``
+copy must be regenerated from it via ``framework/install/reinstall.py`` so the two never
+drift.
+
+The headline test (`test_repo_in_sync_with_canonical`) is the CI gate: it fails a PR that
+edited a canonical mirrored asset (or its live copy) without running reinstall — the
+automated enforcement AC #116 asks for, generalising the hardcoded-list skill-parity test
+to *every* file under a managed tree. The rest exercise the reinstall engine itself.
+
+Stdlib + pytest only.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_FRAMEWORK_ROOT / "install"))
+
+import reinstall  # noqa: E402
+
+
+# --------------------------------------------------------------- the CI gate
+
+
+def test_repo_in_sync_with_canonical() -> None:
+    """Every managed live copy is byte-identical to its canonical source (no drift)."""
+    drift = reinstall.plan()
+    assert drift == [], (
+        "live .claude/ copies have drifted from canonical framework/assets/ — run "
+        "`python3 framework/install/reinstall.py` to reinstall:\n  " + "\n  ".join(drift)
+    )
+
+
+def test_managed_trees_are_present() -> None:
+    """The managed canonical trees exist (guards against a silently empty reinstall)."""
+    for canon_sub, _live_sub in reinstall._MANAGED_TREES:
+        assert (_FRAMEWORK_ROOT / "assets" / canon_sub).is_dir(), (
+            f"managed canonical tree missing: framework/assets/{canon_sub}"
+        )
+
+
+# --------------------------------------------------------------- engine behaviour
+
+
+def _fake_repo(tmp_path: Path) -> tuple[Path, Path]:
+    """Build a tiny (assets_root, claude_root) pair with one managed 'skills' tree."""
+    assets = tmp_path / "assets"
+    claude = tmp_path / ".claude"
+    (assets / "skills" / "demo").mkdir(parents=True)
+    (assets / "skills" / "demo" / "SKILL.md").write_text("canonical body\n", encoding="utf-8")
+    return assets, claude
+
+
+def test_plan_flags_missing_live_copy(tmp_path: Path) -> None:
+    assets, claude = _fake_repo(tmp_path)
+    assert reinstall.plan(assets, claude) == [".claude/skills/demo/SKILL.md"]
+
+
+def test_apply_materializes_and_then_plan_is_clean(tmp_path: Path) -> None:
+    assets, claude = _fake_repo(tmp_path)
+    written = reinstall.apply(assets, claude)
+    assert written == [".claude/skills/demo/SKILL.md"]
+    assert (claude / "skills" / "demo" / "SKILL.md").read_text() == "canonical body\n"
+    # In sync now, and re-applying is a no-op (idempotent).
+    assert reinstall.plan(assets, claude) == []
+    assert reinstall.apply(assets, claude) == []
+
+
+def test_plan_flags_hand_edited_live_copy(tmp_path: Path) -> None:
+    assets, claude = _fake_repo(tmp_path)
+    reinstall.apply(assets, claude)
+    # Someone edits the LIVE copy without updating canonical → drift in the other direction.
+    (claude / "skills" / "demo" / "SKILL.md").write_text("hand edit\n", encoding="utf-8")
+    assert reinstall.plan(assets, claude) == [".claude/skills/demo/SKILL.md"]
+
+
+def test_apply_leaves_live_only_assets_untouched(tmp_path: Path) -> None:
+    """A live-only skill (no canonical counterpart) is never deleted by reinstall."""
+    assets, claude = _fake_repo(tmp_path)
+    reinstall.apply(assets, claude)
+    local = claude / "skills" / "repo-local" / "SKILL.md"
+    local.parent.mkdir(parents=True)
+    local.write_text("local only\n", encoding="utf-8")
+    reinstall.apply(assets, claude)
+    assert local.is_file()  # untouched
+    assert reinstall.plan(assets, claude) == []  # live-only extras are not drift


### PR DESCRIPTION
Closes #116. Flagship of Phase 4 Wave 2 (self-consistency & tech-debt floor).

## The rule
This repo is both the framework **source** and a live **consumer** of it (dogfood), so
Claude assets live in two trees that must not drift:
- **Canonical / install source** — `framework/assets/**` (+ `framework/config/**`, `framework/install/**`)
- **Live runtime** — `.claude/**`

The dual-deploy requirement already mandated the canonical copy. This adds its missing
second half: **after editing a canonical asset, regenerate `.claude/**` from it** so
source and runtime never diverge (the #99 class of self-hosting gap).

## What ships
1. **Charter rule** (canonical + live, byte-identical prose): `pull-requests.md` Definition
   of Done gains *"Claude Assets: Reinstall on Change"* — a change is not done until it is
   in the canonical dir, the live `.claude/**` copy is regenerated, and the two are verified
   in sync. `hooks.md` notes the CI-side gate.
2. **Reinstall command** — `framework/install/reinstall.py`:
   ```bash
   python3 framework/install/reinstall.py           # regenerate .claude/ from framework/assets/
   python3 framework/install/reinstall.py --check    # verify in sync (exit 1 on drift)
   ```
   It manages the byte-mirrored trees Claude loads from `.claude/` (today `skills/`).
   **hooks/ + lib/** are wired in place — `settings.json` points the dispatchers at
   `framework/assets/hooks/`, so they run canonical directly and cannot drift.
   **charter/** is rendered + hand-evolvable. Both are deliberately out of the byte-mirror.
   Deploying elsewhere uses the same installer via the published CLI (`real-team init
   --with-hooks --force`, the bundled bootstrap).
3. **Automated enforcement** — `framework/tests/test_reinstall_parity.py`. The headline
   test asserts `reinstall.plan() == []` (the CI gate; generalises skill-parity past its
   hardcoded list to *every* file in a managed tree). Engine tests cover drift in both
   directions, idempotent apply, and live-only assets left untouched.

## Verify
- Drift PR flagged, in-sync PR passes (demonstrated end-to-end: edited a canonical skill →
  `--check` exits 1 naming the file; `reinstall.py` fixes it; restore clean).
- `ruff check framework/` clean; `pytest framework/tests/` → **337 passed**.

## Coordination
Touches the self-host/charter surface Tariq's **#118** also edits. No `settings.json`
change here (hooks run in place), so the overlap is charter prose only — whichever merges
second rebases. The concrete reinstall command (`python3 framework/install/reinstall.py`)
is what the team's dual-deploy notes can now cite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
