### PR TITLE
docs(charter): merge-model-conditional PR wording + config reconcile (#94)

### DIFF
--- a/.claude/framework.config.json
+++ b/.claude/framework.config.json
@@ -19,7 +19,7 @@
   },
   "policy": {
     "reviewers_required": 1,
-    "merge_model": "direct-to-main"
+    "merge_model": "wave-branch"
   },
   "ci": {
     "merge_requires_green": true,

--- a/.claude/team/charter/charter.md
+++ b/.claude/team/charter/charter.md
@@ -25,7 +25,9 @@ documents (CLAUDE.md, roster cards, skills) should link here rather than restate
   baked into these documents were substituted from that config at install time — if
   the config changes, re-run the framework bootstrap with `--force` to refresh them.
 - **Owner:** `parametrization` · **Default branch:** `main` ·
-  **Merge model:** `direct-to-main` · **Reviews required per PR:** 1
+  **Merge model:** `wave-branch` (configured default; the effective model per
+  wave is declared at kickoff via `lifecycle.py wave kickoff --merge-model …` and
+  recorded in the state file) · **Reviews required per PR:** 1
 - **User approval gates.** Merging to `main`, creating releases, and
   kicking off a new wave all require explicit approval from the project owner. No
   team member may bypass these gates.

--- a/.claude/team/charter/pull-requests.md
+++ b/.claude/team/charter/pull-requests.md
@@ -11,8 +11,13 @@ git push -u origin <feature-branch>
 gh pr create --base <integration-branch> --title "<short title>" --body-file /tmp/pr-body.md
 ```
 
-- Target the wave's integration branch (`deployments/wave-{wave}`), never
-  `main` directly (merge model: `direct-to-main`).
+- **Base branch follows the wave's effective merge model** (configured default:
+  `wave-branch`; the effective model for a wave is declared at kickoff via
+  `lifecycle.py wave kickoff --merge-model …` and recorded in the state file —
+  see [branching.md](branching.md)). Under `wave-branch`, target the wave's
+  integration branch (`deployments/wave-{wave}`), never `main`
+  directly. Under `direct-to-main`, that base collapses to `main`
+  and feature branches PR straight into it.
 - Title under 70 characters; body references the issue with `Closes #N`.
 - Push unpiped — piping `git push` through `tail`/`head` masks a rejected push
   behind the pipe's exit code (flagged — see [hooks.md](hooks.md)).

--- a/framework/assets/team/charter/charter.md
+++ b/framework/assets/team/charter/charter.md
@@ -25,7 +25,9 @@ documents (CLAUDE.md, roster cards, skills) should link here rather than restate
   baked into these documents were substituted from that config at install time — if
   the config changes, re-run the framework bootstrap with `--force` to refresh them.
 - **Owner:** `{{owner}}` · **Default branch:** `{{default_branch}}` ·
-  **Merge model:** `{{merge_model}}` · **Reviews required per PR:** {{reviewers_required}}
+  **Merge model:** `{{merge_model}}` (configured default; the effective model per
+  wave is declared at kickoff via `lifecycle.py wave kickoff --merge-model …` and
+  recorded in the state file) · **Reviews required per PR:** {{reviewers_required}}
 - **User approval gates.** Merging to `{{default_branch}}`, creating releases, and
   kicking off a new wave all require explicit approval from the project owner. No
   team member may bypass these gates.

--- a/framework/assets/team/charter/pull-requests.md
+++ b/framework/assets/team/charter/pull-requests.md
@@ -11,8 +11,13 @@ git push -u origin <feature-branch>
 gh pr create --base <integration-branch> --title "<short title>" --body-file /tmp/pr-body.md
 ```
 
-- Target the wave's integration branch (`{{integration_branch_scheme}}`), never
-  `{{default_branch}}` directly (merge model: `{{merge_model}}`).
+- **Base branch follows the wave's effective merge model** (configured default:
+  `{{merge_model}}`; the effective model for a wave is declared at kickoff via
+  `lifecycle.py wave kickoff --merge-model …` and recorded in the state file —
+  see [branching.md](branching.md)). Under `wave-branch`, target the wave's
+  integration branch (`{{integration_branch_scheme}}`), never `{{default_branch}}`
+  directly. Under `direct-to-main`, that base collapses to `{{default_branch}}`
+  and feature branches PR straight into it.
 - Title under 70 characters; body references the issue with `Closes #N`.
 - Push unpiped — piping `git push` through `tail`/`head` masks a rejected push
   behind the pipe's exit code (flagged — see [hooks.md](hooks.md)).

--- a/framework/tests/test_charter_install.py
+++ b/framework/tests/test_charter_install.py
@@ -97,6 +97,36 @@ def test_force_refreshes_from_template(tmp_path: Path) -> None:
     assert "{{" not in text  # force path substitutes too
 
 
+def test_pr_creation_wording_is_merge_model_conditional(tmp_path: Path) -> None:
+    """Issue #94: the § PR Creation base-branch sentence must NOT render as a
+    self-contradiction under direct-to-main ("never `main` directly (merge
+    model: `direct-to-main`)"). It must describe BOTH models and cite the
+    per-wave kickoff mechanism, so it reads coherently for either config value."""
+    r = _install(tmp_path, "--merge-model", "direct-to-main")
+    assert r.returncode == 0, r.stderr
+    pr = (_charter_dir(tmp_path) / "pull-requests.md").read_text(encoding="utf-8")
+    # The old, self-contradictory phrasing is gone.
+    assert "directly (merge model:" not in pr
+    # Both models are described, and the per-wave declaration is cited.
+    assert "Under `wave-branch`" in pr
+    assert "Under `direct-to-main`" in pr
+    assert "lifecycle.py wave kickoff --merge-model" in pr
+    # No unreplaced placeholder survived the conditional rewrite.
+    assert "{{" not in pr and "}}" not in pr
+
+
+def test_ground_rules_merge_model_acknowledges_per_wave_declaration(tmp_path: Path) -> None:
+    """Issue #94: the charter.md ground-rules 'Merge model:' line must note that
+    the effective model is declared per wave at kickoff, so a `direct-to-main`
+    configured default does not mislead a reader in a repo that runs waves."""
+    r = _install(tmp_path, "--merge-model", "direct-to-main")
+    assert r.returncode == 0, r.stderr
+    charter = (_charter_dir(tmp_path) / "charter.md").read_text(encoding="utf-8")
+    assert "direct-to-main" in charter  # the configured default still renders
+    assert "declared at kickoff" in charter
+    assert "lifecycle.py wave kickoff --merge-model" in charter
+
+
 def test_dry_run_writes_nothing(tmp_path: Path) -> None:
     r = _install(tmp_path, "--dry-run")
     assert r.returncode == 0, r.stderr


### PR DESCRIPTION
## Issue
Closes #94 — merge-model-conditional wording in `pull-requests.md`; reconcile `policy.merge_model` config vs wave-branch practice.

## Problem
1. **Template artifact:** `pull-requests.md` § PR Creation rendered a self-contradiction when `merge_model = direct-to-main`: *"never `main` directly (merge model: `direct-to-main`)"*. `branching.md` already had the correct model-conditional treatment; PR Creation did not.
2. **Config/practice tension:** this repo's `.claude/framework.config.json` declared `policy.merge_model: direct-to-main`, but every phase runs wave branches (`deployments/phase{N}/wave-{M}`). The thin index already reconciled this ("wave-branch model in practice; effective model declared at kickoff"), but the substituted ground-rules "Merge model:" line kept misleading readers.

## Fix

**Template tranche** (canonical `framework/assets/team/charter/` + installed `.claude/team/charter/` mirror):
- **`pull-requests.md` § PR Creation** — base-branch sentence is now merge-model-conditional (mirrors `branching.md`): describes BOTH `wave-branch` and `direct-to-main`, and cites the per-wave declaration (`lifecycle.py wave kickoff --merge-model …`). Coherent for either configured value.
- **`charter.md` Ground Rules "Merge model:" line** — notes the value is the configured default and the effective per-wave model is declared at kickoff.

**Config reconciliation:**
- Flipped this repo's `policy.merge_model` `direct-to-main` → `wave-branch` to match actual practice. **Safe:** `policy.merge_model` is only read at runtime by `session_start.py`'s display line; merge-model *enforcement* keys off the per-wave `wave_{W}_merge_model` recorded in lifecycle state (#99), never this default. The thin index's "wave-branch in practice" note is now consistent with the config.

## Tests
Two regression guards in `test_charter_install.py`: render under `direct-to-main` and assert (a) the § PR Creation sentence is not self-contradictory — describes both models + cites kickoff, old `"directly (merge model:"` phrasing gone; (b) the ground-rules line acknowledges per-wave declaration. `ruff check framework/` clean; full framework suite green (333, +2 new).

## AC status
- [x] `pull-requests.md` template wording is merge-model-conditional.
- [x] Ground-rules "Merge model:" line acknowledges per-wave declaration via `lifecycle.py wave kickoff --merge-model`; repo config value also deliberately set to `wave-branch` and documented.
- [x] Installed `.claude/team/charter/` modules updated in sync (surgical in-place edit preserving existing substituted integration-scheme/reviewer values; equivalent to a `bootstrap --force` re-render of the changed lines).

## Coordination
- **#118 (mine):** touches `charter/issues.md` — different file; kept coherent.
- **#99 (merged):** relied on for the "per-wave merge_model recorded in state" mechanism the wording now cites.

## Dual-deploy + reinstall (#116)
Canonical templates under `framework/assets/**` fixed; dogfood `.claude/**` mirrored. Deployed/existing repos pick up the template fix on the next reinstall (`bootstrap --force`) — tracked under #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTQxgBAcChxvdQJafKyMdX
