### PR TITLE
fix(#131): gate review_false_positives on an actually-raised Must-fix

### DIFF
--- a/framework/assets/lib/trust_signals.py
+++ b/framework/assets/lib/trust_signals.py
@@ -263,12 +263,18 @@ def parse_verdicts(comment_bodies: list[str]) -> list[Verdict]:
         ree_m = _FIELD_RE["requestee"].search(body)
         verdict_str = verdict_m.group(1).strip()
         changes_requested = _is_changes_requested(verdict_str, body)
-        # A retraction only counts when the reviewer actually raised a
-        # finding — approvals are never retractions.  Also strip code
-        # spans and fenced blocks first so symbol/test names that contain
-        # the retraction vocabulary (e.g. `test_no_false_positive_*`) are
-        # not matched.
-        if verdict_str.lower() == "approved":
+        # A review false-positive is, by definition (see the module
+        # docstring), a ``Must-fix:`` item the reviewer *raised* that was
+        # later withdrawn — so a retraction only counts when THIS SAME
+        # comment actually enumerated >=1 must-fix finding. A comment with
+        # ``Must-fix: None`` / no must-fix section raised zero findings, so
+        # retraction vocabulary elsewhere in its body (e.g. a forward-looking
+        # Tech-debt "false-positive watch" note) is not a retraction and must
+        # not score. Approvals never raise must-fix items. Code spans /
+        # fenced blocks are stripped first so symbol/test names that contain
+        # the retraction vocabulary (e.g. `test_no_false_positive_*`) are not
+        # matched.
+        if verdict_str.lower() == "approved" or not _has_must_fix_items(body):
             is_false_positive = False
         else:
             is_false_positive = bool(

--- a/framework/tests/test_trust_signals.py
+++ b/framework/tests/test_trust_signals.py
@@ -233,6 +233,70 @@ def test_parse_skips_non_verdict_comments():
 
 
 # ---------------------------------------------------------------------------
+# review_false_positives must-fix gate (#131).
+#
+# A review false-positive is, by contract, a Must-fix item the reviewer RAISED
+# that was later withdrawn. Retraction vocabulary in a comment that raised no
+# must-fix item is not a retraction and must not score.
+# ---------------------------------------------------------------------------
+
+# PR #115 — Nia's approval, posted as a `Replied` with `Must-fix: None`. Its
+# Tech-debt line carries the phrase "false-positive watch" — a forward-looking
+# note about a hypothetical gate weakness, NOT a retraction of anything she
+# raised. Exact shape from the live #131 repro.
+PR115_CLEAN_APPROVAL = """Requestor: Nia Rossi
+Requestee: Paloma Gupta
+RequestOrReplied: Replied
+
+**Review: LGTM — APPROVE.** CI green; the trust-gate change reads correctly.
+
+Must-fix: None
+Tech-debt: Minor false-positive watch (accept as-is) — the retraction heuristic
+could over-match forward-looking prose; worth a follow-up but not blocking here.
+"""
+
+# A comment that DID raise a Must-fix finding and, in the same comment, retracts
+# it as a false-positive → still a genuine review false-positive (don't
+# over-correct and break the real signal).
+PR_RETRACTED_MUST_FIX = """Requestor: Tariq Morales (QA)
+Requestee: Ibrahim El-Amin
+RequestOrReplied: Request
+
+Must-fix:
+1. The allowlist claim looks wrong here.
+
+On second read this was a false-positive — the README already matches. Withdrawing.
+"""
+
+
+def test_clean_approval_with_false_positive_watch_scores_zero():
+    # Regression for #131: `Must-fix: None` + "false-positive watch" prose must
+    # NOT be counted as a review false-positive.
+    (v,) = ts.parse_verdicts([PR115_CLEAN_APPROVAL])
+    assert v.verdict == "Replied"
+    assert v.changes_requested is False
+    assert v.false_positive is False
+
+
+def test_retracted_must_fix_still_counts_as_false_positive():
+    # Positive case: a comment that raised a must-fix and then retracts it in
+    # the same body still scores — the real signal is preserved.
+    (v,) = ts.parse_verdicts([PR_RETRACTED_MUST_FIX])
+    assert v.changes_requested is True
+    assert v.false_positive is True
+
+
+def test_extract_shape_clean_reviewer_no_false_positive():
+    # End-to-end over parse_verdicts: the #115 shape yields
+    # review_false_positives == 0 for the reviewer.
+    fp = 0
+    for v in ts.parse_verdicts([PR115_CLEAN_APPROVAL]):
+        if v.false_positive and v.requestor:
+            fp += 1
+    assert fp == 0
+
+
+# ---------------------------------------------------------------------------
 # End-to-end accounting: the per-PR loop extract_signals runs, exercised on the
 # real corpus without touching gh. Proves review signals now score non-zero.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #131.

`extract_signals` (via `parse_verdicts`) flagged a verdict comment as a **review
false-positive** whenever retraction vocabulary (`false-positive | withdrawn |
retracted | invalid finding`) appeared in the body of any non-`approved` comment —
**without** checking that the same comment actually raised a `Must-fix:` item.

## Root cause

The scorer's own contract (module docstring, ll. 46-47) defines a review
false-positive as "must-fix items **they raised** that were later
withdrawn/false-positive." A comment with `Must-fix: None` raised zero findings, so
it cannot logically contain a retraction — but the heuristic only short-circuited on
an `approved` verdict, so a `Replied` / `Request` comment with `Must-fix: None`
still matched on any retraction word in its body.

**Live repro:** Nia's approval on PR #115 (`RequestOrReplied: Replied`,
`Must-fix: None`) carries the Tech-debt line *"Minor false-positive watch (accept
as-is)"* — a forward-looking note, not a retraction — and the scorer counted
`review_false_positives=1` → delta −1, docking a clean reviewer one trust step.

## Fix

`framework/assets/lib/trust_signals.py`, in `parse_verdicts` (the false-positive
resolution block, ~ll. 265-282): gate the match on `_has_must_fix_items(body)` — a
retraction now only counts when the **same** comment enumerated ≥1 `Must-fix:`
finding. One-line condition change (`approved` short-circuit preserved); no other
scoring path touched.

```
if verdict_str.lower() == "approved" or not _has_must_fix_items(body):
    is_false_positive = False
else:
    is_false_positive = bool(_FALSE_POSITIVE_RE.search(_strip_code_markup(body)))
```

**Before → after on the #115 shape:** `review_false_positives` `1 → 0`
(`false_positive` `True → False`).

## Tests added (`framework/tests/test_trust_signals.py`)

- `test_clean_approval_with_false_positive_watch_scores_zero` — the exact #115
  shape (`RequestOrReplied: Replied` + `Must-fix: None`, body carries
  "false-positive watch" under a `Tech-debt:` line) → `false_positive is False`.
- `test_retracted_must_fix_still_counts_as_false_positive` — positive case: a
  comment that raised a `Must-fix:` item and then retracts it → still
  `false_positive is True` (real signal preserved, no over-correction).
- `test_extract_shape_clean_reviewer_no_false_positive` — end-to-end over
  `parse_verdicts` on the #115 shape → `review_false_positives == 0`.

New `PR115_CLEAN_APPROVAL` / `PR_RETRACTED_MUST_FIX` fixtures shape-faithful to the
live repro.

## Verification

- `python3 -m pytest framework/tests/ -q` → **376 passed**
- `ruff check framework/` → **All checks passed!**
- `python3 framework/install/reinstall.py --check` → **in sync** (#116 parity;
  `trust_signals.py` is canonical-by-reference, no mirror step)

## Charter review

- **Must-fix:** None — change is minimal and surgical, full suite + ruff green,
  parity check in sync. Test evidence: before/after on the #115 shape is
  regression-locked by `test_clean_approval_with_false_positive_watch_scores_zero`,
  and the real signal is protected by
  `test_retracted_must_fix_still_counts_as_false_positive`.
- **Tech-debt:** None.
