### PR TITLE
feat(#107): consented idempotent user-level install — closes G1 (agent-teams flag)

### DIFF
--- a/framework/install/backup.py
+++ b/framework/install/backup.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Timestamped, restorable backups for consent-gated installer writes.
+
+Part of the reusable user-space install toolkit introduced for #107 (consented
+user-level install) and reused by #108 (repo-level pattern). Stdlib-only, no deps.
+
+Public API
+==========
+``backup_file(path) -> Optional[Path]``
+    Copy ``path`` to a timestamped sibling ``<name>.<UTC-stamp>.bak`` and return the
+    backup path. **No-op returning ``None`` if ``path`` does not exist** — there is
+    nothing to back up before a first-time write. The copy preserves mode + mtime
+    (``shutil.copy2``), so restoring is a plain copy of the ``.bak`` back over the
+    original. If a backup for the same second already exists, a numeric suffix is
+    added so an existing backup is never clobbered.
+
+Contract notes for callers (#108)
+---------------------------------
+* Deliberately **strict**: a real ``OSError`` while copying propagates, so a failed
+  backup surfaces *before* the amend write rather than leaving the caller to write
+  over an un-backed-up file. Guard the missing-source case with the ``None`` return,
+  not with a try/except around this call.
+* The returned path is stable and self-describing; nothing here deletes or prunes
+  old backups (restorability over tidiness).
+"""
+
+from __future__ import annotations
+
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def backup_file(path: Path | str, *, now: datetime | None = None) -> Path | None:
+    """Back up ``path`` to a timestamped ``.bak`` sibling; ``None`` if it is absent.
+
+    ``now`` is injectable purely for deterministic tests; production callers omit it
+    and get a UTC wall-clock stamp.
+    """
+    path = Path(path)
+    if not path.exists():
+        return None
+    stamp = (now or datetime.now(timezone.utc)).strftime("%Y%m%dT%H%M%SZ")
+    candidate = path.with_name(f"{path.name}.{stamp}.bak")
+    n = 1
+    while candidate.exists():
+        candidate = path.with_name(f"{path.name}.{stamp}.{n}.bak")
+        n += 1
+    shutil.copy2(path, candidate)
+    return candidate

--- a/framework/install/bootstrap.py
+++ b/framework/install/bootstrap.py
@@ -1252,6 +1252,14 @@ def main() -> int:
     ontology_group.add_argument("--no-ontology", action="store_true",
                                 help="Skip the ontology seed + structural index (ontology.enabled=false)")
     ap.add_argument("--no-permissions", action="store_true", help="Do NOT install the curated permissions.allow allowlist into settings.json (hook wiring still merges)")
+    ap.add_argument(
+        "--user-space", action="store_true",
+        help="Also run the CONSENTED user-level install step: idempotently add the "
+             "framework's harness-global settings (agent-teams flag, teammateMode, "
+             "worktree baseRef, ~/.claude permission globs) to ~/.claude/settings.json "
+             "(closes #106 G1). Opt-in prompt before any write; --non-interactive skips it; "
+             "existing/matching keys are a no-op; divergent values are surfaced, never clobbered.",
+    )
     ap.add_argument("--force", action="store_true", help="Overwrite existing files")
     ap.add_argument(
         "--refresh-charter", action="store_true",
@@ -1479,6 +1487,27 @@ def main() -> int:
     print(f"team roster:       {roster_status}")
     if team_enabled and roster_plan is not None and not args.no_enforce_identity:
         print("identity gate:     ENABLED (commits must use -c user.name/-c user.email from the roster)")
+
+    # CONSENTED user-level step (#107, closes #106 G1). Opt-in: only when --user-space
+    # is passed. Merge-only, idempotent, consent-gated; --non-interactive skips it and a
+    # dry-run never writes. Reads/writes ~/.claude, never the target repo — kept last so
+    # a repo install is complete before we touch user space.
+    if args.user_space:
+        import user_space  # noqa: E402  (sibling module in install/)
+
+        target_settings = user_space.user_settings_path()
+        if args.dry_run:
+            print("\n-- user-level install (~/.claude/settings.json) --")
+            print(f"would offer to add the framework's harness-global settings to {target_settings}")
+        else:
+            us_result = user_space.install_user_space(non_interactive=args.non_interactive)
+            print("\n" + user_space.report(us_result, target_settings))
+    elif not args.dry_run:
+        print(
+            "\nhint: harness-global team settings (agent-teams flag, worktree base) are a "
+            "USER-level concern. Re-run with --user-space (or `python3 "
+            "framework/install/user_space.py`) to install them into ~/.claude with consent."
+        )
 
     print("\nNext:")
     print("  1. Review .claude/framework.config.json (scm.owner / policy / ci.tooling) and .claude/team/roster.json.")

--- a/framework/install/consent.py
+++ b/framework/install/consent.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Explicit opt-in consent for installer writes that touch user space (``~/.claude``).
+
+Part of the reusable user-space install toolkit introduced for #107 (consented
+user-level install) and reused by #108 (repo-level pattern). Stdlib-only, no deps.
+
+Public API
+==========
+``prompt_consent(summary, *, non_interactive) -> bool``
+    Return ``True`` **only** on an explicit interactive opt-in. The write policy is
+    fail-safe by construction — the function returns ``False`` (do not write) unless a
+    human is present and answers yes:
+
+    * ``non_interactive=True``           -> ``False`` (never prompt, never write).
+    * stdin is not a TTY                 -> ``False`` (no human to consent).
+    * answer is empty / not an explicit yes -> ``False`` (default is no).
+    * answer is ``y`` / ``yes`` (case-insensitive) -> ``True``.
+
+    ``summary`` is printed verbatim above the prompt so the caller controls exactly
+    what the user is consenting to (which file, which keys). Keep it specific.
+
+Contract note for callers (#108): treat a ``False`` return as "leave everything
+untouched". Never write to user space without a ``True`` from this function.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Callable
+
+
+def prompt_consent(
+    summary: str,
+    *,
+    non_interactive: bool,
+    _input: Callable[[str], str] = input,
+    _isatty: bool | None = None,
+) -> bool:
+    """Opt-in consent gate. See the module docstring for the exact policy.
+
+    ``_input`` / ``_isatty`` are injection seams for tests only; production callers
+    pass just ``summary`` and ``non_interactive``.
+    """
+    if non_interactive:
+        return False
+    isatty = _isatty if _isatty is not None else sys.stdin.isatty()
+    if not isatty:
+        return False
+    print(summary)
+    try:
+        answer = _input("Proceed with the above write to ~/.claude? [y/N]: ")
+    except EOFError:
+        return False
+    return answer.strip().lower() in ("y", "yes")

--- a/framework/install/user_space.py
+++ b/framework/install/user_space.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Consented, idempotent user-level install step (``~/.claude/settings.json``).
+
+Closes G1 from the #106 user-space audit: the framework's simulated-team workflow
+silently depends on harness-global settings the repo installer never writes — chiefly
+``env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1``. A fresh clone + ``2real-team init`` on a
+clean machine produces a correct project ``.claude/`` but a harness that cannot spawn a
+team. This step fills that gap **safely**: check-existing first, consent-gated, merge-only,
+never clobbering a user's own value.
+
+Stdlib-only, fail-open consistent with the rest of the installer.
+
+Reusable API (imported by the repo-level pattern, #108)
+=======================================================
+``merge_settings(path, desired, *, non_interactive) -> Result``
+    The full idempotent merge operation for a JSON settings file. Reads ``path``, plans a
+    deep merge of ``desired`` against it, and applies the plan **only after consent**,
+    following these per-key rules (owner-mandated, "check-existing FIRST"):
+
+    * key already present AND **equal** to desired -> no-op, not offered, reported as
+      *matched*. If every desired key matches, the function returns without prompting or
+      writing (``status="already-configured"``).
+    * key **missing** -> offered in the consent summary; on consent it is added.
+    * key present but a **different** scalar (or a type mismatch) -> surfaced as a
+      *conflict* and **never written** — the user's value is left exactly as-is.
+    * list values (e.g. ``permissions.allow``) are **unioned** — desired entries not
+      already present are appended; existing entries and order are preserved. Union is
+      non-destructive, so it is applied as an addition (still consent-gated).
+
+    Writing happens iff there is at least one addition AND consent is granted. Before any
+    write, the existing file (if present) is backed up via ``backup.backup_file``. The
+    merge is applied to an in-memory copy, so a declined/skipped run touches nothing.
+    ``non_interactive=True`` guarantees zero writes (consent is denied unprompted).
+
+    Composes the two lower-level primitives so #108 can reuse the whole flow:
+    ``consent.prompt_consent`` (opt-in gate) and ``backup.backup_file`` (restorable backup).
+    A ``consent_fn`` seam is provided for tests; production callers omit it.
+
+``Result`` (dataclass) — machine-readable outcome:
+    ``status``   : ``"already-configured" | "written" | "skipped" | "no-target"
+                    | "conflicts-only" | "error"``
+    ``added``    : dotted paths (and ``list[]=…`` entries) that were / would be added
+    ``matched``  : dotted paths already equal to desired
+    ``conflicts``: ``Conflict(path, existing, desired)`` divergences left untouched
+    ``backup``   : ``Path`` of the timestamped backup, or ``None``
+    ``written``  : whether the file was actually modified
+
+``DESIRED_USER_SETTINGS`` — the G1..G4-user set this step installs (see the audit).
+``user_settings_path(home=None)`` — resolve ``<home>/.claude/settings.json``.
+``install_user_space(*, home=None, non_interactive, ...)`` — convenience wrapper that
+targets the real user settings file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+from backup import backup_file
+from consent import prompt_consent
+
+# --------------------------------------------------------------------------- desired set
+
+#: The generically-useful, load-bearing user-space settings the installer owns (#106 audit).
+#: G1: the agent-teams flag the whole team workflow depends on. G2: teammate spawn UX.
+#: G3: the mandated worktree isolation default. G4-user: the ``~/.claude/**`` permission
+#: globs (owner-approved split — repo-relative ``.claude/**`` perms stay in the repo
+#: installer's settings.template.json and are intentionally NOT duplicated here).
+DESIRED_USER_SETTINGS: dict[str, Any] = {
+    "env": {
+        "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",  # G1 — enables team spawning
+    },
+    "teammateMode": "auto",  # G2 — teammate spawn UX
+    "worktree": {
+        "baseRef": "fresh",  # G3 — mandated worktree isolation base
+    },
+    "permissions": {
+        # G4-user — absolute home globs so orchestrator writes to user space
+        # don't prompt. Kept generic (``~``-anchored, no machine paths); union-merged.
+        "allow": [
+            "Edit(~/.claude/**)",
+            "Read(~/.claude/**)",
+            "Write(~/.claude/**)",
+        ],
+    },
+}
+
+
+# ------------------------------------------------------------------------------- results
+
+
+@dataclass(frozen=True)
+class Conflict:
+    """A desired key that diverges from an existing user value (left untouched)."""
+
+    path: str
+    existing: Any
+    desired: Any
+
+
+@dataclass
+class Result:
+    """Machine-readable outcome of :func:`merge_settings`. See module docstring."""
+
+    status: str
+    added: list[str] = field(default_factory=list)
+    matched: list[str] = field(default_factory=list)
+    conflicts: list[Conflict] = field(default_factory=list)
+    backup: Path | None = None
+    written: bool = False
+
+
+# --------------------------------------------------------------------------------- merge
+
+
+def _plan_merge(
+    existing: dict,
+    desired: dict,
+    prefix: str,
+    added: list[str],
+    matched: list[str],
+    conflicts: list[Conflict],
+) -> None:
+    """Deep-merge ``desired`` into ``existing`` (mutated in place), recording the plan.
+
+    Applies additions and list-unions to ``existing``; records — but does NOT apply —
+    divergent scalars / type mismatches as conflicts. See module docstring for the rules.
+    """
+    for key, dval in desired.items():
+        dotted = f"{prefix}.{key}" if prefix else key
+        if key not in existing:
+            existing[key] = copy.deepcopy(dval)
+            _collect_added(dotted, dval, added)
+            continue
+        eval_ = existing[key]
+        if isinstance(dval, dict) and isinstance(eval_, dict):
+            _plan_merge(eval_, dval, dotted, added, matched, conflicts)
+        elif isinstance(dval, list) and isinstance(eval_, list):
+            for item in dval:
+                if item in eval_:
+                    matched.append(f"{dotted}[]={item!r}")
+                else:
+                    eval_.append(item)
+                    added.append(f"{dotted}[]={item!r}")
+        elif isinstance(dval, (dict, list)) or isinstance(eval_, (dict, list)):
+            # container-vs-scalar (or list-vs-dict) type mismatch — never coerce.
+            conflicts.append(Conflict(dotted, eval_, dval))
+        elif eval_ == dval:
+            matched.append(dotted)
+        else:
+            conflicts.append(Conflict(dotted, eval_, dval))
+
+
+def _collect_added(dotted: str, value: Any, added: list[str]) -> None:
+    """Record a freshly-added subtree as individual leaf paths (for a readable summary)."""
+    if isinstance(value, dict):
+        for k, v in value.items():
+            _collect_added(f"{dotted}.{k}", v, added)
+    elif isinstance(value, list):
+        for item in value:
+            added.append(f"{dotted}[]={item!r}")
+    else:
+        added.append(f"{dotted}={value!r}")
+
+
+def _summary(path: Path, added: list[str], conflicts: list[Conflict]) -> str:
+    """Human-readable consent summary of exactly what will change."""
+    lines = [f"About to amend {path} (merge-only; your other settings are preserved):"]
+    lines.append("  ADD:")
+    for a in added:
+        lines.append(f"    + {a}")
+    if conflicts:
+        lines.append("  CONFLICT (left as-is, NOT changed):")
+        for c in conflicts:
+            lines.append(f"    ! {c.path}: yours={c.existing!r} (desired {c.desired!r})")
+    lines.append("A timestamped backup of the current file is taken before writing.")
+    return "\n".join(lines)
+
+
+def merge_settings(
+    path: Path | str,
+    desired: dict,
+    *,
+    non_interactive: bool,
+    consent_fn: Callable[[str], bool] | None = None,
+) -> Result:
+    """Idempotently, consent-gated, merge ``desired`` into the JSON file at ``path``.
+
+    See the module docstring for the full contract. ``consent_fn`` (test seam) overrides
+    the default :func:`consent.prompt_consent`; it receives the summary and returns the
+    opt-in decision.
+    """
+    path = Path(path)
+    existing: dict = {}
+    if path.exists():
+        try:
+            existing = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return Result(status="error")
+        if not isinstance(existing, dict):
+            return Result(status="error")
+
+    merged = copy.deepcopy(existing)
+    added: list[str] = []
+    matched: list[str] = []
+    conflicts: list[Conflict] = []
+    _plan_merge(merged, desired, "", added, matched, conflicts)
+
+    # Check-existing FIRST: nothing to add -> never prompt, never write.
+    if not added:
+        status = "conflicts-only" if conflicts else "already-configured"
+        return Result(status=status, matched=matched, conflicts=conflicts)
+
+    summary = _summary(path, added, conflicts)
+    granted = (consent_fn or _default_consent(non_interactive))(summary)
+    if not granted:
+        return Result(
+            status="skipped", added=added, matched=matched, conflicts=conflicts
+        )
+
+    backup = backup_file(path)  # None if the file does not exist yet
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(merged, indent=2) + "\n", encoding="utf-8")
+    return Result(
+        status="written",
+        added=added,
+        matched=matched,
+        conflicts=conflicts,
+        backup=backup,
+        written=True,
+    )
+
+
+def _default_consent(non_interactive: bool) -> Callable[[str], bool]:
+    """Bind :func:`consent.prompt_consent` to the run's interactivity."""
+    return lambda summary: prompt_consent(summary, non_interactive=non_interactive)
+
+
+# --------------------------------------------------------------------------- convenience
+
+
+def user_settings_path(home: Path | None = None) -> Path:
+    """Resolve ``<home>/.claude/settings.json`` (``home`` defaults to ``Path.home()``)."""
+    return (home or Path.home()) / ".claude" / "settings.json"
+
+
+def install_user_space(
+    *,
+    home: Path | None = None,
+    non_interactive: bool,
+    path: Path | None = None,
+    consent_fn: Callable[[str], bool] | None = None,
+) -> Result:
+    """Install :data:`DESIRED_USER_SETTINGS` into the user's settings file.
+
+    Wrapper over :func:`merge_settings` that resolves the real target
+    (``~/.claude/settings.json``). ``path`` / ``home`` are override seams (tests pass a
+    fake HOME so the real user space is never touched).
+    """
+    target = path or user_settings_path(home)
+    return merge_settings(
+        target, DESIRED_USER_SETTINGS, non_interactive=non_interactive, consent_fn=consent_fn
+    )
+
+
+# --------------------------------------------------------------------------------- report
+
+
+def report(result: Result, path: Path) -> str:
+    """One-block human summary of a :func:`merge_settings` outcome for installer output."""
+    lines = ["-- user-level install (~/.claude/settings.json) --"]
+    if result.status == "already-configured":
+        lines.append(f"already configured: {path} has every desired key. No prompt, no write.")
+        return "\n".join(lines)
+    if result.status == "conflicts-only":
+        lines.append("nothing to add; the following differ from your values (left as-is):")
+        for c in result.conflicts:
+            lines.append(f"  ! {c.path}: yours={c.existing!r} (desired {c.desired!r})")
+        return "\n".join(lines)
+    if result.status == "error":
+        lines.append(f"skipped: {path} is not valid JSON — left untouched.")
+        return "\n".join(lines)
+    if result.status == "skipped":
+        lines.append("skipped: no consent (or non-interactive). Nothing written.")
+        lines.append(f"  would have added: {', '.join(result.added)}")
+        if result.conflicts:
+            for c in result.conflicts:
+                lines.append(f"  ! conflict (untouched): {c.path} yours={c.existing!r}")
+        return "\n".join(lines)
+    # written
+    lines.append(f"written: amended {path}")
+    lines.append(f"  added: {', '.join(result.added)}")
+    if result.backup is not None:
+        lines.append(f"  backup: {result.backup}")
+    if result.conflicts:
+        for c in result.conflicts:
+            lines.append(f"  ! conflict left untouched: {c.path} yours={c.existing!r}")
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------------- CLI
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Consented, idempotent user-level install of the framework's "
+        "harness-global settings into ~/.claude/settings.json (closes #106 G1).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument(
+        "--non-interactive",
+        action="store_true",
+        help="Never prompt; the safe default is to SKIP (write nothing) unprompted.",
+    )
+    ap.add_argument(
+        "--home",
+        metavar="DIR",
+        help="Override the home directory (targets <DIR>/.claude/settings.json). "
+        "For testing / non-standard layouts; defaults to the real ~.",
+    )
+    args = ap.parse_args(argv)
+
+    home = Path(args.home).resolve() if args.home else None
+    target = user_settings_path(home)
+    result = install_user_space(home=home, non_interactive=args.non_interactive)
+    print(report(result, target))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/framework/tests/test_user_space_install.py
+++ b/framework/tests/test_user_space_install.py
@@ -1,0 +1,251 @@
+"""Tests for the consented user-level install step (#107, closes #106 G1).
+
+Covers BOTH acceptance cases with a FAKE HOME (``tmp_path``) — the real ``~/.claude`` is
+never read or written:
+
+* fresh-user  — no ``~/.claude/settings.json`` (and an existing-file-missing-the-flag
+  variant): the consent path writes the desired keys correctly and, when a prior file
+  exists, a restorable timestamped backup is created.
+* existing-user — the flag already set: **no-op, no write, no prompt**; a divergent value
+  is surfaced as a conflict and **never clobbered**.
+* ``--non-interactive`` guarantees ZERO writes on every path.
+
+Also unit-tests the reusable primitives (``backup_file`` / ``prompt_consent``) and the
+merge/idempotency contract #108 will build on. Stdlib + pytest only.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+_INSTALL = _FRAMEWORK_ROOT / "install"
+if str(_INSTALL) not in sys.path:
+    sys.path.insert(0, str(_INSTALL))
+
+import backup as backup_mod  # noqa: E402
+import consent as consent_mod  # noqa: E402
+import user_space  # noqa: E402
+from user_space import DESIRED_USER_SETTINGS, Result, merge_settings  # noqa: E402
+
+_YES = lambda summary: True  # noqa: E731 — test consent seam (opt-in)
+_NO = lambda summary: False  # noqa: E731 — test consent seam (declined)
+
+
+def _read(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+# ------------------------------------------------------------------ fresh-user cases
+
+
+def test_fresh_user_no_settings_consented_write_creates_file(tmp_path: Path) -> None:
+    """Fresh user, no settings.json: consent path writes every desired key correctly."""
+    home = tmp_path / "home"
+    path = user_space.user_settings_path(home)
+    assert not path.exists()
+
+    result = user_space.install_user_space(home=home, non_interactive=False, consent_fn=_YES)
+
+    assert result.status == "written"
+    assert result.written is True
+    assert result.backup is None  # nothing existed to back up
+    data = _read(path)
+    assert data["env"]["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] == "1"
+    assert data["teammateMode"] == "auto"
+    assert data["worktree"]["baseRef"] == "fresh"
+    for glob in DESIRED_USER_SETTINGS["permissions"]["allow"]:
+        assert glob in data["permissions"]["allow"]
+
+
+def test_fresh_user_existing_file_missing_flag_amended_and_backed_up(tmp_path: Path) -> None:
+    """Existing settings without the flag: amend in place, back up, preserve other keys."""
+    home = tmp_path / "home"
+    path = user_space.user_settings_path(home)
+    path.parent.mkdir(parents=True)
+    original = {"model": "opus[1m]", "effortLevel": "high", "env": {"FOO": "bar"}}
+    path.write_text(json.dumps(original, indent=2) + "\n", encoding="utf-8")
+    original_bytes = path.read_bytes()
+
+    result = user_space.install_user_space(home=home, non_interactive=False, consent_fn=_YES)
+
+    assert result.status == "written"
+    # backup created, timestamped, and RESTORABLE (byte-identical to the original).
+    assert result.backup is not None and result.backup.exists()
+    assert result.backup.read_bytes() == original_bytes
+    assert result.backup.name.startswith("settings.json.")
+    # amended in place: new keys added, user's own keys untouched.
+    data = _read(path)
+    assert data["model"] == "opus[1m]"  # personal pref preserved
+    assert data["effortLevel"] == "high"  # personal pref preserved
+    assert data["env"]["FOO"] == "bar"  # existing env key preserved
+    assert data["env"]["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] == "1"  # G1 added
+    assert data["worktree"]["baseRef"] == "fresh"
+
+
+# --------------------------------------------------------------- existing-user cases
+
+
+def test_existing_user_flag_already_set_is_noop_no_write_no_prompt(tmp_path: Path) -> None:
+    """Existing user with every desired key already present: no-op, no write, NO prompt."""
+    home = tmp_path / "home"
+    path = user_space.user_settings_path(home)
+    path.parent.mkdir(parents=True)
+    seed = json.loads(json.dumps(DESIRED_USER_SETTINGS))
+    seed["model"] = "opus[1m]"  # plus some unrelated user prefs
+    path.write_text(json.dumps(seed, indent=2) + "\n", encoding="utf-8")
+    before = path.read_bytes()
+
+    def _explode(summary: str) -> bool:  # consent must NOT be called on a full match
+        raise AssertionError("prompt_consent must not be called when already configured")
+
+    result = user_space.install_user_space(home=home, non_interactive=False, consent_fn=_explode)
+
+    assert result.status == "already-configured"
+    assert result.written is False
+    assert not result.added
+    assert path.read_bytes() == before  # byte-identical: nothing written
+
+
+def test_divergent_value_surfaces_conflict_and_never_clobbers(tmp_path: Path) -> None:
+    """A user-set divergent value is surfaced as a conflict and left exactly as-is."""
+    home = tmp_path / "home"
+    path = user_space.user_settings_path(home)
+    path.parent.mkdir(parents=True)
+    # user chose split-panes; the desired teammateMode is "auto" -> divergence.
+    seed = {"teammateMode": "split-panes", "worktree": {"baseRef": "fresh"}}
+    path.write_text(json.dumps(seed, indent=2) + "\n", encoding="utf-8")
+
+    result = user_space.install_user_space(home=home, non_interactive=False, consent_fn=_YES)
+
+    conflict_paths = {c.path for c in result.conflicts}
+    assert "teammateMode" in conflict_paths
+    conflict = next(c for c in result.conflicts if c.path == "teammateMode")
+    assert conflict.existing == "split-panes" and conflict.desired == "auto"
+    # the flag (an ADD) still went in, but the user's teammateMode was NOT clobbered.
+    data = _read(path)
+    assert data["teammateMode"] == "split-panes"  # untouched
+    assert data["env"]["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] == "1"  # added alongside
+
+
+# --------------------------------------------------------- --non-interactive & consent
+
+
+def test_non_interactive_never_writes_fresh(tmp_path: Path) -> None:
+    """--non-interactive on a fresh user: skip, zero writes, file stays absent."""
+    home = tmp_path / "home"
+    path = user_space.user_settings_path(home)
+
+    result = user_space.install_user_space(home=home, non_interactive=True)
+
+    assert result.status == "skipped"
+    assert result.written is False
+    assert not path.exists()  # never created
+
+
+def test_non_interactive_never_writes_existing(tmp_path: Path) -> None:
+    """--non-interactive with a divergent existing file: skip, byte-identical, no backup."""
+    home = tmp_path / "home"
+    path = user_space.user_settings_path(home)
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps({"teammateMode": "split-panes"}) + "\n", encoding="utf-8")
+    before = path.read_bytes()
+
+    result = user_space.install_user_space(home=home, non_interactive=True)
+
+    assert result.status == "skipped"
+    assert path.read_bytes() == before
+    # no backup file was produced by a skipped run.
+    assert not any(p.name.startswith("settings.json.") for p in path.parent.iterdir())
+
+
+def test_consent_declined_writes_nothing(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    path = user_space.user_settings_path(home)
+
+    result = user_space.install_user_space(home=home, non_interactive=False, consent_fn=_NO)
+
+    assert result.status == "skipped"
+    assert result.added  # there WAS something to add...
+    assert not path.exists()  # ...but consent was declined -> no write
+
+
+def test_rerun_after_write_is_idempotent(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    path = user_space.user_settings_path(home)
+    user_space.install_user_space(home=home, non_interactive=False, consent_fn=_YES)
+    after_first = path.read_bytes()
+
+    second = user_space.install_user_space(home=home, non_interactive=False, consent_fn=_NO)
+
+    assert second.status == "already-configured"
+    assert path.read_bytes() == after_first  # re-run changed nothing
+
+
+def test_invalid_json_is_left_untouched(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    path = user_space.user_settings_path(home)
+    path.parent.mkdir(parents=True)
+    path.write_text("{ not valid json", encoding="utf-8")
+
+    result = merge_settings(path, DESIRED_USER_SETTINGS, non_interactive=False, consent_fn=_YES)
+
+    assert result.status == "error"
+    assert path.read_text(encoding="utf-8") == "{ not valid json"  # untouched
+
+
+# ---------------------------------------------------------- reusable primitives (unit)
+
+
+def test_backup_file_absent_source_is_noop() -> None:
+    assert backup_mod.backup_file(Path("/nonexistent/does/not/exist.json")) is None
+
+
+def test_backup_file_is_restorable_and_non_clobbering(tmp_path: Path) -> None:
+    src = tmp_path / "settings.json"
+    src.write_text("v1", encoding="utf-8")
+    b1 = backup_mod.backup_file(src)
+    assert b1 is not None and b1.read_text() == "v1"
+    src.write_text("v2", encoding="utf-8")
+    b2 = backup_mod.backup_file(src)  # same second must not clobber b1
+    assert b2 is not None and b2 != b1
+    assert b1.read_text() == "v1"  # first backup intact -> restorable
+
+
+def test_prompt_consent_non_interactive_is_false() -> None:
+    assert consent_mod.prompt_consent("x", non_interactive=True) is False
+
+
+def test_prompt_consent_non_tty_is_false() -> None:
+    assert consent_mod.prompt_consent("x", non_interactive=False, _isatty=False) is False
+
+
+def test_prompt_consent_yes_only_on_explicit_yes() -> None:
+    assert consent_mod.prompt_consent(
+        "x", non_interactive=False, _isatty=True, _input=lambda _p: "y"
+    ) is True
+    assert consent_mod.prompt_consent(
+        "x", non_interactive=False, _isatty=True, _input=lambda _p: "yes"
+    ) is True
+    for no in ("", "n", "no", "nope", "Y E S"):
+        assert consent_mod.prompt_consent(
+            "x", non_interactive=False, _isatty=True, _input=lambda _p, v=no: v
+        ) is False
+
+
+# --------------------------------------------------------------- CLI entrypoint (safe)
+
+
+def test_cli_non_interactive_skips_and_never_touches_real_home(tmp_path: Path) -> None:
+    """The standalone CLI with --non-interactive writes nothing under a fake HOME."""
+    home = tmp_path / "home"
+    rc = user_space.main(["--non-interactive", "--home", str(home)])
+    assert rc == 0
+    assert not (home / ".claude" / "settings.json").exists()
+
+
+def test_result_dataclass_shape() -> None:
+    r = Result(status="written")
+    assert r.added == [] and r.matched == [] and r.conflicts == [] and r.backup is None


### PR DESCRIPTION
## Summary

Closes #107. Adds a **consented, idempotent user-level install step** that ensures the framework's harness-global settings live in `~/.claude/settings.json` — closing **G1** from my #106 audit (the single load-bearing invisible dependency: `env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`, without which a fresh clone + `init` produces a correct project `.claude/` but a harness that **cannot spawn a team**).

Desired set installed (`DESIRED_USER_SETTINGS`, per the owner-approved dispositions):
- `env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1"` (G1)
- `teammateMode = "auto"` (G2)
- `worktree.baseRef = "fresh"` (G3)
- `permissions.allow` `~/.claude/**` Edit/Read/Write globs (G4-user)

### How idempotent check-existing works (owner requirement, "check-existing FIRST")
`merge_settings` reads the file and plans a deep merge **before** prompting or writing:
- key present **and equal** to desired → **no-op, not offered, no prompt** (reported *matched*). If every key matches, returns `already-configured` without prompting/writing.
- key **missing** → included in the consent summary; on consent, added.
- key present but a **different** scalar (or type mismatch) → surfaced as a **conflict** and **never written** — the user's value is left exactly as-is.
- list values (`permissions.allow`) → **union** (non-destructive), applied as an addition.

A write happens **iff** there is ≥1 addition **and** consent is granted; the existing file is backed up (timestamped, restorable) first, then amended in place (merge keys) — never blanket-overwritten.

### Safety / consent
- Explicit opt-in prompt before **any** write to `~/.claude`.
- `--non-interactive` (and non-TTY) → consent denied unprompted → **zero writes**.
- Timestamped `.bak` before amending; never clobbers an existing backup.
- Invalid-JSON existing file → left untouched (`error`).

### Wiring
- Opt-in `--user-space` flag on `bootstrap.py` runs the step after the repo install (merge-only; `--non-interactive` skips; `--dry-run` never writes). Without the flag a one-line hint points at it.
- Standalone entrypoint: `python3 framework/install/user_space.py [--non-interactive] [--home DIR]`.

### Verification
- `python3 -m pytest framework/tests/ -q` → **392 passed**
- `ruff check framework/` → clean
- `python3 framework/install/reinstall.py --check` → in sync
- Manually exercised the standalone CLI + `bootstrap --user-space` against a fake HOME (skip on non-interactive; consented amend preserves `model`/prefs + creates a backup). The real `~/.claude` was never touched.

## Reusable API for #108

Canonical, stdlib-only, fail-open modules in `framework/install/` (Paloma's repo-level step imports these):

- `consent.py` — `prompt_consent(summary: str, *, non_interactive: bool) -> bool`
  Opt-in gate. `non_interactive=True` or non-TTY → `False`; `True` only on an explicit `y`/`yes`. Never writes unprompted.
- `backup.py` — `backup_file(path) -> Optional[Path]`
  Copies `path` → `<name>.<UTC-stamp>.bak` (mode/mtime preserved, restorable). `None` no-op if the source is absent; numeric suffix so an existing backup is never clobbered.
- `user_space.py` — `merge_settings(path, desired: dict, *, non_interactive: bool) -> Result`
  The full idempotent, consent-gated merge (rules above). Composes `prompt_consent` + `backup_file`. Optional `consent_fn` test seam. Also exports `Result`/`Conflict` dataclasses, `DESIRED_USER_SETTINGS`, `user_settings_path(home=None)`, `install_user_space(...)`, and `report(...)`. Each function's contract is documented in the module docstring.

Fresh-vs-existing test names (fake HOME, `framework/tests/test_user_space_install.py`):
- fresh: `test_fresh_user_no_settings_consented_write_creates_file`, `test_fresh_user_existing_file_missing_flag_amended_and_backed_up`
- existing: `test_existing_user_flag_already_set_is_noop_no_write_no_prompt`, `test_divergent_value_surfaces_conflict_and_never_clobbers`
- non-interactive: `test_non_interactive_never_writes_fresh`, `test_non_interactive_never_writes_existing`

## Charter review

- **Identity:** committed as Ibrahim El-Amin via per-commit `-c` flags; two `Co-Authored-By` trailers; no global/repo git config touched; hooks ran (no `--no-verify`).
- **Worktree isolation:** authored in an isolated worktree off `deployments/phase5/wave-2`.
- **Dual-deploy:** installer *code* is canonical in `framework/install/` and bundles into the CLI package the same way as its siblings (`install_config`/`roster_gen`); `reinstall --check` stays green (it manages byte-mirrored `skills/` only — installer code is canonical-by-reference).
- **Owner decision — permission-glob split:** only the `~/.claude/**` globs are shipped here; repo-relative `.claude/**` perms stay in the repo installer's `settings.template.json` and are **not** duplicated. **Reviewer note:** the audit's "cross-repo permission globs" (e.g. absolute `code/**/.claude/**`) are intentionally **omitted** — they are machine-shaped and hardcoding a machine path would violate the "generic, no absolute paths" rule the `settings.template.json` lint test enforces. Flagging for confirmation this interpretation is acceptable.
- **Approval gates:** targets `deployments/phase5/wave-2` (not main). **DO NOT merge** without owner sign-off.

Reviewer: **Paloma Gupta**.

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTQxgBAcChxvdQJafKyMdX
