### PR TITLE
feat(#108): repo-level consent + backup/archive/restore; atomic settings write (#145)

### DIFF
--- a/framework/install/atomic_io.py
+++ b/framework/install/atomic_io.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Atomic text-file writes for consent-gated installer writes (#145).
+
+Shared by the user-level (#107) and repo-level (#108) install paths — the write
+primitive both settle on. Writing a settings / manifest file with a plain
+``path.write_text`` truncates the target to zero bytes first, so a crash or
+interrupt mid-write can leave a corrupt, partially-written file. Recoverable from
+a backup, but the write itself should never be able to strand a half-file.
+
+``atomic_write_text`` writes the full contents to a uniquely-named temp file in
+the SAME directory, flushes + fsyncs it, then ``os.replace``s it onto the target.
+``os.replace`` is an atomic rename on POSIX (and same-volume on Windows), so any
+concurrent reader — and any post-crash observer — sees either the old file intact
+or the complete new file, never a truncated in-between. Stdlib-only.
+
+Public API
+==========
+``atomic_write_text(path, text, *, encoding="utf-8") -> None``
+    Create ``path``'s parent if needed, write ``text`` to a temp file in the same
+    directory (so the final rename stays on one filesystem and is therefore
+    atomic), then ``os.replace`` it into place. The temp file is removed on any
+    error before the replace, so a failed write leaves neither a stray temp nor a
+    damaged target.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+
+def atomic_write_text(path: Path | str, text: str, *, encoding: str = "utf-8") -> None:
+    """Atomically write ``text`` to ``path`` (temp file in the same dir + ``os.replace``)."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding=encoding) as fh:
+            fh.write(text)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp, path)  # atomic rename onto the target (same filesystem)
+    except BaseException:
+        # Never leave a stray temp file behind; the target is untouched until replace.
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise

--- a/framework/install/bootstrap.py
+++ b/framework/install/bootstrap.py
@@ -88,6 +88,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import child_install  # noqa: E402  (sibling module in install/)
 import install_config  # noqa: E402  (sibling module in install/)
+import repo_space  # noqa: E402  (sibling module in install/)
 import roster_gen  # noqa: E402  (sibling module in install/)
 
 # framework/install/bootstrap.py  ->  framework/
@@ -1302,6 +1303,34 @@ def main() -> int:
     if not proceed:
         print("ERROR: refusing to install (repo expectation gate).", file=sys.stderr)
         return 1
+
+    # Repo-level disposition (#108): if the target already carries FOREIGN Claude
+    # assets (a .claude/ or CLAUDE.md we did NOT install), offer — with explicit
+    # consent — to ARCHIVE them out of Claude's scope for a fresh install, or amend
+    # them in place. Non-interactive / non-TTY / dry-run take the safe non-destructive
+    # path (amend), preserving today's behaviour for CI. Skipped on our own idempotent
+    # re-runs (state["installed"]) and when there is nothing existing to touch.
+    if not args.dry_run and not state["installed"] and repo_space.has_existing_assets(target):
+        prep = repo_space.prepare_for_install(target, non_interactive=args.non_interactive)
+        if prep.action == "cancel":
+            print(
+                "aborted: existing repo Claude assets left untouched "
+                "(no consent to archive; nothing written).",
+                file=sys.stderr,
+            )
+            return 1
+        if prep.action == "archived":
+            print("\n-- repo Claude assets archived (out of Claude's scope; restorable) --")
+            print(f"moved:   {', '.join(prep.archive.moved)} -> {prep.archive.archive_dir}")
+            print(
+                f"restore: python3 framework/install/repo_space.py restore "
+                f"{prep.archive.archive_dir}"
+            )
+        elif prep.action == "amend":
+            print(
+                "\nexisting repo Claude assets: amending in place "
+                "(idempotent; nothing archived)."
+            )
 
     # The CHILD install mode is a different layout (no hook code of its own) —
     # dedicated path.

--- a/framework/install/consent.py
+++ b/framework/install/consent.py
@@ -6,7 +6,7 @@ user-level install) and reused by #108 (repo-level pattern). Stdlib-only, no dep
 
 Public API
 ==========
-``prompt_consent(summary, *, non_interactive) -> bool``
+``prompt_consent(summary, *, non_interactive, prompt=None) -> bool``
     Return ``True`` **only** on an explicit interactive opt-in. The write policy is
     fail-safe by construction — the function returns ``False`` (do not write) unless a
     human is present and answers yes:
@@ -18,6 +18,9 @@ Public API
 
     ``summary`` is printed verbatim above the prompt so the caller controls exactly
     what the user is consenting to (which file, which keys). Keep it specific.
+    ``prompt`` overrides the question line so the same gate serves user-space (#107,
+    the default ``~/.claude`` wording) and repo-level (#108) writes; omit it for the
+    user-space default.
 
 Contract note for callers (#108): treat a ``False`` return as "leave everything
 untouched". Never write to user space without a ``True`` from this function.
@@ -28,18 +31,24 @@ from __future__ import annotations
 import sys
 from typing import Callable
 
+#: Default question line (user-space #107 wording). ``prompt_consent(prompt=...)``
+#: overrides it for repo-level (#108) writes.
+_DEFAULT_PROMPT = "Proceed with the above write to ~/.claude? [y/N]: "
+
 
 def prompt_consent(
     summary: str,
     *,
     non_interactive: bool,
+    prompt: str | None = None,
     _input: Callable[[str], str] = input,
     _isatty: bool | None = None,
 ) -> bool:
     """Opt-in consent gate. See the module docstring for the exact policy.
 
+    ``prompt`` overrides the question line (defaults to the user-space wording).
     ``_input`` / ``_isatty`` are injection seams for tests only; production callers
-    pass just ``summary`` and ``non_interactive``.
+    pass just ``summary`` and ``non_interactive`` (plus ``prompt`` for repo-level).
     """
     if non_interactive:
         return False
@@ -48,7 +57,7 @@ def prompt_consent(
         return False
     print(summary)
     try:
-        answer = _input("Proceed with the above write to ~/.claude? [y/N]: ")
+        answer = _input(prompt or _DEFAULT_PROMPT)
     except EOFError:
         return False
     return answer.strip().lower() in ("y", "yes")

--- a/framework/install/repo_space.py
+++ b/framework/install/repo_space.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Consent-gated backup / archive / restore for REPO-level ``.claude`` assets (#108).
+
+Mirrors the user-level install UX (#107) for a repo's own Claude assets — the
+repo-root ``.claude/`` directory and ``CLAUDE.md``. Before an install replaces or
+overwrites a repo's existing Claude assets, the operator chooses — with explicit
+consent — between two dispositions:
+
+* **amend in place** (default, non-destructive): keep the existing assets; the
+  bootstrapper's idempotent merge / skip-if-exists steps augment them. This is
+  today's behaviour and the safe default for ``--non-interactive`` / non-TTY / CI.
+* **archive then fresh**: move the existing ``.claude/`` and ``CLAUDE.md`` OUT of
+  Claude's load scope into a timestamped ``.claude-backups/<UTC>/`` directory — which
+  Claude does NOT load — leaving a clean slate for a fresh install. Fully restorable.
+
+Why ``.claude-backups/`` and not somewhere under ``.claude/``: Claude loads exactly
+``.claude/`` and ``CLAUDE.md`` at the repo root. The archive is deliberately relocated
+to a sibling directory that is neither of those (and is NOT named ``.claude*``), so an
+archived copy is inert — it cannot shadow or be loaded alongside a fresh install.
+
+Reuses the #107 toolkit rather than reimplementing it: ``consent.prompt_consent`` (the
+opt-in gate, with a repo-scoped prompt line) and ``atomic_io.atomic_write_text`` (the
+atomic manifest write, #145). The timestamped, non-clobbering naming mirrors
+``backup.backup_file``'s scheme. Stdlib-only, no deps.
+
+Public API
+==========
+``has_existing_assets(repo_root) -> bool``
+    Whether the repo root carries any managed Claude asset (``.claude/`` or ``CLAUDE.md``).
+
+``choose_disposition(repo_root, *, non_interactive, chooser=None) -> str``
+    Resolve the archive-vs-amend decision. Fail-safe: returns ``"amend"`` (the
+    non-destructive path) for ``non_interactive`` or a non-TTY; an interactive TTY is
+    offered keep-&-amend / archive-&-fresh / cancel. Returns ``"amend" | "archive"
+    | "cancel"``. ``chooser`` is a test seam.
+
+``archive_assets(repo_root, *, now=None) -> ArchiveResult``
+    MOVE every existing managed asset into a fresh, non-clobbering
+    ``.claude-backups/<UTC>/`` directory and write a restore manifest there. Returns
+    the archive dir, the moved names, and the manifest path. No-op (empty result) when
+    there is nothing to archive.
+
+``restore_assets(repo_root, archive_dir, *, overwrite=False) -> RestoreResult``
+    MOVE archived assets back to their original repo-root locations, byte-identical.
+    Refuses to clobber a currently-present target (records it as a conflict) unless
+    ``overwrite=True``, which removes the current target first. Reads the manifest
+    written by :func:`archive_assets`.
+
+``prepare_for_install(repo_root, *, non_interactive, ...) -> PrepareResult``
+    The high-level entry the bootstrapper calls: no-op for a fresh repo; otherwise
+    resolves the disposition and, for archive, takes an explicit destructive consent
+    (via :func:`consent.prompt_consent`) BEFORE moving anything. Returns the action
+    taken (``"fresh" | "amend" | "archived" | "cancel"``) and any :class:`ArchiveResult`.
+
+CLI
+===
+  python3 repo_space.py archive <repo>
+  python3 repo_space.py restore <archive_dir> [--into <repo>] [--force]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+from atomic_io import atomic_write_text
+from consent import prompt_consent
+
+#: Repo-root Claude assets the harness loads (and that an install may replace).
+REPO_CLAUDE_ASSETS: tuple[str, ...] = (".claude", "CLAUDE.md")
+
+#: Container for relocated archives — a sibling of ``.claude/``, NOT under it and NOT
+#: named ``.claude*``, so Claude never loads an archived copy. One subdir per archive.
+BACKUPS_DIRNAME = ".claude-backups"
+
+#: Restore manifest dropped inside each archive dir (records what to move back where).
+MANIFEST_NAME = "archive-manifest.json"
+MANIFEST_VERSION = 1
+
+#: Destructive-action consent line (repo-scoped; overrides the user-space default).
+_CONSENT_PROMPT = (
+    "Archive the above repo Claude assets out of Claude's scope and install fresh? [y/N]: "
+)
+
+
+# ------------------------------------------------------------------------------- results
+
+
+@dataclass
+class ArchiveResult:
+    """Outcome of :func:`archive_assets`. ``archived`` is False on a no-op."""
+
+    archive_dir: Path | None = None
+    moved: list[str] = field(default_factory=list)
+    manifest_path: Path | None = None
+
+    @property
+    def archived(self) -> bool:
+        return bool(self.moved)
+
+
+@dataclass
+class RestoreResult:
+    """Outcome of :func:`restore_assets`. ``conflicts`` are targets left untouched."""
+
+    restored: list[str] = field(default_factory=list)
+    conflicts: list[str] = field(default_factory=list)
+
+
+@dataclass
+class PrepareResult:
+    """Outcome of :func:`prepare_for_install`.
+
+    ``action`` is one of ``"fresh"`` (no existing assets), ``"amend"`` (keep in place),
+    ``"archived"`` (existing assets relocated; see ``archive``), or ``"cancel"`` (no
+    consent — the caller must leave everything untouched and abort).
+    """
+
+    action: str
+    archive: ArchiveResult | None = None
+
+
+# --------------------------------------------------------------------------- detection
+
+
+def has_existing_assets(repo_root: Path | str) -> bool:
+    """True if any managed Claude asset (``.claude/`` or ``CLAUDE.md``) is present."""
+    root = Path(repo_root)
+    return any((root / name).exists() for name in REPO_CLAUDE_ASSETS)
+
+
+def _present_assets(root: Path) -> list[str]:
+    return [name for name in REPO_CLAUDE_ASSETS if (root / name).exists()]
+
+
+# --------------------------------------------------------------------- archive / restore
+
+
+def archive_assets(repo_root: Path | str, *, now: datetime | None = None) -> ArchiveResult:
+    """Move existing managed assets into ``.claude-backups/<UTC>/`` + write a manifest.
+
+    Deliberately relocates (moves, not copies) each asset OUT of Claude's load scope so
+    the archived copy is inert. The archive dir is non-clobbering (a numeric suffix is
+    added if the same-second dir exists). ``now`` is injectable for deterministic tests.
+    """
+    root = Path(repo_root)
+    present = _present_assets(root)
+    if not present:
+        return ArchiveResult()
+
+    moment = now or datetime.now(timezone.utc)
+    stamp = moment.strftime("%Y%m%dT%H%M%SZ")
+    base = root / BACKUPS_DIRNAME
+    archive_dir = base / stamp
+    n = 1
+    while archive_dir.exists():
+        archive_dir = base / f"{stamp}.{n}"
+        n += 1
+    archive_dir.mkdir(parents=True)
+
+    entries: list[dict] = []
+    moved: list[str] = []
+    for name in present:
+        src = root / name
+        dst = archive_dir / name
+        is_dir = src.is_dir()
+        shutil.move(str(src), str(dst))
+        entries.append({"name": name, "type": "dir" if is_dir else "file"})
+        moved.append(name)
+
+    manifest = {
+        "version": MANIFEST_VERSION,
+        "archived_utc": stamp,
+        "repo_root": str(root),
+        "entries": entries,
+    }
+    manifest_path = archive_dir / MANIFEST_NAME
+    atomic_write_text(manifest_path, json.dumps(manifest, indent=2) + "\n")
+    return ArchiveResult(archive_dir=archive_dir, moved=moved, manifest_path=manifest_path)
+
+
+def restore_assets(
+    repo_root: Path | str, archive_dir: Path | str, *, overwrite: bool = False
+) -> RestoreResult:
+    """Move archived assets back to their original repo-root locations, byte-identical.
+
+    Reads the manifest written by :func:`archive_assets`. A currently-present target is
+    NEVER clobbered unless ``overwrite=True`` (which removes the current target first,
+    e.g. a fresh install laid down after the archive); without it the member is left in
+    the archive and reported as a conflict. Restoring is idempotent for already-restored
+    members (a missing archive member is skipped).
+    """
+    root = Path(repo_root)
+    archive_dir = Path(archive_dir)
+    manifest_path = archive_dir / MANIFEST_NAME
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    result = RestoreResult()
+    for entry in manifest.get("entries", []):
+        name = entry["name"]
+        src = archive_dir / name
+        dst = root / name
+        if not src.exists():
+            continue  # already restored / member absent from the archive
+        if dst.exists() or dst.is_symlink():
+            if not overwrite:
+                result.conflicts.append(name)
+                continue
+            if dst.is_dir() and not dst.is_symlink():
+                shutil.rmtree(dst)
+            else:
+                dst.unlink()
+        shutil.move(str(src), str(dst))
+        result.restored.append(name)
+    return result
+
+
+# ------------------------------------------------------------------- disposition choice
+
+
+def _disposition_summary(root: Path) -> str:
+    present = ", ".join(_present_assets(root)) or "(none)"
+    return (
+        f"This repo already carries Claude assets: {present}\n"
+        f"  [k] keep & amend  — leave them; the installer augments them idempotently (default)\n"
+        f"  [a] archive & fresh — move them to {BACKUPS_DIRNAME}/<UTC>/ "
+        "(out of Claude's scope, restorable), then install fresh\n"
+        "  [c] cancel        — do nothing"
+    )
+
+
+def choose_disposition(
+    repo_root: Path | str,
+    *,
+    non_interactive: bool,
+    chooser: Callable[[], str] | None = None,
+    _isatty: bool | None = None,
+    _input: Callable[[str], str] = input,
+) -> str:
+    """Resolve archive-vs-amend. Fail-safe default is ``"amend"`` (non-destructive).
+
+    ``non_interactive`` or a non-TTY always returns ``"amend"`` (today's behaviour,
+    safe for CI). An interactive TTY is offered keep / archive / cancel. ``chooser``
+    is a test seam returning the decision directly; ``_isatty`` / ``_input`` are test
+    seams for the interactive path.
+    """
+    if non_interactive:
+        return "amend"
+    if chooser is not None:  # test seam: stands in for the interactive choice
+        return chooser()
+    isatty = _isatty if _isatty is not None else sys.stdin.isatty()
+    if not isatty:
+        return "amend"
+    print(_disposition_summary(Path(repo_root)))
+    try:
+        ans = _input("[k]eep & amend / [a]rchive & fresh / [c]ancel [keep]: ").strip().lower()
+    except EOFError:
+        return "cancel"
+    if ans in ("a", "archive"):
+        return "archive"
+    if ans in ("c", "cancel", "n", "no"):
+        return "cancel"
+    return "amend"
+
+
+def _archive_consent_summary(root: Path) -> str:
+    present = ", ".join(_present_assets(root)) or "(none)"
+    return (
+        f"About to ARCHIVE this repo's existing Claude assets ({present}):\n"
+        f"  - each is MOVED into {BACKUPS_DIRNAME}/<UTC-stamp>/ (out of Claude's load scope)\n"
+        "  - a restore manifest is written alongside them; restore is fully reversible\n"
+        f"  - the fresh install then writes a clean {REPO_CLAUDE_ASSETS[0]}/"
+    )
+
+
+def _default_consent(non_interactive: bool) -> Callable[[str], bool]:
+    """Bind :func:`consent.prompt_consent` to this run with the repo-scoped prompt."""
+    return lambda summary: prompt_consent(
+        summary, non_interactive=non_interactive, prompt=_CONSENT_PROMPT
+    )
+
+
+def prepare_for_install(
+    repo_root: Path | str,
+    *,
+    non_interactive: bool,
+    chooser: Callable[[], str] | None = None,
+    consent_fn: Callable[[str], bool] | None = None,
+    now: datetime | None = None,
+    _isatty: bool | None = None,
+) -> PrepareResult:
+    """Resolve + apply the pre-install disposition for a repo's existing Claude assets.
+
+    * no existing assets                         -> ``"fresh"`` (nothing to consent to).
+    * disposition ``amend``                      -> ``"amend"`` (proceed, non-destructive).
+    * disposition ``cancel``                     -> ``"cancel"`` (caller aborts).
+    * disposition ``archive`` + destructive consent granted -> archive, ``"archived"``.
+    * disposition ``archive`` + consent declined -> ``"cancel"`` (nothing moved).
+
+    ``chooser`` / ``consent_fn`` / ``_isatty`` are test seams; production callers pass
+    only ``repo_root`` and ``non_interactive``.
+    """
+    root = Path(repo_root)
+    if not has_existing_assets(root):
+        return PrepareResult(action="fresh")
+
+    disposition = choose_disposition(
+        root, non_interactive=non_interactive, chooser=chooser, _isatty=_isatty
+    )
+    if disposition == "cancel":
+        return PrepareResult(action="cancel")
+    if disposition == "amend":
+        return PrepareResult(action="amend")
+
+    # archive: take an EXPLICIT destructive consent before moving anything.
+    granted = (consent_fn or _default_consent(non_interactive))(_archive_consent_summary(root))
+    if not granted:
+        return PrepareResult(action="cancel")
+    return PrepareResult(action="archived", archive=archive_assets(root, now=now))
+
+
+# --------------------------------------------------------------------------------- CLI
+
+
+def _cmd_archive(args: argparse.Namespace) -> int:
+    root = Path(args.repo).resolve()
+    if not has_existing_assets(root):
+        print(f"nothing to archive: no {' / '.join(REPO_CLAUDE_ASSETS)} under {root}")
+        return 0
+    result = archive_assets(root)
+    print(f"archived {', '.join(result.moved)} -> {result.archive_dir}")
+    print(f"restore with: python3 {Path(__file__).name} restore {result.archive_dir}")
+    return 0
+
+
+def _cmd_restore(args: argparse.Namespace) -> int:
+    archive_dir = Path(args.archive_dir).resolve()
+    manifest_path = archive_dir / MANIFEST_NAME
+    if not manifest_path.is_file():
+        print(f"ERROR: no {MANIFEST_NAME} in {archive_dir} — not a repo_space archive.",
+              file=sys.stderr)
+        return 1
+    root = Path(args.into).resolve() if args.into else Path(
+        json.loads(manifest_path.read_text(encoding="utf-8")).get("repo_root", ".")
+    ).resolve()
+    result = restore_assets(root, archive_dir, overwrite=args.force)
+    if result.restored:
+        print(f"restored {', '.join(result.restored)} -> {root}")
+    if result.conflicts:
+        print(
+            f"skipped (already present at target; use --force to overwrite): "
+            f"{', '.join(result.conflicts)}",
+            file=sys.stderr,
+        )
+        return 1
+    if not result.restored:
+        print("nothing to restore (archive already empty).")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Consent-gated archive / restore of repo-level .claude assets (#108).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    a = sub.add_parser("archive", help="Move a repo's existing .claude/ + CLAUDE.md out of scope.")
+    a.add_argument("repo", nargs="?", default=".", help="Repo root (default: cwd).")
+    a.set_defaults(func=_cmd_archive)
+
+    r = sub.add_parser("restore", help="Restore an archive back to its original repo state.")
+    r.add_argument("archive_dir", help="The .claude-backups/<UTC>/ dir to restore from.")
+    r.add_argument("--into", metavar="DIR",
+                   help="Repo root to restore into (default: the manifest's repo_root).")
+    r.add_argument("--force", action="store_true",
+                   help="Overwrite a target that currently exists (removes it first).")
+    r.set_defaults(func=_cmd_restore)
+
+    args = ap.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/framework/install/user_space.py
+++ b/framework/install/user_space.py
@@ -60,6 +60,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
 
+from atomic_io import atomic_write_text
 from backup import backup_file
 from consent import prompt_consent
 
@@ -223,8 +224,9 @@ def merge_settings(
         )
 
     backup = backup_file(path)  # None if the file does not exist yet
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(merged, indent=2) + "\n", encoding="utf-8")
+    # Atomic write (#145): temp file in the same dir + os.replace, so an interrupt
+    # can never leave a truncated settings.json (the backup above stays a fallback).
+    atomic_write_text(path, json.dumps(merged, indent=2) + "\n")
     return Result(
         status="written",
         added=added,

--- a/framework/tests/test_repo_space.py
+++ b/framework/tests/test_repo_space.py
@@ -1,0 +1,347 @@
+"""Tests for repo-level consent + backup/archive/restore (#108) and atomic writes (#145).
+
+Everything runs under ``tmp_path`` — the real repo is never touched. Covers:
+
+* archive: existing repo Claude assets are MOVED out of Claude's load scope
+  (``.claude-backups/<UTC>/``, NOT under ``.claude/``), with a restore manifest.
+* restore: archived assets come back byte-identical; a present target is a conflict
+  unless ``overwrite=True``.
+* the KEY round-trip AC: install → archive existing → assert out-of-scope → restore
+  → original state byte-identical.
+* disposition + consent: non-interactive / non-TTY take the safe non-destructive
+  (amend) path; archive is only reached on explicit interactive consent.
+* #145 atomic write: the shared write path is temp-file + ``os.replace``; an interrupt
+  mid-write can never leave a truncated target (proven for BOTH repo_space and the
+  reused user_space path).
+
+Stdlib + pytest only.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+_INSTALL = _FRAMEWORK_ROOT / "install"
+if str(_INSTALL) not in sys.path:
+    sys.path.insert(0, str(_INSTALL))
+
+import atomic_io  # noqa: E402
+import consent as consent_mod  # noqa: E402
+import repo_space  # noqa: E402
+import user_space  # noqa: E402
+
+
+# ------------------------------------------------------------------- helpers / fixtures
+
+
+def _seed_repo(root: Path) -> dict[str, bytes]:
+    """Create a repo with existing .claude/ (nested) + CLAUDE.md; return a byte snapshot."""
+    claude = root / ".claude"
+    (claude / "team").mkdir(parents=True)
+    (claude / "settings.json").write_text('{"hooks": {"old": 1}}\n', encoding="utf-8")
+    (claude / "team" / "charter.md").write_text("# my charter\n", encoding="utf-8")
+    (root / "CLAUDE.md").write_text("# repo instructions\n", encoding="utf-8")
+    return _snapshot(root, (".claude", "CLAUDE.md"))
+
+
+def _snapshot(root: Path, names: tuple[str, ...]) -> dict[str, bytes]:
+    """Map every file under each named asset -> its bytes (deep, order-independent)."""
+    snap: dict[str, bytes] = {}
+    for name in names:
+        p = root / name
+        if p.is_dir():
+            for f in sorted(p.rglob("*")):
+                if f.is_file():
+                    snap[f.relative_to(root).as_posix()] = f.read_bytes()
+        elif p.is_file():
+            snap[name] = p.read_bytes()
+    return snap
+
+
+# --------------------------------------------------------------------------- detection
+
+
+def test_has_existing_assets(tmp_path: Path) -> None:
+    assert repo_space.has_existing_assets(tmp_path) is False
+    (tmp_path / "CLAUDE.md").write_text("x", encoding="utf-8")
+    assert repo_space.has_existing_assets(tmp_path) is True
+
+
+# ----------------------------------------------------------------------------- archive
+
+
+def test_archive_moves_assets_out_of_claude_scope(tmp_path: Path) -> None:
+    """Existing assets are relocated OUT of Claude's scope, with a manifest; originals gone."""
+    _seed_repo(tmp_path)
+    result = repo_space.archive_assets(tmp_path)
+
+    assert result.archived is True
+    assert set(result.moved) == {".claude", "CLAUDE.md"}
+    # Originals are gone from the repo root (moved, not copied).
+    assert not (tmp_path / ".claude").exists()
+    assert not (tmp_path / "CLAUDE.md").exists()
+    # The archive is under .claude-backups/, NOT under .claude/ and not named .claude*.
+    assert result.archive_dir.parent.name == repo_space.BACKUPS_DIRNAME
+    assert repo_space.BACKUPS_DIRNAME != ".claude"
+    assert ".claude/" not in result.archive_dir.as_posix().replace(
+        f"{repo_space.BACKUPS_DIRNAME}/", ""
+    )
+    # Archived content is intact + a manifest describes what to restore.
+    assert (result.archive_dir / ".claude" / "settings.json").read_text() == '{"hooks": {"old": 1}}\n'
+    manifest = json.loads(result.manifest_path.read_text())
+    assert {e["name"] for e in manifest["entries"]} == {".claude", "CLAUDE.md"}
+    assert {e["type"] for e in manifest["entries"]} == {"dir", "file"}
+
+
+def test_archive_noop_when_nothing_present(tmp_path: Path) -> None:
+    result = repo_space.archive_assets(tmp_path)
+    assert result.archived is False
+    assert result.archive_dir is None
+    assert not (tmp_path / repo_space.BACKUPS_DIRNAME).exists()
+
+
+def test_archive_dir_is_non_clobbering(tmp_path: Path) -> None:
+    """Two archives at the same UTC second never overwrite each other."""
+    from datetime import datetime, timezone
+
+    fixed = datetime(2026, 7, 5, 12, 0, 0, tzinfo=timezone.utc)
+    (tmp_path / "CLAUDE.md").write_text("v1", encoding="utf-8")
+    a1 = repo_space.archive_assets(tmp_path, now=fixed)
+    (tmp_path / "CLAUDE.md").write_text("v2", encoding="utf-8")
+    a2 = repo_space.archive_assets(tmp_path, now=fixed)
+    assert a1.archive_dir != a2.archive_dir
+    assert (a1.archive_dir / "CLAUDE.md").read_text() == "v1"  # first archive intact
+    assert (a2.archive_dir / "CLAUDE.md").read_text() == "v2"
+
+
+# ----------------------------------------------------------------------------- restore
+
+
+def test_restore_brings_assets_back_byte_identical(tmp_path: Path) -> None:
+    original = _seed_repo(tmp_path)
+    archived = repo_space.archive_assets(tmp_path)
+
+    result = repo_space.restore_assets(tmp_path, archived.archive_dir)
+
+    assert set(result.restored) == {".claude", "CLAUDE.md"}
+    assert not result.conflicts
+    assert _snapshot(tmp_path, (".claude", "CLAUDE.md")) == original  # byte-for-byte
+
+
+def test_restore_refuses_to_clobber_without_overwrite(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    archived = repo_space.archive_assets(tmp_path)
+    # A fresh install lays down a NEW CLAUDE.md at the original location.
+    (tmp_path / "CLAUDE.md").write_text("FRESH install\n", encoding="utf-8")
+
+    result = repo_space.restore_assets(tmp_path, archived.archive_dir)
+
+    assert "CLAUDE.md" in result.conflicts  # present target left untouched
+    assert (tmp_path / "CLAUDE.md").read_text() == "FRESH install\n"
+    assert ".claude" in result.restored  # the non-conflicting member still restored
+
+
+def test_restore_overwrite_replaces_present_target(tmp_path: Path) -> None:
+    original = _seed_repo(tmp_path)
+    archived = repo_space.archive_assets(tmp_path)
+    (tmp_path / "CLAUDE.md").write_text("FRESH\n", encoding="utf-8")
+
+    result = repo_space.restore_assets(tmp_path, archived.archive_dir, overwrite=True)
+
+    assert not result.conflicts
+    assert (tmp_path / "CLAUDE.md").read_bytes() == original["CLAUDE.md"]
+
+
+# -------------------------------------------------------- KEY round-trip acceptance test
+
+
+def test_round_trip_install_archive_out_of_scope_restore_identical(tmp_path: Path) -> None:
+    """install → archive existing → OUT of Claude's scope → restore → byte-identical original."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    original = _seed_repo(repo)
+
+    # 1. archive the existing assets (relocate out of Claude's scope).
+    archived = repo_space.archive_assets(repo)
+
+    # 2. assert the OLD assets are OUT of Claude's load scope: not under repo/.claude,
+    #    and the archive container is a sibling that Claude does not load.
+    assert not (repo / ".claude").exists()
+    assert not (repo / "CLAUDE.md").exists()
+    assert archived.archive_dir.is_relative_to(repo / repo_space.BACKUPS_DIRNAME)
+    assert not archived.archive_dir.is_relative_to(repo / ".claude")
+
+    # 3. a fresh install lands a clean, DIFFERENT .claude/ + CLAUDE.md.
+    (repo / ".claude").mkdir()
+    (repo / ".claude" / "settings.json").write_text('{"hooks": {"fresh": true}}\n', encoding="utf-8")
+    (repo / "CLAUDE.md").write_text("# fresh framework install\n", encoding="utf-8")
+    assert _snapshot(repo, (".claude", "CLAUDE.md")) != original  # genuinely changed
+
+    # 4. restore → original state byte-identical (fresh install cleared).
+    result = repo_space.restore_assets(repo, archived.archive_dir, overwrite=True)
+    assert not result.conflicts
+    assert _snapshot(repo, (".claude", "CLAUDE.md")) == original
+
+
+# ------------------------------------------------------------ disposition + consent gate
+
+
+def test_choose_disposition_non_interactive_is_amend(tmp_path: Path) -> None:
+    assert repo_space.choose_disposition(tmp_path, non_interactive=True) == "amend"
+
+
+def test_choose_disposition_non_tty_is_amend(tmp_path: Path) -> None:
+    assert repo_space.choose_disposition(tmp_path, non_interactive=False, _isatty=False) == "amend"
+
+
+def test_choose_disposition_interactive_parses_choices(tmp_path: Path) -> None:
+    for answer, expected in [
+        ("a", "archive"), ("archive", "archive"),
+        ("k", "amend"), ("", "amend"), ("huh", "amend"),
+        ("c", "cancel"), ("cancel", "cancel"), ("n", "cancel"),
+    ]:
+        got = repo_space.choose_disposition(
+            tmp_path, non_interactive=False, _isatty=True, _input=lambda _p, v=answer: v
+        )
+        assert got == expected, answer
+
+
+def test_prepare_fresh_repo_is_noop(tmp_path: Path) -> None:
+    prep = repo_space.prepare_for_install(tmp_path, non_interactive=False)
+    assert prep.action == "fresh"
+    assert prep.archive is None
+
+
+def test_prepare_non_interactive_amends_never_archives(tmp_path: Path) -> None:
+    """--non-interactive with existing assets: amend in place, nothing moved (CI-safe)."""
+    _seed_repo(tmp_path)
+    prep = repo_space.prepare_for_install(tmp_path, non_interactive=True)
+    assert prep.action == "amend"
+    assert (tmp_path / ".claude").exists()  # untouched
+    assert not (tmp_path / repo_space.BACKUPS_DIRNAME).exists()
+
+
+def test_prepare_archive_requires_explicit_consent(tmp_path: Path) -> None:
+    """Choosing archive but DECLINING the destructive consent moves nothing."""
+    _seed_repo(tmp_path)
+    prep = repo_space.prepare_for_install(
+        tmp_path, non_interactive=False,
+        chooser=lambda: "archive", consent_fn=lambda _s: False,
+    )
+    assert prep.action == "cancel"
+    assert (tmp_path / ".claude").exists()  # nothing moved without consent
+    assert not (tmp_path / repo_space.BACKUPS_DIRNAME).exists()
+
+
+def test_prepare_archive_on_consent_relocates(tmp_path: Path) -> None:
+    original = _seed_repo(tmp_path)
+    prep = repo_space.prepare_for_install(
+        tmp_path, non_interactive=False,
+        chooser=lambda: "archive", consent_fn=lambda _s: True,
+    )
+    assert prep.action == "archived"
+    assert not (tmp_path / ".claude").exists()  # relocated out of scope
+    # Still fully restorable.
+    repo_space.restore_assets(tmp_path, prep.archive.archive_dir)
+    assert _snapshot(tmp_path, (".claude", "CLAUDE.md")) == original
+
+
+def test_prepare_cancel_disposition_aborts(tmp_path: Path) -> None:
+    _seed_repo(tmp_path)
+    prep = repo_space.prepare_for_install(
+        tmp_path, non_interactive=False, chooser=lambda: "cancel"
+    )
+    assert prep.action == "cancel"
+    assert (tmp_path / ".claude").exists()
+
+
+# --------------------------------------------------------------- consent prompt override
+
+
+def test_consent_prompt_override_is_repo_scoped() -> None:
+    """prompt_consent still fail-safe, and the repo prompt line replaces the ~/.claude one."""
+    seen: dict[str, str] = {}
+
+    def _capture(prompt: str) -> str:
+        seen["prompt"] = prompt
+        return "y"
+
+    ok = consent_mod.prompt_consent(
+        "summary", non_interactive=False, prompt="ARCHIVE now? [y/N]: ",
+        _isatty=True, _input=_capture,
+    )
+    assert ok is True
+    assert seen["prompt"] == "ARCHIVE now? [y/N]: "
+    # Default (no prompt) keeps the user-space wording (#107 unchanged).
+    consent_mod.prompt_consent(
+        "s", non_interactive=False, _isatty=True, _input=lambda p: seen.setdefault("d", p) and "n"
+    )
+    assert "~/.claude" in seen["d"]
+
+
+# ------------------------------------------------------------------ #145 atomic writes
+
+
+def test_atomic_write_success_leaves_no_temp(tmp_path: Path) -> None:
+    target = tmp_path / "sub" / "out.json"
+    atomic_io.atomic_write_text(target, '{"a": 1}\n')
+    assert target.read_text() == '{"a": 1}\n'
+    assert list(target.parent.iterdir()) == [target]  # no stray temp file
+
+
+def test_atomic_write_uses_same_dir_temp_and_replace(tmp_path: Path, monkeypatch) -> None:
+    """The rename source is a temp file in the SAME directory as the target (atomic rename)."""
+    target = tmp_path / "out.json"
+    captured: dict[str, Path] = {}
+    real_replace = atomic_io.os.replace
+
+    def _spy(src, dst):
+        captured["src"] = Path(src)
+        captured["dst"] = Path(dst)
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(atomic_io.os, "replace", _spy)
+    atomic_io.atomic_write_text(target, "data")
+    assert captured["dst"] == target
+    assert captured["src"].parent == target.parent  # temp lived beside the target
+    assert target.read_text() == "data"
+
+
+def test_atomic_write_interrupt_never_truncates_target(tmp_path: Path, monkeypatch) -> None:
+    """A crash at the replace step leaves the OLD target intact — never a partial write."""
+    target = tmp_path / "out.json"
+    target.write_text("OLD-COMPLETE", encoding="utf-8")
+
+    def _boom(src, dst):
+        raise RuntimeError("simulated interrupt at replace")
+
+    monkeypatch.setattr(atomic_io.os, "replace", _boom)
+    with pytest.raises(RuntimeError):
+        atomic_io.atomic_write_text(target, "NEW-PARTIAL")
+
+    assert target.read_text() == "OLD-COMPLETE"  # untouched: never truncated
+    # And no temp file was left stranded.
+    assert list(target.parent.iterdir()) == [target]
+
+
+def test_user_space_write_is_atomic_and_crash_safe(tmp_path: Path, monkeypatch) -> None:
+    """The reused user-space merge (#107) shares the hardened atomic write (#145)."""
+    home = tmp_path / "home"
+    path = user_space.user_settings_path(home)
+    path.parent.mkdir(parents=True)
+    path.write_text('{"model": "opus"}\n', encoding="utf-8")  # valid; the flag WILL be added
+    before = path.read_bytes()
+
+    monkeypatch.setattr(
+        atomic_io.os, "replace",
+        lambda *a: (_ for _ in ()).throw(RuntimeError("crash")),
+    )
+    with pytest.raises(RuntimeError):
+        user_space.install_user_space(home=home, non_interactive=False, consent_fn=lambda _s: True)
+
+    assert path.read_bytes() == before  # settings.json never truncated by the failed write


### PR DESCRIPTION
## Summary
Mirrors the user-level install UX (#107) for a repo's own Claude assets (`.claude/` + `CLAUDE.md`). Before an install replaces existing repo assets, the operator chooses — with **explicit consent** — between:

- **amend in place** (default, non-destructive) — keep existing assets; the installer augments them idempotently. Safe default for `--non-interactive` / non-TTY / CI.
- **archive then fresh** — MOVE existing `.claude/` + `CLAUDE.md` OUT of Claude's load scope into a timestamped, non-clobbering `.claude-backups/<UTC>/` directory, leaving a clean slate. Fully restorable, byte-identical.

Also folds in **#145** (atomic settings write).

## Archive / restore design
- **Where archives go:** `<repo>/.claude-backups/<UTC-stamp>/` — a sibling of `.claude/`, NOT under it and NOT named `.claude*`. Claude loads only `.claude/` and root `CLAUDE.md`, so an archived copy is **inert** (cannot shadow or be loaded alongside a fresh install). Same-second collisions get a numeric suffix (mirrors `backup.py`).
- **Manifest:** each archive dir carries `archive-manifest.json` recording every relocated asset (`name` + `dir`/`file`) and the original `repo_root`.
- **Restore:** `restore_assets()` / `repo_space.py restore <archive_dir>` MOVES each member back to its original location, byte-identical. A currently-present target is **never clobbered** (recorded as a conflict) unless `--force`/`overwrite=True`, which removes the current target first (e.g. a fresh install laid down after the archive).

## New module `framework/install/repo_space.py`
`has_existing_assets`, `choose_disposition` (fail-safe → `amend`), `archive_assets`, `restore_assets`, `prepare_for_install` (the high-level entry the bootstrapper calls), plus an `archive` / `restore` CLI. Wired into `bootstrap.py`: foreign-`.claude` targets are offered the disposition before install; `--non-interactive` / non-TTY / dry-run take the non-destructive `amend` path (today's behaviour); our own idempotent re-runs are skipped.

## Code shared with #107
- **Reuses** `consent.prompt_consent` for the destructive-archive gate — generalised with an optional `prompt` line (user-space `~/.claude` wording kept as the default; #107 unchanged), so one gate serves both scopes.
- **Reuses** the timestamped, non-clobbering naming scheme from `backup.py`.
- Did NOT reimplement consent/backup. New shared primitive `atomic_io.atomic_write_text` is used by BOTH `user_space` (#107) and `repo_space`.

## #145 — atomic write (Closes #145)
New `atomic_io.atomic_write_text`: write to a temp file in the same dir, `flush`+`fsync`, then `os.replace` (atomic rename on POSIX). An interrupt mid-write can never leave a truncated file. Applied to `user_space.merge_settings` (fixes the user-space path) and `repo_space`'s manifest write — one fix, both paths.

## Round-trip test (the key AC)
`test_repo_space.py::test_round_trip_install_archive_out_of_scope_restore_identical` — install → archive existing → assert the old assets are OUT of Claude's scope (not under `.claude/`) → fresh install → restore → **original state byte-identical**. All under `tmp_path`; the real repo is never touched. 21 new tests total.

## Verify
- `pytest framework/tests/ -q` → **413 passed** (392 base + 21 new)
- `ruff check framework/` → clean
- `python3 framework/install/reinstall.py --check` → in sync
- Drove `bootstrap.py` (non-interactive amend preserved a foreign `.claude`) and the `repo_space.py` archive→fresh→restore CLI round-trip by hand.

## Dual-deploy
`repo_space.py` / `atomic_io.py` live in `framework/install/` alongside #107's `consent.py`/`backup.py`/`user_space.py`. That tree is bundled into the `2real-team` CLI (hatch), so they deploy to target repos automatically — no `.claude/` runtime copy, so `reinstall --check` stays green.

## Charter review
- Commit by **Paloma Gupta** via per-commit `-c user.name/-c user.email` + dual `Co-Authored-By` trailers; no global/repo git config touched; hooks not bypassed.
- Branch `P.Gupta/0108-...` → PR to `deployments/phase5/wave-2` (NOT main). No merge/release without owner sign-off.
- Safety bar met: nothing deleted/overwritten without consent + a restorable archive; `--non-interactive` / non-TTY never take the destructive path; archive naming timestamped + non-clobbering.

Reviewer: **Ibrahim El-Amin**.

Closes #108
Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTQxgBAcChxvdQJafKyMdX
