### PR TITLE
feat(#105): install/test/teardown harness (B1-B9 + B12 inline); folds #138

### DIFF
--- a/framework/harness/__init__.py
+++ b/framework/harness/__init__.py
@@ -1,0 +1,27 @@
+"""Install / test / teardown quality harness (issue #105).
+
+The integration/quality-trend layer on top of the unit suite: it provisions each
+repo-type fixture from the #103 taxonomy (``INSTALL_QUALITY_HARNESS.md``), runs the
+real installer(s) with the bucket's flag permutation, asserts the #103 metric
+vocabulary, tears the fixture down with a residue proof, and emits the #104
+metric-record schema (``INSTALL_TEST_METHODOLOGY.md``) plus a human + machine rollup.
+
+This package is **dev/test tooling** — it is NOT part of the installed ``.claude/``
+runtime and never ships to a target repo, so it does not affect
+``reinstall.py --check`` parity.
+
+Entrypoint::
+
+    python3 -m framework.harness            # default: hermetic B1-B9 + B12 dogfood
+    python3 -m framework.harness --include-real   # opt-in B10/B11 (owner-gated, flag off by default)
+
+See ``framework/recipes/INSTALL_QUALITY_HARNESS.md`` and
+``framework/recipes/INSTALL_TEST_METHODOLOGY.md``.
+"""
+
+from __future__ import annotations
+
+HARNESS_VERSION = "0.1.0"
+SCHEMA_VERSION = 1
+
+__all__ = ["HARNESS_VERSION", "SCHEMA_VERSION"]

--- a/framework/harness/__main__.py
+++ b/framework/harness/__main__.py
@@ -1,0 +1,152 @@
+"""CLI entrypoint: ``python3 -m framework.harness``.
+
+Runs the install/test/teardown matrix, emits the #104 metric-record JSON to a harness-owned
+results dir, prints a human + machine-readable rollup (per-bucket / per-category pass rates,
+``install_success_rate``, ``reinstall_parity_clean``, and — when a baseline exists — the
+run-over-run verdict), and exits non-zero on any failed graded metric or a REGRESSION verdict
+so CI can gate on it. Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from . import HARNESS_VERSION
+from .compare import compare, load_baseline
+from .records import RunEnvelope
+from .runner import run_matrix
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+_DEFAULT_RUNS_DIR = _FRAMEWORK_ROOT / "tests" / "install_quality" / "runs"
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    ap = argparse.ArgumentParser(
+        prog="python3 -m framework.harness",
+        description="Install / test / teardown quality harness (#105).",
+    )
+    ap.add_argument("--buckets", help="comma-separated bucket ids (default: hermetic B1-B9 + B12)")
+    ap.add_argument("--installers", default="bootstrap,cli",
+                    help="comma-separated installers to run (bootstrap,cli)")
+    ap.add_argument("--include-real", action="store_true",
+                    help="opt in to the [real] B10/B11 buckets (owner-gated; OFF by default)")
+    ap.add_argument("--no-dogfood", action="store_true", help="skip the B12 reinstall --check leg")
+    ap.add_argument("--scale", type=int, default=None, help="B9 file count (default: 300)")
+    ap.add_argument("--out", type=Path, default=_DEFAULT_RUNS_DIR,
+                    help="results dir for the run envelope JSON")
+    ap.add_argument("--no-write", action="store_true", help="do not persist the run JSON")
+    ap.add_argument("--compare", action="store_true",
+                    help="diff against the newest prior run in --out and gate on the verdict")
+    ap.add_argument("--json", action="store_true", help="print the machine JSON to stdout too")
+    ap.add_argument("--quick", action="store_true",
+                    help="fast subset (B1,B2,B4,B8b) through bootstrap only — for CI smoke")
+    return ap.parse_args(argv)
+
+
+def _opts(args: argparse.Namespace) -> dict:
+    if args.quick:
+        buckets = ["B1", "B2", "B4", "B8b"]
+        installers = ["bootstrap"]
+        dogfood = not args.no_dogfood
+    else:
+        buckets = [b.strip() for b in args.buckets.split(",")] if args.buckets else None
+        installers = [i.strip() for i in args.installers.split(",") if i.strip()]
+        dogfood = not args.no_dogfood
+    opts: dict = {
+        "buckets": buckets,
+        "installers": installers,
+        "include_real": args.include_real,
+        "dogfood": dogfood,
+        "host_kind": "local",
+    }
+    if args.scale is not None:
+        opts["scale"] = args.scale
+    return opts
+
+
+def _fmt_rate(v) -> str:
+    return "  -  " if v is None else f"{v:5.2f}"
+
+
+def print_rollup(env: RunEnvelope) -> None:
+    doc = env.to_dict()
+    rollup = doc["rollup"]
+    graded = [r for r in env.records if r.passed is not None and r.kind in ("pass_fail", "scored")]
+    passed = sum(1 for r in graded if r.passed)
+    failed = [r for r in graded if not r.passed]
+    skipped = [r for r in env.records if r.passed is None and r.kind != "trend"]
+
+    print("\n==================== 2real install-quality harness ====================")
+    print(f" run_id: {env.run_id}   harness: v{HARNESS_VERSION}   sha: {env.git_sha[:7]}")
+    print(f" buckets: {', '.join(env.buckets)}")
+    print(f" installers: {', '.join(env.installers)}")
+    print("-----------------------------------------------------------------------")
+    print(" per-bucket pass rate:")
+    for b, v in rollup["per_bucket_pass_rate"].items():
+        print(f"   {b:5s} {_fmt_rate(v)}")
+    print(" per-category pass rate (A-J):")
+    cats = "  ".join(f"{c}:{_fmt_rate(v).strip()}" for c, v in rollup["per_category_pass_rate"].items())
+    print(f"   {cats}")
+    print("-----------------------------------------------------------------------")
+    isr = rollup["install_success_rate"]
+    print(f" install_success_rate : {_fmt_rate(isr).strip()}  ({passed}/{len(graded)} graded metrics)")
+    print(f" reinstall_parity_clean: {rollup['reinstall_parity_clean']}")
+    if rollup["trend"]:
+        print(" trend (seconds):")
+        for metric, series in rollup["trend"].items():
+            pairs = ", ".join(f"{b}={s}" for b, s in series.items())
+            print(f"   {metric}: {pairs}")
+    if failed:
+        print("-----------------------------------------------------------------------")
+        print(f" FAILURES ({len(failed)}):")
+        for r in failed:
+            print(f"   FAIL  {r.record_id}")
+            print(f"         observed: {json.dumps(r.observed)[:300]}")
+    if skipped:
+        print(f" skipped/pending: {len(skipped)} "
+              f"(e.g. {', '.join(sorted({r.metric for r in skipped}))[:120]})")
+    print("=======================================================================")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    opts = _opts(args)
+
+    env = run_matrix(opts)
+    doc = env.to_dict()
+
+    out_path = None
+    if not args.no_write:
+        args.out.mkdir(parents=True, exist_ok=True)
+        out_path = args.out / f"{env.run_id}.json"
+        out_path.write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+
+    print_rollup(env)
+    if out_path:
+        print(f" wrote: {out_path}")
+
+    verdict = None
+    if args.compare:
+        baseline = load_baseline(args.out, exclude=out_path)
+        cmp = compare(doc, baseline)
+        verdict = cmp["verdict"]
+        print(f" run-over-run verdict: {verdict}"
+              + (f"  (baseline {cmp['baseline_run_id']})" if cmp.get("baseline_run_id") else ""))
+        for t in cmp.get("transitions", []):
+            print(f"   {t.get('class')}: {t['record_id']}")
+
+    if args.json:
+        print(json.dumps(doc, indent=2))
+
+    graded = [r for r in env.records if r.passed is not None and r.kind in ("pass_fail", "scored")]
+    any_fail = any(not r.passed for r in graded)
+    if verdict == "REGRESSION":
+        return 1
+    return 1 if any_fail else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/framework/harness/buckets.py
+++ b/framework/harness/buckets.py
@@ -1,0 +1,350 @@
+"""Repo-type buckets (#103 taxonomy) as DATA — provisioners, legs, permutations, applicability.
+
+Each ``Bucket`` names a fixture the harness synthesizes into a disposable tmp workdir and one
+or more ``Leg`` s — an installer permutation plus the #103 metric ids applicable to it. The
+matrix is inspectable/diffable data (#104 §6 handoff items 2+3): bucket→installers,
+bucket→permutation-flags, bucket→[metric-id]. Metric ids are #103 verbatim.
+
+Owner decisions bound into this wave:
+  * Default run = hermetic **B1-B9** + **B12 dogfood INLINE** (reinstall --check on this repo).
+  * **B10/B11** are DEFINED but flag-gated OFF (``real=True``); ``--include-real`` opts in, and
+    their provisioning (clone-at-pinned-SHA into scratch) is a guarded stub, never the live repo.
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+_BOOTSTRAP = _FRAMEWORK_ROOT / "install" / "bootstrap.py"
+
+#: Default B9 scale (trivial .py files). #103 proposes ~2000; kept lower for CI wall-clock,
+#: overridable via ``--scale`` so the scale check can be dialed up on demand.
+DEFAULT_B9_FILES = 300
+
+
+# --------------------------------------------------------------------- git helpers
+
+
+def _git(path: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(path), *args], check=True, capture_output=True)
+
+
+def _git_init(path: Path, *, commit: bool = False) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-q")
+    if commit:
+        (path / "README.md").write_text("hello\n", encoding="utf-8")
+        _git(path, "add", "-A")
+        subprocess.run(
+            ["git", "-C", str(path), "-c", "user.name=T", "-c", "user.email=t@e.com",
+             "commit", "-q", "-m", "init"],
+            check=True, capture_output=True,
+        )
+
+
+def _install_parent_framework(parent: Path) -> None:
+    """Install the framework into ``parent`` (a prerequisite for B7 child mode)."""
+    subprocess.run(
+        [sys.executable, str(_BOOTSTRAP), str(parent), "--owner", "acme",
+         "--no-team", "--non-interactive", "--no-ontology"],
+        check=True, capture_output=True, text=True, stdin=subprocess.DEVNULL,
+    )
+
+
+# --------------------------------------------------------------------- model types
+
+
+@dataclass
+class Leg:
+    """One installer permutation of a bucket + the metric ids it exercises."""
+
+    perm_label: str
+    installers: tuple[str, ...]
+    metrics: list[str]
+    permutation: dict
+    build_flags: Callable[[Path], list[str]] = lambda _wd: []
+    #: CLI-bridge flag builder (``2real-team init`` flag vocabulary). Only consulted for the
+    #: ``cli`` installer; falls back to ``build_flags`` when unset.
+    cli_flags: Callable[[Path], list[str]] | None = None
+    expect_exit: int = 0
+    gate_expect: str | None = None
+    teardown_proof: bool = False
+    target_subdir: str = "."  # install target relative to the workdir (B7 child = "svc")
+
+
+@dataclass
+class Bucket:
+    id: str
+    label: str
+    provision: Callable[[Path, dict], dict]  # (workdir, opts) -> fixture context
+    legs: list[Leg]
+    real: bool = False
+    installers_hint: tuple[str, ...] = ("bootstrap",)
+
+
+# --------------------------------------------------------------------- provisioners
+
+
+def _prov_empty(wd: Path, opts: dict) -> dict:
+    return {}
+
+
+def _prov_fresh_git(wd: Path, opts: dict) -> dict:
+    _git_init(wd)
+    return {}
+
+
+def _prov_single_lang(wd: Path, opts: dict) -> dict:
+    (wd / "pyproject.toml").write_text("[project]\nname = 'demo'\n", encoding="utf-8")
+    (wd / "module.py").write_text("def greet(name):\n    return f'hi {name}'\n", encoding="utf-8")
+    (wd / "pkg").mkdir()
+    (wd / "pkg" / "__init__.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+    # Unified config for the CLI leg: the `2real-team init` bridge has no --expect flag, so an
+    # existing-repo install is expressed through repo.expect in a forwarded --config YAML.
+    (wd / "cli.yaml").write_text(
+        "version: 1\nrepo:\n  expect: existing\nscm:\n  owner: acme\n"
+        "ontology:\n  enabled: true\nteam:\n  enabled: true\n  preset: library\n",
+        encoding="utf-8",
+    )
+    return {"extra": {"expect_source_path": "module.py"}}
+
+
+def _prov_existing_foreign(wd: Path, opts: dict) -> dict:
+    (wd / "src").mkdir()
+    (wd / "src" / "main.py").write_text("print('app')\n", encoding="utf-8")
+    (wd / "README.md").write_text("# real project\n", encoding="utf-8")
+    _git_init(wd, commit=True)
+    return {}
+
+
+def _prov_preexisting_claude(wd: Path, opts: dict) -> dict:
+    content = b"my own hand-written project notes\n"
+    (wd / "CLAUDE.md").write_bytes(content)
+    (wd / ".claude").mkdir()
+    foreign = '{"foreignKey": "keep-me", "hooks": {"PreToolUse": [{"matcher": "Grep", "hooks": []}]}}'
+    (wd / ".claude" / "settings.json").write_text(foreign, encoding="utf-8")
+    return {
+        "preexisting": {
+            "claude_md": content,
+            "settings_foreign_key": ("foreignKey", "keep-me"),
+        }
+    }
+
+
+def _prov_meta(wd: Path, opts: dict) -> dict:
+    _git_init(wd / "api")
+    (wd / "api" / "pyproject.toml").write_text("[project]\nname='api'\n", encoding="utf-8")
+    _git_init(wd / "web")
+    yaml = wd / "install.meta.yaml"
+    yaml.write_text(
+        "repo:\n  expect: any\nscm:\n  owner: acme\n"
+        "project:\n  model: meta\n"
+        "children:\n  - path: api\n  - path: web\n    flavor: infra\n",
+        encoding="utf-8",
+    )
+    return {
+        "child": {"children": [
+            {"path": "api", "rel": "..", "flavor": "product"},
+            {"path": "web", "rel": "..", "flavor": "infra"},
+        ]},
+        "extra": {"machine_root": str(wd)},
+        "yaml": str(yaml),
+    }
+
+
+def _prov_child_ok(wd: Path, opts: dict) -> dict:
+    """Parent WITH framework + a child git repo at ``svc`` (target)."""
+    _install_parent_framework(wd)
+    _git_init(wd / "svc")
+    yaml = wd / "child.yaml"
+    yaml.write_text(
+        "project:\n  model: child\n  flavor: infra\nparent:\n  path: ..\n", encoding="utf-8"
+    )
+    return {
+        "child": {"children": [{"path": ".", "rel": "..", "flavor": "infra"}]},
+        "extra": {"machine_root": str(wd), "child_expect": {"parent": "..", "flavor": "infra"}},
+        "yaml": str(yaml),
+    }
+
+
+def _prov_child_no_parent(wd: Path, opts: dict) -> dict:
+    """BARE parent (no framework) + child git repo at ``svc`` — child install must refuse."""
+    _git_init(wd / "svc")
+    yaml = wd / "child.yaml"
+    yaml.write_text("project:\n  model: child\nparent:\n  path: ..\n", encoding="utf-8")
+    return {"yaml": str(yaml)}
+
+
+def _prov_adversarial(wd: Path, opts: dict) -> dict:
+    (wd / "ontology").mkdir()
+    (wd / "ontology" / "structural").write_text("not a directory\n", encoding="utf-8")
+    return {}
+
+
+def _prov_invalid_config(wd: Path, opts: dict) -> dict:
+    bad = wd / "bad.config.json"
+    bad.write_text('{"version": 0}\n', encoding="utf-8")
+    return {"config_json": str(bad)}
+
+
+def _prov_large(wd: Path, opts: dict) -> dict:
+    n = int(opts.get("scale", DEFAULT_B9_FILES))
+    gen = wd / "gen"
+    gen.mkdir()
+    for i in range(n):
+        (gen / f"f{i:05d}.py").write_text(f"def fn_{i}():\n    return {i}\n", encoding="utf-8")
+    return {"extra": {"expect_source_path": "gen/f00000.py"}, "n_files": n}
+
+
+def _prov_real_stub(wd: Path, opts: dict) -> dict:
+    raise NotImplementedError(
+        "B10/B11 real-world provisioning is flag-gated and NOT wired in this wave. When enabled "
+        "it must CLONE the remote default branch at a pinned SHA into this scratch dir — never "
+        "copy/worktree the live working repo (other sessions operate there). See owner-decision 1."
+    )
+
+
+# --------------------------------------------------------------------- the matrix
+
+
+def _bootstrap_flags(*flags: str) -> Callable[[Path], list[str]]:
+    return lambda _wd: list(flags)
+
+
+# Common metric groups (kept DRY; #103 ids verbatim).
+_CORE_STANDALONE = [
+    "install_exit_status", "non_interactive_zero_prompts", "no_unexpected_files",
+    "install_snapshot_recorded", "settings_hooks_wired", "permissions_allowlist_present",
+    "config_module_lists_complete", "files_installed_complete", "install_duration_s",
+]
+_BEHAVIORAL = ["gate_blocks_no_verify", "gate_passes_benign", "identity_gate_active"]
+
+
+def build_buckets() -> list[Bucket]:
+    return [
+        Bucket("B1", "empty-non-git", _prov_empty, [
+            Leg("default", ("bootstrap",),
+                _CORE_STANDALONE + _BEHAVIORAL + ["reinstall_idempotent", "no_backup_litter"],
+                {"model": "single-repo", "expect": "fresh", "ontology": False, "team": True},
+                _bootstrap_flags("--expect", "fresh", "--owner", "acme", "--no-ontology")),
+        ]),
+        Bucket("B2", "fresh-git", _prov_fresh_git, [
+            Leg("default", ("bootstrap", "cli"),
+                _CORE_STANDALONE + _BEHAVIORAL
+                + ["reinstall_idempotent", "dry_run_writes_nothing", "no_backup_litter",
+                   "teardown_residue_zero", "shell_gate_respected"],
+                {"model": "single-repo", "expect": "fresh", "ontology": True, "team": True,
+                 "shell": "zsh"},
+                _bootstrap_flags("--owner", "acme", "--shell", "zsh"),
+                cli_flags=lambda wd: ["--preset", "library", "--owner", "acme"],
+                teardown_proof=True),
+        ], installers_hint=("bootstrap", "cli")),
+        Bucket("B3", "single-language-app", _prov_single_lang, [
+            Leg("with-ontology", ("bootstrap", "cli"),
+                _CORE_STANDALONE
+                + ["ontology_overlay_seeded", "ontology_structural_generated",
+                   "ontology_gen_duration_s", "reinstall_idempotent", "no_backup_litter"],
+                {"model": "single-repo", "expect": "existing", "ontology": True, "team": True},
+                _bootstrap_flags("--with-ontology", "--expect", "existing", "--owner", "acme"),
+                cli_flags=lambda wd: ["--config", str(wd / "cli.yaml")]),
+        ], installers_hint=("bootstrap", "cli")),
+        Bucket("B4", "existing-foreign-no-claude", _prov_existing_foreign, [
+            Leg("refuse", ("bootstrap",),
+                ["install_exit_status", "repo_state_gate_correct", "non_interactive_zero_prompts"],
+                {"model": "single-repo", "expect": "fresh", "gate": "refuse"},
+                _bootstrap_flags("--expect", "fresh", "--no-team"),
+                expect_exit=1, gate_expect="refuse"),
+            Leg("proceed", ("bootstrap",),
+                _CORE_STANDALONE + ["repo_state_gate_correct", "no_backup_litter"],
+                {"model": "single-repo", "expect": "existing", "gate": "proceed", "team": True},
+                _bootstrap_flags("--expect", "existing", "--owner", "acme"),
+                gate_expect="proceed"),
+        ]),
+        Bucket("B5", "preexisting-claude-settings", _prov_preexisting_claude, [
+            Leg("bootstrap-merge", ("bootstrap",),
+                # NOTE: settings_hooks_wired is a CLEAN-install assertion (exact matcher set);
+                # B5 deliberately merges a foreign matcher (Grep), so the union is a superset —
+                # that survival IS the point, asserted by settings_merge_preserves_foreign.
+                ["install_exit_status", "non_interactive_zero_prompts",
+                 "settings_merge_preserves_foreign", "config_module_lists_complete"],
+                {"model": "single-repo", "expect": "any", "team": True},
+                _bootstrap_flags("--expect", "any", "--owner", "acme", "--no-ontology")),
+            Leg("cli-claude-backup", ("cli",),
+                ["install_exit_status", "claude_md_backup_safe", "non_interactive_zero_prompts"],
+                {"model": "single-repo", "installer_writes_claude_md": True, "team": True},
+                lambda wd: ["--preset", "library", "--no-ontology"]),
+        ]),
+        Bucket("B6", "meta-and-children", _prov_meta, [
+            Leg("meta", ("bootstrap",),
+                ["install_exit_status", "non_interactive_zero_prompts",
+                 "child_wiring_portable", "child_flavor_filtered",
+                 "no_unexpected_files", "reinstall_idempotent", "no_backup_litter",
+                 "teardown_residue_zero", "install_duration_s"],
+                {"model": "meta-and-children", "expect": "any", "team": True},
+                lambda wd: ["--install-config", str(wd / "install.meta.yaml"), "--model",
+                            "meta-and-children"],
+                teardown_proof=True),
+        ]),
+        Bucket("B7", "standalone-child", _prov_child_ok, [
+            Leg("child", ("bootstrap",),
+                ["install_exit_status", "non_interactive_zero_prompts",
+                 "child_wiring_portable", "child_config_inherits"],
+                {"model": "child", "flavor": "infra", "team": True},
+                lambda wd: ["--install-config", str(wd / "child.yaml")],
+                target_subdir="svc"),
+        ]),
+        Bucket("B7b", "child-missing-parent", _prov_child_no_parent, [
+            Leg("no-parent", ("bootstrap",),
+                ["install_exit_status", "child_parent_precondition",
+                 "non_interactive_zero_prompts"],
+                {"model": "child", "parent_missing": True},
+                lambda wd: ["--install-config", str(wd / "child.yaml")],
+                expect_exit=1, target_subdir="svc"),
+        ]),
+        Bucket("B8", "adversarial-degraded", _prov_adversarial, [
+            Leg("ontology-fail-open", ("bootstrap",),
+                ["install_exit_status", "ontology_fail_open", "non_interactive_zero_prompts",
+                 "settings_hooks_wired"],
+                {"model": "single-repo", "ontology": True, "team": True},
+                _bootstrap_flags("--with-ontology", "--owner", "acme")),
+        ]),
+        Bucket("B8b", "invalid-config", _prov_invalid_config, [
+            Leg("invalid-config", ("bootstrap",),
+                ["install_exit_status", "invalid_config_refused",
+                 "non_interactive_zero_prompts"],
+                {"model": "single-repo", "invalid_version": True},
+                lambda wd: ["--config", str(wd / "bad.config.json"), "--expect", "any",
+                            "--no-team"],
+                expect_exit=1),
+        ]),
+        Bucket("B9", "large-repo", _prov_large, [
+            Leg("scale", ("bootstrap",),
+                ["install_exit_status", "install_duration_s", "ontology_gen_duration_s",
+                 "ontology_structural_generated", "non_interactive_zero_prompts"],
+                {"model": "single-repo", "ontology": True, "team": True, "scale": True,
+                 "expect": "any"},
+                # A nonempty non-git dir classifies as EXISTING, so --expect any keeps the gate
+                # out of the way — B9 stresses scale/timing, not the fresh-vs-existing verdict.
+                _bootstrap_flags("--with-ontology", "--expect", "any", "--owner", "acme")),
+        ]),
+        # --- [real] flag-gated OFF by default (owner-decision 1) ---
+        Bucket("B10", "meta-real-world", _prov_real_stub, [
+            Leg("meta-real", ("bootstrap",), ["install_exit_status"],
+                {"model": "meta-and-children", "real": True}),
+        ], real=True),
+        Bucket("B11", "standalone-real-world", _prov_real_stub, [
+            Leg("existing-real", ("bootstrap",), ["install_exit_status"],
+                {"model": "single-repo", "real": True}),
+        ], real=True),
+    ]
+
+
+# B12 dogfood is special-cased in the runner (read-only reinstall --check on THIS repo;
+# no fixture, no teardown), not a synthesized bucket.
+B12_METRIC = "reinstall_parity_clean"

--- a/framework/harness/compare.py
+++ b/framework/harness/compare.py
@@ -1,0 +1,125 @@
+"""Run-over-run comparison / heuristics (#104 §4).
+
+Joins the current run envelope to a baseline (the previous run for the same matrix, by newest
+``finished_at``) on ``record_id`` and classifies each record REGRESSION / IMPROVEMENT / STABLE,
+then computes an overall run verdict. Trend metrics use a per-metric budget
+``max(0.5s, 0.20 × baseline)`` (§4b proposed default). Stdlib only.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+TREND_ABS_FLOOR_S = 0.5
+TREND_REL_FRACTION = 0.20
+
+
+def _budget(baseline_value: float) -> float:
+    return max(TREND_ABS_FLOOR_S, TREND_REL_FRACTION * abs(baseline_value))
+
+
+def load_baseline(runs_dir: Path, exclude: Path | None = None) -> dict | None:
+    """The newest prior run envelope in ``runs_dir`` (by ``run.finished_at``), or None."""
+    candidates = []
+    for p in sorted(runs_dir.glob("*.json")):
+        if exclude and p.resolve() == exclude.resolve():
+            continue
+        try:
+            doc = json.loads(p.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        fin = doc.get("run", {}).get("finished_at", "")
+        candidates.append((fin, doc))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda t: t[0])
+    return candidates[-1][1]
+
+
+def _index(doc: dict) -> dict[str, dict]:
+    return {r["record_id"]: r for r in doc.get("records", [])}
+
+
+def compare(current: dict, baseline: dict | None) -> dict:
+    """Classify transitions and return the verdict + per-record diff (#104 §4b/§4c)."""
+    cur = _index(current)
+    if baseline is None:
+        return {
+            "verdict": "BASELINE",
+            "baseline_run_id": None,
+            "transitions": [],
+            "new_records": sorted(cur),
+            "dropped_records": [],
+            "note": "no prior run to compare against — this run becomes the baseline",
+        }
+
+    base = _index(baseline)
+    transitions: list[dict] = []
+    regressions = improvements = 0
+
+    for rid in sorted(set(cur) & set(base)):
+        c, b = cur[rid], base[rid]
+        kind = c.get("kind")
+        if kind == "trend":
+            cv, bv = c.get("value"), b.get("value")
+            if isinstance(cv, (int, float)) and isinstance(bv, (int, float)):
+                delta = cv - bv
+                budget = _budget(bv)
+                if delta > budget:
+                    transitions.append({"record_id": rid, "kind": "trend", "class": "REGRESSION",
+                                        "delta": round(delta, 4), "budget": round(budget, 4)})
+                    regressions += 1
+                elif delta < -budget:
+                    transitions.append({"record_id": rid, "kind": "trend", "class": "IMPROVEMENT",
+                                        "delta": round(delta, 4), "budget": round(budget, 4)})
+                    improvements += 1
+            continue
+        cp, bp = c.get("pass"), b.get("pass")
+        if cp is None or bp is None:
+            continue
+        if bp and not cp:
+            transitions.append({"record_id": rid, "class": "REGRESSION", "from": bp, "to": cp})
+            regressions += 1
+        elif cp and not bp:
+            transitions.append({"record_id": rid, "class": "IMPROVEMENT", "from": bp, "to": cp})
+            improvements += 1
+        else:
+            # scored soft-regression: value degraded even though pass held.
+            cv, bv = c.get("value"), b.get("value")
+            if c.get("kind") == "scored" and isinstance(cv, (int, float)) and isinstance(bv, (int, float)):
+                if (rid.endswith("teardown_residue_zero") and cv > bv) or (
+                    rid.endswith("files_installed_complete") and cv < bv
+                ):
+                    transitions.append({"record_id": rid, "class": "SOFT_REGRESSION",
+                                        "from": bv, "to": cv})
+                    regressions += 1
+
+    cur_rate = current.get("rollup", {}).get("install_success_rate")
+    base_rate = baseline.get("rollup", {}).get("install_success_rate")
+    rate_dropped = (
+        isinstance(cur_rate, (int, float)) and isinstance(base_rate, (int, float))
+        and cur_rate < base_rate
+    )
+    parity_flipped = (
+        baseline.get("rollup", {}).get("reinstall_parity_clean") is True
+        and current.get("rollup", {}).get("reinstall_parity_clean") is False
+    )
+
+    if regressions or rate_dropped or parity_flipped:
+        verdict = "REGRESSION"
+    elif improvements:
+        verdict = "IMPROVEMENT"
+    else:
+        verdict = "STABLE"
+
+    return {
+        "verdict": verdict,
+        "baseline_run_id": baseline.get("run", {}).get("run_id"),
+        "install_success_rate": {"current": cur_rate, "baseline": base_rate},
+        "regressions": regressions,
+        "improvements": improvements,
+        "transitions": transitions,
+        "new_records": sorted(set(cur) - set(base)),
+        "dropped_records": sorted(set(base) - set(cur)),
+    }

--- a/framework/harness/installers.py
+++ b/framework/harness/installers.py
@@ -1,0 +1,135 @@
+"""Real installer invocations (#104 §1 Stage 2) — bootstrap, CLI bridge, fired-hook payloads.
+
+Every install is grounded in the actual installer flags (``framework/install/bootstrap.py``
+argparse; ``2real-team init``). Runs are always ``--non-interactive`` with **stdin closed**
+so ``non_interactive_zero_prompts`` is exercised on every cell — a hang/``EOFError`` is a
+failure. Stdlib only.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+# framework/harness/installers.py -> framework/
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+_BOOTSTRAP = _FRAMEWORK_ROOT / "install" / "bootstrap.py"
+_REINSTALL = _FRAMEWORK_ROOT / "install" / "reinstall.py"
+
+#: Wall-clock ceiling per install invocation. A cell that exceeds this is a hard failure
+#: (guards `non_interactive_zero_prompts` against a stdin-blocked hang and B9 pathologies).
+INSTALL_TIMEOUT_S = 180
+
+
+@dataclass
+class RunResult:
+    """A captured installer invocation — the parseable oracle every metric measures against."""
+
+    argv: list[str]
+    returncode: int
+    stdout: str
+    stderr: str
+    duration_s: float
+    timed_out: bool = False
+
+    @property
+    def out(self) -> str:
+        """Combined stdout+stderr (the result block prints across both)."""
+        return f"{self.stdout}\n{self.stderr}"
+
+
+def _run(argv: list[str], *, cwd: Path | None = None) -> RunResult:
+    start = time.monotonic()
+    try:
+        cp = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            stdin=subprocess.DEVNULL,  # zero-prompt contract: any prompt EOFErrors
+            timeout=INSTALL_TIMEOUT_S,
+            cwd=str(cwd) if cwd else None,
+        )
+        return RunResult(argv, cp.returncode, cp.stdout, cp.stderr, time.monotonic() - start)
+    except subprocess.TimeoutExpired as exc:
+        out = exc.stdout or ""
+        err = (exc.stderr or "") + f"\nHARNESS: timed out after {INSTALL_TIMEOUT_S}s"
+        return RunResult(
+            argv,
+            124,
+            out if isinstance(out, str) else out.decode("utf-8", "replace"),
+            err if isinstance(err, str) else err.decode("utf-8", "replace"),
+            time.monotonic() - start,
+            timed_out=True,
+        )
+
+
+def run_bootstrap(target: Path, flags: list[str]) -> RunResult:
+    """``python3 framework/install/bootstrap.py <target> <flags> --non-interactive``."""
+    argv = [sys.executable, str(_BOOTSTRAP), str(target), *flags]
+    if "--non-interactive" not in flags and "--dry-run" not in flags:
+        argv.append("--non-interactive")
+    return _run(argv)
+
+
+def run_cli(target: Path, flags: list[str]) -> RunResult:
+    """``2real-team init --target <target> --non-interactive <flags>`` (bundled-bootstrap bridge).
+
+    Invoked as a module (``python3 -m real_team.cli``-equivalent via the installed console
+    script) so it works whether or not the ``2real-team`` shim is on PATH.
+    """
+    argv = [
+        sys.executable,
+        "-c",
+        "import sys; from real_team.cli import app; app()",
+        "init",
+        "--target",
+        str(target),
+        "--non-interactive",
+        *flags,
+    ]
+    return _run(argv)
+
+
+def run_reinstall_check() -> RunResult:
+    """``python3 framework/install/reinstall.py --check`` — read-only dogfood parity (B12)."""
+    return _run([sys.executable, str(_REINSTALL), "--check"])
+
+
+def fire_hook(
+    target: Path, command: str, *, tool_name: str = "Bash", post: bool = False,
+    identity: dict | None = None,
+) -> RunResult:
+    """Pipe a JSON tool payload into the INSTALLED dispatcher (#103 group D).
+
+    Mirrors ``test_bootstrap_smoke.py``: returns the dispatcher's exit code + stdout.
+    ``identity`` lets the caller inject a forged git author for the identity gate.
+    """
+    dispatcher = "post_dispatcher.py" if post else "dispatcher.py"
+    payload_obj: dict = {
+        "tool_name": tool_name,
+        "cwd": str(target),
+        "tool_input": {"command": command},
+    }
+    if identity:
+        payload_obj["tool_input"].update(identity)
+    hook = target / ".claude" / "hooks" / dispatcher
+    # Suppress the real events-log write into the fixture (mirrors conftest); the fixture is
+    # torn down anyway, but this keeps the .claude byte-diff clean for reinstall_idempotent.
+    env = {**os.environ, "FRAMEWORK_HOOK_TEST_MODE": "1"}
+    start = time.monotonic()
+    cp = subprocess.run(
+        [sys.executable, str(hook)],
+        input=json.dumps(payload_obj),
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+    )
+    return RunResult(
+        [str(hook)], cp.returncode, cp.stdout, cp.stderr, time.monotonic() - start
+    )

--- a/framework/harness/manifest.py
+++ b/framework/harness/manifest.py
@@ -1,0 +1,61 @@
+"""Golden-manifest bridge to Nia's #139 (fail-open until it lands on the wave branch).
+
+#139 delivers ``framework/install/manifest.py`` exposing
+``expected_install_set(config) -> set[str]`` (the relpaths the installer should produce for a
+given install config) plus a generated ``framework/install/golden-manifest.json`` snapshot.
+The ``files_installed_complete`` metric asserts the actual post-install ``.claude`` tree
+equals that expected set.
+
+Her PR may not be merged when the harness runs, so the import is guarded: if the module is
+not importable yet, ``expected_install_set`` returns ``None`` and the metric is SKIPPED with a
+clear "pending #139" note rather than crashing. Once #139 lands this wires automatically — no
+harness change needed. Loaded via importlib from the file path so we do not depend on
+``framework.install`` being an importable package.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+_MANIFEST_PY = _FRAMEWORK_ROOT / "install" / "manifest.py"
+
+PENDING_NOTE = "pending #139 (framework/install/manifest.py not on the wave branch yet)"
+
+
+def _load():
+    """Import the #139 manifest module by path, or return None if it does not exist yet."""
+    if not _MANIFEST_PY.is_file():
+        return None
+    try:
+        spec = importlib.util.spec_from_file_location("_harness_golden_manifest", _MANIFEST_PY)
+        if spec is None or spec.loader is None:
+            return None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    except Exception:  # noqa: BLE001 — fail-open: a broken #139 must not crash the harness
+        return None
+
+
+def available() -> bool:
+    """True iff #139's ``expected_install_set`` can be resolved."""
+    mod = _load()
+    return mod is not None and hasattr(mod, "expected_install_set")
+
+
+def expected_install_set(config: dict) -> set[str] | None:
+    """Delegate to #139's ``expected_install_set(config)``; ``None`` when #139 is absent.
+
+    ``config`` is the resolved install config for the cell (model, team, ontology, …). The
+    exact shape is #139's contract; the harness passes the permutation dict through verbatim.
+    """
+    mod = _load()
+    if mod is None or not hasattr(mod, "expected_install_set"):
+        return None
+    try:
+        result = mod.expected_install_set(config)
+        return set(result) if result is not None else None
+    except Exception:  # noqa: BLE001 — treat a manifest error as "unavailable", skip the metric
+        return None

--- a/framework/harness/manifest.py
+++ b/framework/harness/manifest.py
@@ -23,6 +23,37 @@ _MANIFEST_PY = _FRAMEWORK_ROOT / "install" / "manifest.py"
 
 PENDING_NOTE = "pending #139 (framework/install/manifest.py not on the wave branch yet)"
 
+#: Harness runtime model token -> canonical install-config ``project.model`` token. This MUST
+#: match ``install_config.INSTALL_MODEL_MAP`` (guarded by
+#: ``test_harness_model_map_matches_install_config``); #139's ``expected_install_set`` branches
+#: on the install-config spelling (``standalone`` / ``meta`` / ``child``), NOT the harness's
+#: runtime spelling (``single-repo`` / ``meta-and-children`` / ``child``).
+_HARNESS_MODEL_TO_INSTALL = {
+    "single-repo": "standalone",
+    "meta-and-children": "meta",
+    "child": "child",
+}
+
+
+def permutation_to_install_config(permutation: dict) -> dict:
+    """Convert a harness leg's FLAT permutation into the NESTED resolved install-config shape.
+
+    #139's ``expected_install_set`` reads its input with dotted
+    ``install_config.get_key(config, "project.model")`` / ``"team.enabled"`` — i.e. it expects a
+    nested dict (the ``.claude/install.config.json`` shape), not the harness's flat permutation.
+    Passing the flat dict silently resolved EVERY cell to the ``standalone`` / team-enabled
+    default (the discriminant was ignored), so a child/meta/no-team cell would be mis-graded.
+    This maps the permutation's ``model``/``team`` into ``project.model`` (canonical install
+    token) + ``team.enabled`` so the manifest branch matches the cell's actual install mode.
+    """
+    model = permutation.get("model", "standalone")
+    canonical = _HARNESS_MODEL_TO_INSTALL.get(model, model)  # identity if already canonical
+    team_enabled = bool(permutation.get("team", True))
+    config: dict = {"project": {"model": canonical}, "team": {"enabled": team_enabled}}
+    if "flavor" in permutation:
+        config["project"]["flavor"] = permutation["flavor"]
+    return config
+
 
 def _load():
     """Import the #139 manifest module by path, or return None if it does not exist yet."""
@@ -45,15 +76,18 @@ def available() -> bool:
     return mod is not None and hasattr(mod, "expected_install_set")
 
 
-def expected_install_set(config: dict) -> set[str] | None:
-    """Delegate to #139's ``expected_install_set(config)``; ``None`` when #139 is absent.
+def expected_install_set(permutation: dict) -> set[str] | None:
+    """Expected ``.claude/**`` relpaths for a cell's PERMUTATION; ``None`` when #139 is absent.
 
-    ``config`` is the resolved install config for the cell (model, team, ontology, …). The
-    exact shape is #139's contract; the harness passes the permutation dict through verbatim.
+    Takes the harness leg's FLAT permutation, converts it to the nested install-config shape
+    #139 consumes (see ``permutation_to_install_config``), and delegates to
+    #139's ``expected_install_set``. Converting here — the single seam — is what makes the
+    permutation discriminant actually reach the manifest (the #139 config-shape fix).
     """
     mod = _load()
     if mod is None or not hasattr(mod, "expected_install_set"):
         return None
+    config = permutation_to_install_config(permutation)
     try:
         result = mod.expected_install_set(config)
         return set(result) if result is not None else None

--- a/framework/harness/metrics.py
+++ b/framework/harness/metrics.py
@@ -173,19 +173,20 @@ def m_non_interactive_zero_prompts(ctx: CellContext) -> Measurement:
 
 
 def m_files_installed_complete(ctx: CellContext) -> Measurement:
+    # The manifest is scoped to the target's own .claude/** tree (#139 contract), and its input
+    # is the cell's PERMUTATION converted to the nested install-config shape inside the bridge.
     expected = manifest.expected_install_set(ctx.permutation)
     if expected is None:
         return _skip(manifest.PENDING_NOTE)
-    present = {p for p in ctx.after if p.startswith(".claude/") or p.startswith("ontology/")
-               or p.startswith("CLAUDE.md") or p.startswith(".git/hooks/pre-push")}
+    present = {p for p in ctx.after if p.startswith(".claude/")}
     missing = sorted(expected - present)
     fraction = round(len(expected & present) / len(expected), 4) if expected else 1.0
     ok = not missing
     return Measurement(
         value=fraction, passed=ok,
-        expected={"count": len(expected)},
+        expected={"count": len(expected), "model": ctx.permutation.get("model")},
         observed={"fraction": fraction, "missing": missing[:20], "missing_count": len(missing)},
-        notes="wired to #139 golden manifest",
+        notes="wired to #139 golden manifest (permutation → install-config shape)",
     )
 
 

--- a/framework/harness/metrics.py
+++ b/framework/harness/metrics.py
@@ -1,0 +1,585 @@
+"""Metric measurement (#103 vocabulary, #104 §3 Stage 3).
+
+Each metric has a stable snake_case id (verbatim from #103), a category (A-J), a kind
+(pass_fail / scored / trend), and a mechanical measurement function that reads a
+``CellContext`` and returns a ``Measurement`` (value + pass + expected/observed evidence).
+
+Every measurement is one of #104's five mechanical kinds: a return code, a stdout/stderr
+line, a file check, a byte-diff, or a fired-hook payload. Nothing is invented — the oracle is
+the captured process(es) and the post-install file tree. Stdlib only.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+from . import manifest
+from .records import KIND_PASS_FAIL, KIND_SCORED, KIND_TREND
+
+# The exact installed root-settings hook wiring (asserted by settings_hooks_wired).
+_EXPECTED_EVENTS = {
+    "SessionStart": {None},                       # matcher-less -> start_dispatcher.py
+    "PreToolUse": {"Bash", "Agent"},              # -> dispatcher.py
+    "Stop": {None},                               # matcher-less -> stop_dispatcher.py
+    "PostToolUse": {"Bash", "Edit|Write|MultiEdit|NotebookEdit"},  # -> post_dispatcher.py
+}
+_EVENT_DISPATCHER = {
+    "SessionStart": "start_dispatcher.py",
+    "PreToolUse": "dispatcher.py",
+    "Stop": "stop_dispatcher.py",
+    "PostToolUse": "post_dispatcher.py",
+}
+# framework.config.json default module lists (#84 regression guard).
+_REQUIRED_PRE_BASH = {"validate_labels", "block_squash_wave_merge"}
+
+
+@dataclass
+class Measurement:
+    """A single metric's mechanical result."""
+
+    value: object
+    passed: object  # bool for pass_fail/scored; None for pure-trend OR a skip
+    expected: object
+    observed: object
+    notes: str = ""
+
+
+@dataclass
+class MetricSpec:
+    metric: str
+    category: str
+    kind: str
+    fn: Callable[["CellContext"], Measurement]
+
+
+@dataclass
+class CellContext:
+    """Everything a metric needs to measure one (fixture, installer, permutation) cell.
+
+    The runner populates only the auxiliaries the cell's applicable metrics require; metric
+    functions defend against ``None`` and skip cleanly.
+    """
+
+    workdir: Path
+    installer: str
+    permutation: dict
+    expect_exit: int = 0
+    gate_expect: str | None = None  # "refuse" | "proceed" for repo_state_gate_correct
+    primary: object = None          # RunResult of the install
+    before: dict = field(default_factory=dict)
+    after: dict = field(default_factory=dict)
+    reinstall: object = None        # RunResult of the 2nd run
+    reinstall_diff: list = field(default_factory=list)  # byte-diff of .claude between runs
+    dry_run: object = None
+    dry_run_unchanged: object = None  # bool: target byte-identical after --dry-run
+    fired: dict = field(default_factory=dict)  # name -> RunResult
+    teardown_residue: object = None  # list of residual paths after manifest-driven uninstall
+    preexisting: dict = field(default_factory=dict)
+    child: dict = field(default_factory=dict)  # child buckets: {settings_text, config, ...}
+    extra: dict = field(default_factory=dict)
+
+
+# --------------------------------------------------------------------- helpers
+
+
+def _skip(reason: str, *, expected=None, observed=None) -> Measurement:
+    return Measurement(value=None, passed=None, expected=expected, observed=observed, notes=reason)
+
+
+def _load_settings(workdir: Path) -> dict | None:
+    p = workdir / ".claude" / "settings.json"
+    if not p.is_file():
+        return None
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _load_config(workdir: Path) -> dict | None:
+    p = workdir / ".claude" / "framework.config.json"
+    if not p.is_file():
+        return None
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+# ------------------------------------------------------------ A. exit & gates
+
+
+def m_install_exit_status(ctx: CellContext) -> Measurement:
+    got = ctx.primary.returncode
+    return Measurement(
+        value=(got == ctx.expect_exit),
+        passed=(got == ctx.expect_exit),
+        expected={"exit": ctx.expect_exit},
+        observed={"exit": got, "timed_out": ctx.primary.timed_out},
+    )
+
+
+def m_repo_state_gate_correct(ctx: CellContext) -> Measurement:
+    out = ctx.primary.out
+    rc = ctx.primary.returncode
+    if ctx.gate_expect == "refuse":
+        ok = rc == 1 and (
+            "refusing to install (repo expectation gate)" in out
+            or "looks EXISTING" in out
+            or "looks FRESH" in out
+        )
+        installed = (ctx.workdir / ".claude" / "framework.config.json").is_file()
+        ok = ok and not installed
+        return Measurement(
+            value=ok, passed=ok,
+            expected={"exit": 1, "stdout_contains": ["refusing to install (repo expectation gate)"]},
+            observed={"exit": rc, "installed": installed, "stdout_excerpt": _excerpt(out)},
+        )
+    # proceed leg (--expect existing|any, or an idempotent re-run)
+    installed = (ctx.workdir / ".claude" / "framework.config.json").is_file()
+    ok = rc == 0 and installed
+    return Measurement(
+        value=ok, passed=ok,
+        expected={"exit": 0, "installed": True},
+        observed={"exit": rc, "installed": installed},
+    )
+
+
+def m_invalid_config_refused(ctx: CellContext) -> Measurement:
+    rc = ctx.primary.returncode
+    installed = (ctx.workdir / ".claude" / "framework.config.json").is_file()
+    ok = rc != 0 and not installed
+    return Measurement(
+        value=ok, passed=ok,
+        expected={"exit": "!=0", "wrote_nothing": True},
+        observed={"exit": rc, "installed": installed, "stdout_excerpt": _excerpt(ctx.primary.out)},
+    )
+
+
+def m_non_interactive_zero_prompts(ctx: CellContext) -> Measurement:
+    # stdin is always closed; a prompt would EOFError/hang -> our timeout (124).
+    ok = not ctx.primary.timed_out
+    return Measurement(
+        value=ok, passed=ok,
+        expected={"completed_without_stdin": True},
+        observed={"timed_out": ctx.primary.timed_out, "duration_s": round(ctx.primary.duration_s, 3)},
+    )
+
+
+# ------------------------------------------------------------ B. completeness
+
+
+def m_files_installed_complete(ctx: CellContext) -> Measurement:
+    expected = manifest.expected_install_set(ctx.permutation)
+    if expected is None:
+        return _skip(manifest.PENDING_NOTE)
+    present = {p for p in ctx.after if p.startswith(".claude/") or p.startswith("ontology/")
+               or p.startswith("CLAUDE.md") or p.startswith(".git/hooks/pre-push")}
+    missing = sorted(expected - present)
+    fraction = round(len(expected & present) / len(expected), 4) if expected else 1.0
+    ok = not missing
+    return Measurement(
+        value=fraction, passed=ok,
+        expected={"count": len(expected)},
+        observed={"fraction": fraction, "missing": missing[:20], "missing_count": len(missing)},
+        notes="wired to #139 golden manifest",
+    )
+
+
+def m_no_unexpected_files(ctx: CellContext) -> Measurement:
+    from .snapshot import unexpected_paths
+
+    stray = unexpected_paths(ctx.before, ctx.after)
+    return Measurement(
+        value=len(stray), passed=(not stray),
+        expected={"stray": 0},
+        observed={"stray_count": len(stray), "stray": stray[:20]},
+    )
+
+
+def m_install_snapshot_recorded(ctx: CellContext) -> Measurement:
+    p = ctx.workdir / ".claude" / "install.config.json"
+    if not p.is_file():
+        return Measurement(False, False, {"exists": True}, {"exists": False})
+    try:
+        snap = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return Measurement(False, False, {"parses": True}, {"parses": False})
+    if ctx.installer == "cli":
+        team = snap.get("team", {})
+        ok = "enabled" in team
+        return Measurement(ok, ok, {"team_synced": True}, {"team": team})
+    return Measurement(True, True, {"exists": True}, {"keys": sorted(snap)[:10]})
+
+
+# ------------------------------------------------------------ C. hook wiring
+
+
+def m_settings_hooks_wired(ctx: CellContext) -> Measurement:
+    settings = _load_settings(ctx.workdir)
+    if settings is None:
+        return Measurement(False, False, {"settings.json": "present+parseable"}, {"settings.json": None})
+    hooks = settings.get("hooks", {})
+    problems: list[str] = []
+    for event, want_matchers in _EXPECTED_EVENTS.items():
+        blocks = hooks.get(event, [])
+        got_matchers = {b.get("matcher") for b in blocks}
+        if got_matchers != want_matchers:
+            problems.append(f"{event} matchers {sorted(map(str, got_matchers))} != {sorted(map(str, want_matchers))}")
+            continue
+        want_disp = _EVENT_DISPATCHER[event]
+        cmds = [h.get("command", "") for b in blocks for h in b.get("hooks", [])]
+        if not any(want_disp in c for c in cmds):
+            problems.append(f"{event} not wired to {want_disp}")
+    ok = not problems
+    return Measurement(ok, ok, {"events": {k: sorted(map(str, v)) for k, v in _EXPECTED_EVENTS.items()}},
+                       {"problems": problems})
+
+
+def m_permissions_allowlist_present(ctx: CellContext) -> Measurement:
+    settings = _load_settings(ctx.workdir)
+    allow = (settings or {}).get("permissions", {}).get("allow", [])
+    no_perms = ctx.permutation.get("no_permissions", False)
+    if no_perms:
+        ok = not allow
+        return Measurement(ok, ok, {"allow": "absent"}, {"allow_count": len(allow)})
+    ok = len(allow) >= 5
+    return Measurement(ok, ok, {"allow": ">=5 curated rules"}, {"allow_count": len(allow)})
+
+
+def m_config_module_lists_complete(ctx: CellContext) -> Measurement:
+    cfg = _load_config(ctx.workdir)
+    if cfg is None:
+        return Measurement(False, False, {"framework.config.json": "present"}, {"present": False})
+    hooks = cfg.get("hooks", {})
+    pre = set(hooks.get("pre_bash", []))
+    problems: list[str] = []
+    if not _REQUIRED_PRE_BASH <= pre:
+        problems.append(f"pre_bash missing {sorted(_REQUIRED_PRE_BASH - pre)}")
+    if hooks.get("agent") != []:
+        problems.append(f"hooks.agent != [] (got {hooks.get('agent')})")
+    if hooks.get("stop") != ["session_handoff"]:
+        problems.append(f"hooks.stop != ['session_handoff'] (got {hooks.get('stop')})")
+    ok = not problems
+    return Measurement(ok, ok, {"pre_bash>=": sorted(_REQUIRED_PRE_BASH), "agent": [], "stop": ["session_handoff"]},
+                       {"problems": problems})
+
+
+# ------------------------------------------------------------ D. behavioral
+
+
+def m_gate_blocks_no_verify(ctx: CellContext) -> Measurement:
+    r = ctx.fired.get("no_verify")
+    if r is None:
+        return _skip("hook not fired")
+    ok = r.returncode == 2 and "no-verify" in r.stdout.lower()
+    return Measurement(ok, ok, {"exit": 2, "mentions": "no-verify"},
+                       {"exit": r.returncode, "stdout_excerpt": _excerpt(r.stdout)})
+
+
+def m_gate_passes_benign(ctx: CellContext) -> Measurement:
+    r = ctx.fired.get("benign")
+    if r is None:
+        return _skip("hook not fired")
+    ok = r.returncode == 0 and r.stdout.strip() == ""
+    return Measurement(ok, ok, {"exit": 0, "stdout": "empty"},
+                       {"exit": r.returncode, "stdout_excerpt": _excerpt(r.stdout)})
+
+
+def m_identity_gate_active(ctx: CellContext) -> Measurement:
+    cfg = _load_config(ctx.workdir)
+    roster = (ctx.workdir / ".claude" / "team" / "roster.json").is_file()
+    enforce = bool((cfg or {}).get("identity", {}).get("enforce"))
+    pre = (cfg or {}).get("hooks", {}).get("pre_bash", [])
+    first_is_identity = pre[:1] == ["validate_commit_identity"]
+    wired = roster and enforce and first_is_identity
+    r = ctx.fired.get("foreign_commit")
+    fired_block = (r is not None and r.returncode == 2)
+    ok = wired and fired_block
+    return Measurement(
+        ok, ok,
+        {"roster": True, "enforce": True, "pre_bash[0]": "validate_commit_identity", "foreign_commit_exit": 2},
+        {"roster": roster, "enforce": enforce, "identity_first": first_is_identity,
+         "foreign_commit_exit": (r.returncode if r else None)},
+    )
+
+
+def m_shell_gate_respected(ctx: CellContext) -> Measurement:
+    r = ctx.fired.get("bashism")
+    if r is None:
+        return _skip("hook not fired")
+    ok = r.returncode == 0 and "ZSH-SAFETY" in r.stdout
+    return Measurement(ok, ok, {"exit": 0, "advisory": "ZSH-SAFETY"},
+                       {"exit": r.returncode, "stdout_excerpt": _excerpt(r.stdout)})
+
+
+# ------------------------------------------------------------ E. ontology
+
+
+def m_ontology_overlay_seeded(ctx: CellContext) -> Measurement:
+    onto = ctx.workdir / "ontology"
+    names = ("domain.yaml", "services.yaml", "conventions.md", "README.md")
+    missing = [n for n in names if not (onto / n).is_file()]
+    ok = not missing
+    return Measurement(ok, ok, {"overlay": list(names)}, {"missing": missing})
+
+
+def m_ontology_structural_generated(ctx: CellContext) -> Measurement:
+    struct = ctx.workdir / "ontology" / "structural"
+    graph_p = struct / "code-graph.json"
+    llms_p = struct / "llms.txt"
+    if not graph_p.is_file() or not llms_p.is_file():
+        return Measurement(False, False, {"files": ["code-graph.json", "llms.txt"]},
+                           {"code-graph.json": graph_p.is_file(), "llms.txt": llms_p.is_file()})
+    try:
+        graph = json.loads(graph_p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return Measurement(False, False, {"parses": True}, {"parses": False})
+    has_shape = "nodes" in graph and "edges" in graph
+    want_src = ctx.extra.get("expect_source_path")
+    src_ok = True
+    if want_src:
+        paths = {n.get("path") for n in graph.get("nodes", [])}
+        src_ok = want_src in paths
+    ok = has_shape and src_ok
+    return Measurement(ok, ok, {"nodes+edges": True, "source_in_graph": want_src},
+                       {"has_shape": has_shape, "source_present": src_ok})
+
+
+def m_ontology_fail_open(ctx: CellContext) -> Measurement:
+    out = ctx.primary.out
+    rc = ctx.primary.returncode
+    skipped = "structural index:  SKIPPED" in out or "install continues" in out
+    overlay = (ctx.workdir / "ontology" / "domain.yaml").is_file()
+    dispatcher = (ctx.workdir / ".claude" / "hooks" / "dispatcher.py").is_file()
+    ok = rc == 0 and skipped and overlay and dispatcher
+    return Measurement(ok, ok, {"exit": 0, "structural": "SKIPPED", "overlay+runtime": True},
+                       {"exit": rc, "skipped_line": skipped, "overlay": overlay, "dispatcher": dispatcher})
+
+
+# ------------------------------------------------------------ F. idempotency & safety
+
+
+def m_reinstall_idempotent(ctx: CellContext) -> Measurement:
+    r = ctx.reinstall
+    if r is None:
+        return _skip("second run not performed")
+    out = r.out
+    ok = (
+        r.returncode == 0
+        and "skipped (exists)" in out
+        and "already wired" in out
+        and not ctx.reinstall_diff
+    )
+    return Measurement(ok, ok,
+                       {"exit": 0, "stdout": ["skipped (exists)", "already wired"], "claude_byte_diff": "empty"},
+                       {"exit": r.returncode, "byte_diff": ctx.reinstall_diff[:20],
+                        "byte_diff_count": len(ctx.reinstall_diff)})
+
+
+def m_claude_md_backup_safe(ctx: CellContext) -> Measurement:
+    original = ctx.preexisting.get("claude_md")
+    if original is None:
+        return _skip("no pre-existing CLAUDE.md in this fixture")
+    # The original bytes must be recoverable from a .bak/.bak.N and a new CLAUDE.md written.
+    baks = sorted(ctx.workdir.glob("CLAUDE.md.bak*"))
+    recovered = any(b.read_bytes() == original for b in baks)
+    new_written = (ctx.workdir / "CLAUDE.md").is_file()
+    ok = recovered and new_written
+    return Measurement(ok, ok, {"original_recoverable": True, "new_CLAUDE.md": True},
+                       {"backups": [b.name for b in baks], "recovered": recovered, "new_written": new_written})
+
+
+def m_settings_merge_preserves_foreign(ctx: CellContext) -> Measurement:
+    key = ctx.preexisting.get("settings_foreign_key")
+    if not key:
+        return _skip("no pre-existing foreign settings key in this fixture")
+    settings = _load_settings(ctx.workdir)
+    fk, fv = key
+    ok = settings is not None and settings.get(fk) == fv
+    return Measurement(ok, ok, {f"settings[{fk}]": fv},
+                       {"present": ok, "value": (settings or {}).get(fk)})
+
+
+def m_dry_run_writes_nothing(ctx: CellContext) -> Measurement:
+    if ctx.dry_run is None:
+        return _skip("dry-run leg not performed")
+    out = ctx.dry_run.out
+    marker = "-- plan --" in out or "would generate" in out or "would write" in out
+    ok = ctx.dry_run.returncode == 0 and bool(ctx.dry_run_unchanged) and marker
+    return Measurement(ok, ok, {"exit": 0, "tree_unchanged": True, "stdout": "-- plan --/would …"},
+                       {"exit": ctx.dry_run.returncode, "tree_unchanged": ctx.dry_run_unchanged,
+                        "plan_marker": marker})
+
+
+# ------------------------------------------------------------ G. meta / child wiring
+
+
+def m_child_wiring_portable(ctx: CellContext) -> Measurement:
+    children = ctx.child.get("children", [])
+    if not children:
+        return _skip("no child settings in this fixture")
+    problems: list[str] = []
+    machine_root = ctx.extra.get("machine_root", "")
+    for c in children:
+        text = c["settings_text"]
+        if machine_root and machine_root in text:
+            problems.append(f"{c['path']}: machine-absolute path leaked")
+        anchor = f"$CLAUDE_PROJECT_DIR/{c['rel']}/.claude/hooks/"
+        if anchor not in text:
+            problems.append(f"{c['path']}: missing anchor {anchor}")
+        child_dir = ctx.workdir / c["path"] / ".claude"
+        for local in ("hooks", "lib", "team/charter", "ontology"):
+            if (child_dir / local).exists():
+                problems.append(f"{c['path']}: unexpected local {local}")
+    ok = not problems
+    return Measurement(ok, ok, {"portable": True, "no_local_hooks_lib_charter": True},
+                       {"problems": problems})
+
+
+def m_child_flavor_filtered(ctx: CellContext) -> Measurement:
+    children = ctx.child.get("children", [])
+    infra = [c for c in children if c.get("flavor") == "infra"]
+    product = [c for c in children if c.get("flavor") == "product"]
+    if not infra and not product:
+        return _skip("no flavored children in this fixture")
+    problems: list[str] = []
+    for c in infra:
+        s = json.loads(c["settings_text"])
+        events = set(s.get("hooks", {}))
+        if events != {"PreToolUse", "PostToolUse"}:
+            problems.append(f"{c['path']} infra events {sorted(events)} != PreToolUse+PostToolUse")
+        matchers = {b.get("matcher") for blocks in s["hooks"].values() for b in blocks}
+        if matchers != {"Bash"}:
+            problems.append(f"{c['path']} infra matchers {sorted(map(str, matchers))} != Bash-only")
+    for c in product:
+        s = json.loads(c["settings_text"])
+        events = set(s.get("hooks", {}))
+        if events != {"SessionStart", "PreToolUse", "PostToolUse", "Stop"}:
+            problems.append(f"{c['path']} product events {sorted(events)} incomplete")
+    ok = not problems
+    return Measurement(ok, ok, {"infra": "Bash pre/post only", "product": "all events"},
+                       {"problems": problems})
+
+
+def m_child_parent_precondition(ctx: CellContext) -> Measurement:
+    rc = ctx.primary.returncode
+    out = ctx.primary.out
+    installed = (ctx.workdir / ".claude" / "settings.json").is_file()
+    ok = rc == 1 and "does not have the framework installed" in out and not installed
+    return Measurement(ok, ok, {"exit": 1, "message": "parent … does not have the framework installed"},
+                       {"exit": rc, "installed": installed, "stdout_excerpt": _excerpt(out)})
+
+
+def m_child_config_inherits(ctx: CellContext) -> Measurement:
+    cfg = _load_config(ctx.workdir)
+    if cfg is None:
+        return Measurement(False, False, {"framework.config.json": "present"}, {"present": False})
+    proj = cfg.get("project", {})
+    want = ctx.extra.get("child_expect", {})
+    problems: list[str] = []
+    if proj.get("model") != "child":
+        problems.append(f"model={proj.get('model')} != child")
+    if "parent" not in proj:
+        problems.append("no project.parent")
+    for k, v in want.items():
+        if proj.get(k) != v:
+            problems.append(f"project.{k}={proj.get(k)} != {v}")
+    if "scm" not in cfg:
+        problems.append("scm not inherited")
+    ok = not problems
+    return Measurement(ok, ok, {"model": "child", "parent+flavor": True, "inherits_scm": True},
+                       {"problems": problems, "project": proj})
+
+
+# ------------------------------------------------------------ H. teardown / residue
+
+
+def m_teardown_residue_zero(ctx: CellContext) -> Measurement:
+    residue = ctx.teardown_residue
+    if residue is None:
+        return _skip("manifest-driven teardown leg not run for this fixture")
+    ok = len(residue) == 0
+    return Measurement(len(residue), ok, {"residue": 0},
+                       {"residue_count": len(residue), "residue": residue[:20]})
+
+
+def m_no_backup_litter(ctx: CellContext) -> Measurement:
+    # A happy-path fresh install (no conflict) must create zero .bak* files.
+    baks = [p.name for p in ctx.workdir.rglob("*.bak*") if ".git" not in p.parts]
+    ok = not baks
+    return Measurement(len(baks), ok, {"bak_files": 0}, {"bak_count": len(baks), "baks": baks[:20]})
+
+
+# ------------------------------------------------------------ I. performance / trend
+
+
+def m_install_duration_s(ctx: CellContext) -> Measurement:
+    d = round(ctx.primary.duration_s, 4)
+    return Measurement(d, None, {"trend": True}, {"seconds": d})
+
+
+def m_ontology_gen_duration_s(ctx: CellContext) -> Measurement:
+    # Attribute the whole install wall-clock as an upper bound proxy for the ontology-gen
+    # buckets (B3/B9 run --with-ontology; the structural gen dominates their delta over time).
+    d = round(ctx.primary.duration_s, 4)
+    return Measurement(d, None, {"trend": True}, {"seconds_upper_bound": d})
+
+
+# ------------------------------------------------------------ J. dogfood parity
+
+
+def m_reinstall_parity_clean(ctx: CellContext) -> Measurement:
+    r = ctx.primary
+    ok = r.returncode == 0
+    return Measurement(ok, ok, {"exit": 0, "invariant": "canonical<->live in sync (#116)"},
+                       {"exit": r.returncode, "stdout_excerpt": _excerpt(r.out)})
+
+
+def _excerpt(text: str, limit: int = 600) -> str:
+    text = text.strip()
+    return text if len(text) <= limit else text[:limit] + " …[truncated]"
+
+
+# --------------------------------------------------------------------- registry
+
+REGISTRY: dict[str, MetricSpec] = {}
+
+
+def _reg(metric: str, category: str, kind: str, fn) -> None:
+    REGISTRY[metric] = MetricSpec(metric, category, kind, fn)
+
+
+_reg("install_exit_status", "A", KIND_PASS_FAIL, m_install_exit_status)
+_reg("repo_state_gate_correct", "A", KIND_PASS_FAIL, m_repo_state_gate_correct)
+_reg("invalid_config_refused", "A", KIND_PASS_FAIL, m_invalid_config_refused)
+_reg("non_interactive_zero_prompts", "A", KIND_PASS_FAIL, m_non_interactive_zero_prompts)
+_reg("files_installed_complete", "B", KIND_SCORED, m_files_installed_complete)
+_reg("no_unexpected_files", "B", KIND_PASS_FAIL, m_no_unexpected_files)
+_reg("install_snapshot_recorded", "B", KIND_PASS_FAIL, m_install_snapshot_recorded)
+_reg("settings_hooks_wired", "C", KIND_PASS_FAIL, m_settings_hooks_wired)
+_reg("permissions_allowlist_present", "C", KIND_PASS_FAIL, m_permissions_allowlist_present)
+_reg("config_module_lists_complete", "C", KIND_PASS_FAIL, m_config_module_lists_complete)
+_reg("gate_blocks_no_verify", "D", KIND_PASS_FAIL, m_gate_blocks_no_verify)
+_reg("gate_passes_benign", "D", KIND_PASS_FAIL, m_gate_passes_benign)
+_reg("identity_gate_active", "D", KIND_PASS_FAIL, m_identity_gate_active)
+_reg("shell_gate_respected", "D", KIND_PASS_FAIL, m_shell_gate_respected)
+_reg("ontology_overlay_seeded", "E", KIND_PASS_FAIL, m_ontology_overlay_seeded)
+_reg("ontology_structural_generated", "E", KIND_PASS_FAIL, m_ontology_structural_generated)
+_reg("ontology_fail_open", "E", KIND_PASS_FAIL, m_ontology_fail_open)
+_reg("reinstall_idempotent", "F", KIND_PASS_FAIL, m_reinstall_idempotent)
+_reg("claude_md_backup_safe", "F", KIND_PASS_FAIL, m_claude_md_backup_safe)
+_reg("settings_merge_preserves_foreign", "F", KIND_PASS_FAIL, m_settings_merge_preserves_foreign)
+_reg("dry_run_writes_nothing", "F", KIND_PASS_FAIL, m_dry_run_writes_nothing)
+_reg("child_wiring_portable", "G", KIND_PASS_FAIL, m_child_wiring_portable)
+_reg("child_flavor_filtered", "G", KIND_PASS_FAIL, m_child_flavor_filtered)
+_reg("child_parent_precondition", "G", KIND_PASS_FAIL, m_child_parent_precondition)
+_reg("child_config_inherits", "G", KIND_PASS_FAIL, m_child_config_inherits)
+_reg("teardown_residue_zero", "H", KIND_SCORED, m_teardown_residue_zero)
+_reg("no_backup_litter", "H", KIND_PASS_FAIL, m_no_backup_litter)
+_reg("install_duration_s", "I", KIND_TREND, m_install_duration_s)
+_reg("ontology_gen_duration_s", "I", KIND_TREND, m_ontology_gen_duration_s)
+_reg("reinstall_parity_clean", "J", KIND_PASS_FAIL, m_reinstall_parity_clean)

--- a/framework/harness/records.py
+++ b/framework/harness/records.py
@@ -1,0 +1,155 @@
+"""Metric-record schema + rollup (#104 §3) with the #138 record_id fix.
+
+A run emits one **run envelope** containing one **metric record per
+(fixture, installer, permutation, metric)** plus a computed **rollup**.
+
+#138 FIX — the join key was ``<bucket>/<installer>/<metric>``, which collides when a single
+bucket asserts the same metric across multiple installer permutations (e.g. B4's gate matrix
+records ``repo_state_gate_correct`` on both the *refuse* leg and the *proceed* leg). This
+harness adds the **permutation discriminant** to the key:
+
+    record_id = "<bucket>/<installer>/<permutation>/<metric>"
+
+so run-over-run diffs (§4) never collide. The colliding 3-part key is never emitted.
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# Metric measurement kinds (#104 §3b).
+KIND_PASS_FAIL = "pass_fail"
+KIND_SCORED = "scored"   # a number that also carries a pass threshold
+KIND_TREND = "trend"     # a number with NO pass/fail, tracked only over time
+
+
+def make_record_id(bucket: str, installer: str, permutation: str, metric: str) -> str:
+    """The stable run-over-run join key WITH the #138 permutation discriminant."""
+    return f"{bucket}/{installer}/{permutation}/{metric}"
+
+
+@dataclass
+class MetricRecord:
+    """One (fixture × installer × permutation × metric) result — #104 §3b."""
+
+    bucket: str
+    fixture: str
+    installer: str
+    permutation_label: str
+    permutation: dict
+    metric: str
+    category: str
+    kind: str
+    value: object          # bool for pass_fail; number for scored/trend
+    passed: object         # bool for pass_fail/scored; None for pure-trend
+    expected: object
+    observed: object
+    duration_s: float
+    timestamp: str
+    git_sha: str
+    notes: str = ""
+
+    @property
+    def record_id(self) -> str:
+        return make_record_id(self.bucket, self.installer, self.permutation_label, self.metric)
+
+    def to_dict(self) -> dict:
+        return {
+            "record_id": self.record_id,
+            "bucket": self.bucket,
+            "fixture": self.fixture,
+            "installer": self.installer,
+            "permutation": self.permutation,
+            "metric": self.metric,
+            "category": self.category,
+            "kind": self.kind,
+            "value": self.value,
+            "pass": self.passed,
+            "expected": self.expected,
+            "observed": self.observed,
+            "duration_s": round(self.duration_s, 4),
+            "timestamp": self.timestamp,
+            "git_sha": self.git_sha,
+            "notes": self.notes,
+        }
+
+
+def _is_graded(rec: MetricRecord) -> bool:
+    """True for pass_fail/scored records (they have a pass/fail); False for pure-trend."""
+    return rec.kind in (KIND_PASS_FAIL, KIND_SCORED) and rec.passed is not None
+
+
+def compute_rollup(records: list[MetricRecord]) -> dict:
+    """The §3c/§4a rollup: per-bucket & per-category pass rates, the top-line
+    ``install_success_rate`` (metric-level denominator, §4a), ``reinstall_parity_clean``,
+    and the scored trend series.
+    """
+    graded = [r for r in records if _is_graded(r)]
+
+    def _rate(subset: list[MetricRecord]) -> float | None:
+        graded_sub = [r for r in subset if _is_graded(r)]
+        if not graded_sub:
+            return None
+        passed = sum(1 for r in graded_sub if r.passed)
+        return round(passed / len(graded_sub), 4)
+
+    buckets = sorted({r.bucket for r in records})
+    categories = sorted({r.category for r in records})
+    per_bucket = {b: _rate([r for r in records if r.bucket == b]) for b in buckets}
+    per_category = {c: _rate([r for r in records if r.category == c]) for c in categories}
+
+    install_success_rate = None
+    if graded:
+        install_success_rate = round(sum(1 for r in graded if r.passed) / len(graded), 4)
+
+    parity = None
+    for r in records:
+        if r.metric == "reinstall_parity_clean":
+            parity = bool(r.passed)
+
+    trend: dict[str, dict[str, float]] = {}
+    for r in records:
+        if r.kind == KIND_TREND:
+            trend.setdefault(r.metric, {})[r.bucket] = round(float(r.value), 4)
+
+    return {
+        "per_bucket_pass_rate": per_bucket,
+        "per_category_pass_rate": per_category,
+        "install_success_rate": install_success_rate,
+        "reinstall_parity_clean": parity,
+        "trend": trend,
+    }
+
+
+@dataclass
+class RunEnvelope:
+    """The one-JSON-document-per-run container (#104 §3a)."""
+
+    run_id: str
+    git_sha: str
+    started_at: str
+    finished_at: str
+    harness_version: str
+    schema_version: int
+    host_kind: str
+    installers: list[str]
+    buckets: list[str]
+    records: list[MetricRecord] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "schema_version": self.schema_version,
+            "run": {
+                "run_id": self.run_id,
+                "git_sha": self.git_sha,
+                "started_at": self.started_at,
+                "finished_at": self.finished_at,
+                "harness_version": self.harness_version,
+                "host_kind": self.host_kind,
+                "installers": self.installers,
+                "buckets": self.buckets,
+            },
+            "records": [r.to_dict() for r in self.records],
+            "rollup": compute_rollup(self.records),
+        }

--- a/framework/harness/runner.py
+++ b/framework/harness/runner.py
@@ -1,0 +1,309 @@
+"""Orchestration: provision → install → assert → teardown per cell (#104 §1).
+
+Drives every (bucket, installer, permutation) cell mechanically: mint a disposable tmp
+workdir, synthesize the fixture, capture the pre-install snapshot, run the real installer,
+run whatever auxiliary invocations the applicable metrics require (a second run for
+idempotency, a --dry-run leg, fired-hook payloads, a manifest-driven teardown proof),
+measure each metric into a record, then drop the copy. Failures are isolated per cell — a
+crash in one fixture becomes failing/error records, never a harness abort. Stdlib only.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+import traceback
+from datetime import datetime, timezone
+from pathlib import Path
+
+from . import HARNESS_VERSION, SCHEMA_VERSION, installers
+from .buckets import B12_METRIC, Bucket, Leg, build_buckets
+from .metrics import REGISTRY, CellContext, Measurement
+from .records import MetricRecord, RunEnvelope
+from .snapshot import snapshot, symmetric_diff
+from .teardown import manifest_driven_uninstall
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+_REPO_ROOT = _FRAMEWORK_ROOT.parent
+
+#: Metrics that are meaningful only for the standalone bootstrap installer, not the CLI bridge
+#: (the CLI forwards --no-team so identity is off; it fixes shell=bash; and re-running it
+#: re-scaffolds the team, so idempotency/dry-run/teardown are asserted through bootstrap).
+_CLI_SKIP = frozenset({
+    "identity_gate_active", "reinstall_idempotent", "dry_run_writes_nothing",
+    "teardown_residue_zero", "shell_gate_respected", "config_module_lists_complete",
+})
+
+DEFAULT_HERMETIC = ["B1", "B2", "B3", "B4", "B5", "B6", "B7", "B7b", "B8", "B8b", "B9"]
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _git_sha() -> str:
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(_REPO_ROOT), "rev-parse", "HEAD"],
+            capture_output=True, text=True, check=True,
+        )
+        return out.stdout.strip()
+    except (subprocess.SubprocessError, OSError):
+        return "unknown"
+
+
+def _claude_only(snap: dict) -> dict:
+    return {k: v for k, v in snap.items() if k.startswith(".claude/")}
+
+
+def _install(installer: str, target: Path, flags: list[str]) -> installers.RunResult:
+    if installer == "cli":
+        return installers.run_cli(target, flags)
+    return installers.run_bootstrap(target, flags)
+
+
+def _collect_child_settings(target: Path, children: list[dict]) -> None:
+    """Read each child's post-install settings.json into its descriptor (for the G metrics)."""
+    for c in children:
+        sp = target / c["path"] / ".claude" / "settings.json"
+        c["settings_text"] = sp.read_text(encoding="utf-8") if sp.is_file() else ""
+
+
+def _valid_commit_prefix(target: Path) -> str:
+    """A ``git -c user.name=.. -c user.email=..`` prefix using a roster identity, if the
+    identity gate is active — so the no-verify SCM gate (not the identity gate) is what a
+    ``--no-verify`` commit trips. Empty when there is no roster (identity off)."""
+    import json as _json
+
+    roster = target / ".claude" / "team" / "roster.json"
+    if not roster.is_file():
+        return ""
+    try:
+        data = _json.loads(roster.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return ""
+    if isinstance(data, dict) and data:
+        name, email = next(iter(data.items()))
+        return f'git -c user.name="{name}" -c user.email="{email}" '
+    return ""
+
+
+def _fire_hooks(target: Path, metric_ids: set[str]) -> dict:
+    fired: dict = {}
+    if "gate_blocks_no_verify" in metric_ids:
+        prefix = _valid_commit_prefix(target)
+        cmd = (prefix + "commit --no-verify -m x") if prefix else "git commit --no-verify -m x"
+        fired["no_verify"] = installers.fire_hook(target, cmd)
+    if "gate_passes_benign" in metric_ids:
+        fired["benign"] = installers.fire_hook(target, "ls -la")
+    if "shell_gate_respected" in metric_ids:
+        fired["bashism"] = installers.fire_hook(
+            target, 'for k in "${!arr[@]}"; do echo $k; done'
+        )
+    if "identity_gate_active" in metric_ids:
+        fired["foreign_commit"] = installers.fire_hook(
+            target, 'git commit -m "unattributed"'
+        )
+    return fired
+
+
+def _measure(metric_id: str, ctx: CellContext) -> Measurement:
+    spec = REGISTRY[metric_id]
+    try:
+        return spec.fn(ctx)
+    except Exception as exc:  # noqa: BLE001 — a metric bug must not abort the run
+        return Measurement(None, False, {"measured": True},
+                           {"error": f"{type(exc).__name__}: {exc}"},
+                           notes="metric raised — see observed.error")
+
+
+def _record(bucket: Bucket, leg: Leg, installer: str, metric_id: str, m: Measurement,
+            ctx: CellContext, git_sha: str, duration_s: float) -> MetricRecord:
+    spec = REGISTRY[metric_id]
+    return MetricRecord(
+        bucket=bucket.id, fixture=bucket.label, installer=installer,
+        permutation_label=leg.perm_label, permutation=leg.permutation, metric=metric_id,
+        category=spec.category, kind=spec.kind, value=m.value, passed=m.passed,
+        expected=m.expected, observed=m.observed, duration_s=duration_s,
+        timestamp=_now(), git_sha=git_sha, notes=m.notes,
+    )
+
+
+def run_cell(bucket: Bucket, leg: Leg, installer: str, opts: dict, scratch: Path,
+             git_sha: str) -> list[MetricRecord]:
+    """Provision → install → (aux) → assert → teardown one cell; return its metric records."""
+    metric_ids = [m for m in leg.metrics if not (installer == "cli" and m in _CLI_SKIP)]
+    metric_set = set(metric_ids)
+
+    workdir = Path(tempfile.mkdtemp(prefix=f"harness-{bucket.id}-{installer}-", dir=str(scratch)))
+    try:
+        fixture = bucket.provision(workdir, opts)
+        target = workdir / leg.target_subdir
+        target.mkdir(parents=True, exist_ok=True)
+
+        before = snapshot(target)
+        flags = (leg.cli_flags or leg.build_flags)(workdir) if installer == "cli" \
+            else leg.build_flags(workdir)
+        primary = _install(installer, target, flags)
+        after = snapshot(target)
+
+        ctx = CellContext(
+            workdir=target, installer=installer, permutation=leg.permutation,
+            expect_exit=leg.expect_exit, gate_expect=leg.gate_expect, primary=primary,
+            before=before, after=after,
+            preexisting=fixture.get("preexisting", {}),
+            child=fixture.get("child", {}), extra=fixture.get("extra", {}),
+        )
+
+        # child settings (G metrics)
+        if ctx.child.get("children"):
+            _collect_child_settings(target, ctx.child["children"])
+
+        # aux: second run for idempotency (byte-diff of .claude), bootstrap only
+        if "reinstall_idempotent" in metric_set and installer == "bootstrap":
+            claude1 = _claude_only(after)
+            ctx.reinstall = _install(installer, target, flags)
+            claude2 = _claude_only(snapshot(target))
+            ctx.reinstall_diff = symmetric_diff(claude1, claude2)
+
+        # aux: dry-run leg on a FRESH copy (target must be byte-identical after)
+        if "dry_run_writes_nothing" in metric_set and installer == "bootstrap":
+            ctx.dry_run, ctx.dry_run_unchanged = _dry_run_leg(bucket, leg, opts, scratch)
+
+        # aux: fired-hook payloads
+        if metric_set & {"gate_blocks_no_verify", "gate_passes_benign",
+                         "shell_gate_respected", "identity_gate_active"}:
+            ctx.fired = _fire_hooks(target, metric_set)
+
+        # aux: manifest-driven teardown PROOF on a fresh copy (bootstrap only)
+        if "teardown_residue_zero" in metric_set and leg.teardown_proof and installer == "bootstrap":
+            ctx.teardown_residue = _teardown_proof_leg(bucket, leg, opts, scratch)
+
+        records: list[MetricRecord] = []
+        for mid in metric_ids:
+            if mid not in REGISTRY:
+                continue
+            dur = primary.duration_s if mid in ("install_duration_s", "ontology_gen_duration_s") else 0.0
+            m = _measure(mid, ctx)
+            records.append(_record(bucket, leg, installer, mid, m, ctx, git_sha, dur))
+        return records
+    except NotImplementedError as exc:
+        # A flag-gated / stubbed provisioner (B10/B11). Emit one skipped record, do not crash.
+        spec_metric = leg.metrics[0]
+        return [MetricRecord(
+            bucket.id, bucket.label, installer, leg.perm_label, leg.permutation, spec_metric,
+            REGISTRY.get(spec_metric).category if spec_metric in REGISTRY else "A",
+            REGISTRY.get(spec_metric).kind if spec_metric in REGISTRY else "pass_fail",
+            None, None, {"stub": True}, {"reason": str(exc)}, 0.0, _now(), git_sha,
+            notes="flag-gated / stubbed provisioner",
+        )]
+    except Exception as exc:  # noqa: BLE001 — isolate a provisioning/install failure to this cell
+        return [MetricRecord(
+            bucket.id, bucket.label, installer, leg.perm_label, leg.permutation,
+            "install_exit_status", "A", "pass_fail", None, False,
+            {"cell_ran": True},
+            {"error": f"{type(exc).__name__}: {exc}", "traceback": traceback.format_exc()[-800:]},
+            0.0, _now(), git_sha, notes="cell raised during provision/install",
+        )]
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)  # drop-the-copy teardown (§2a)
+
+
+def _dry_run_leg(bucket: Bucket, leg: Leg, opts: dict, scratch: Path):
+    wd = Path(tempfile.mkdtemp(prefix=f"harness-{bucket.id}-dry-", dir=str(scratch)))
+    try:
+        bucket.provision(wd, opts)
+        target = wd / leg.target_subdir
+        target.mkdir(parents=True, exist_ok=True)
+        before = snapshot(target)
+        flags = [*leg.build_flags(wd), "--dry-run"]
+        r = installers.run_bootstrap(target, flags)
+        unchanged = snapshot(target) == before
+        return r, unchanged
+    finally:
+        shutil.rmtree(wd, ignore_errors=True)
+
+
+def _teardown_proof_leg(bucket: Bucket, leg: Leg, opts: dict, scratch: Path) -> list[str]:
+    wd = Path(tempfile.mkdtemp(prefix=f"harness-{bucket.id}-teardown-", dir=str(scratch)))
+    try:
+        bucket.provision(wd, opts)
+        target = wd / leg.target_subdir
+        target.mkdir(parents=True, exist_ok=True)
+        pre = snapshot(target)
+        installers.run_bootstrap(target, leg.build_flags(wd))
+        return manifest_driven_uninstall(target, pre)
+    finally:
+        shutil.rmtree(wd, ignore_errors=True)
+
+
+def _run_b12(git_sha: str) -> MetricRecord:
+    """B12 dogfood: read-only reinstall --check on THIS repo (no fixture, no teardown)."""
+    before = subprocess.run(["git", "-C", str(_REPO_ROOT), "status", "--porcelain"],
+                            capture_output=True, text=True).stdout
+    r = installers.run_reinstall_check()
+    after = subprocess.run(["git", "-C", str(_REPO_ROOT), "status", "--porcelain"],
+                           capture_output=True, text=True).stdout
+    ctx = CellContext(workdir=_REPO_ROOT, installer="bootstrap",
+                      permutation={"dogfood": True, "read_only": True}, primary=r)
+    m = _measure(B12_METRIC, ctx)
+    if before != after:  # the read-only guard: --check must not touch the working tree
+        m = Measurement(False, False, {"working_tree": "unchanged"},
+                        {"working_tree": "MUTATED by --check", **(m.observed or {})})
+    spec = REGISTRY[B12_METRIC]
+    return MetricRecord(
+        bucket="B12", fixture="self-host-dogfood", installer="bootstrap",
+        permutation_label="dogfood", permutation={"dogfood": True, "read_only": True},
+        metric=B12_METRIC, category=spec.category, kind=spec.kind, value=m.value,
+        passed=m.passed, expected=m.expected, observed=m.observed, duration_s=r.duration_s,
+        timestamp=_now(), git_sha=git_sha, notes=m.notes,
+    )
+
+
+def run_matrix(opts: dict | None = None) -> RunEnvelope:
+    """Run the full matrix and return the populated run envelope."""
+    opts = dict(opts or {})
+    started = _now()
+    git_sha = _git_sha()
+    scratch = Path(opts.get("scratch") or tempfile.mkdtemp(prefix="harness-scratch-"))
+    scratch.mkdir(parents=True, exist_ok=True)
+
+    want_buckets = opts.get("buckets") or DEFAULT_HERMETIC
+    want_installers = opts.get("installers") or ["bootstrap", "cli"]
+    include_real = bool(opts.get("include_real"))
+
+    all_buckets = {b.id: b for b in build_buckets()}
+    records: list[MetricRecord] = []
+    ran_buckets: list[str] = []
+    ran_installers: set[str] = set()
+
+    for bid in want_buckets:
+        bucket = all_buckets.get(bid)
+        if bucket is None:
+            continue
+        if bucket.real and not include_real:
+            continue  # flag-gated OFF by default (owner-decision 1)
+        ran_buckets.append(bid)
+        for leg in bucket.legs:
+            for installer in leg.installers:
+                if installer not in want_installers:
+                    continue
+                ran_installers.add(installer)
+                records.extend(run_cell(bucket, leg, installer, opts, scratch, git_sha))
+
+    # B12 dogfood inline (read-only reinstall --check on this repo), unless excluded.
+    if opts.get("dogfood", True) and (not opts.get("buckets") or "B12" in want_buckets):
+        records.append(_run_b12(git_sha))
+        ran_buckets.append("B12")
+
+    if opts.get("cleanup_scratch", True) and not opts.get("scratch"):
+        shutil.rmtree(scratch, ignore_errors=True)
+
+    return RunEnvelope(
+        run_id=f"{started}-{git_sha[:7]}", git_sha=git_sha, started_at=started,
+        finished_at=_now(), harness_version=HARNESS_VERSION, schema_version=SCHEMA_VERSION,
+        host_kind=opts.get("host_kind", "local"),
+        installers=sorted(ran_installers) or list(want_installers),
+        buckets=ran_buckets, records=records,
+    )

--- a/framework/harness/snapshot.py
+++ b/framework/harness/snapshot.py
@@ -1,0 +1,98 @@
+"""Filesystem snapshots — the ground truth teardown restores to (#104 §1 Stage 1 / §2).
+
+A snapshot is a ``{relpath: sha256}`` map of a fixture workdir captured *before* a single
+install byte lands. Teardown recomputes it and diffs (symmetric difference) to prove zero
+residue. We hash working-tree files but skip volatile git plumbing (``.git/objects``,
+``.git/logs``, index churn) so a re-run is deterministic — EXCEPT ``.git/hooks`` which is
+framework-owned (the installed ``pre-push`` must be captured, torn down, and diffed).
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+#: Framework-owned namespace (#103 `no_unexpected_files`, mirrors bootstrap `_FRAMEWORK_OWNED`).
+#: Any path a clean install adds must match one of these prefixes/patterns.
+OWNED_PREFIXES = (".claude/", "ontology/", ".git/hooks/")
+OWNED_EXACT = (".claude", "ontology")
+
+
+def _skip(rel_parts: tuple[str, ...]) -> bool:
+    """True for volatile git internals we deliberately do not hash.
+
+    Everything under a ``.git`` dir (at ANY depth — meta installs nest child git repos) is
+    skipped EXCEPT ``.git/hooks`` (the installed pre-push is a framework-owned artifact teardown
+    must account for).
+    """
+    if ".git" in rel_parts:
+        i = rel_parts.index(".git")
+        after = rel_parts[i + 1] if i + 1 < len(rel_parts) else None
+        return after != "hooks"
+    return "__pycache__" in rel_parts
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def snapshot(root: Path) -> dict[str, str]:
+    """Map every non-volatile file under ``root`` to its sha256 (posix relpaths)."""
+    out: dict[str, str] = {}
+    if not root.is_dir():
+        return out
+    for p in sorted(root.rglob("*")):
+        if not p.is_file():
+            continue
+        rel = p.relative_to(root)
+        if _skip(rel.parts):
+            continue
+        out[rel.as_posix()] = _sha256(p)
+    return out
+
+
+def added_paths(before: dict[str, str], after: dict[str, str]) -> list[str]:
+    """Relpaths present after install that were absent before."""
+    return sorted(set(after) - set(before))
+
+
+def symmetric_diff(before: dict[str, str], after: dict[str, str]) -> list[str]:
+    """Paths that differ between two snapshots: added, removed, or content-changed.
+
+    This is the residue metric for teardown — a fully reversible install returns an empty
+    list against its pre-install snapshot.
+    """
+    diff: set[str] = set(before) ^ set(after)
+    for rel in set(before) & set(after):
+        if before[rel] != after[rel]:
+            diff.add(rel)
+    return sorted(diff)
+
+
+def is_owned(relpath: str) -> bool:
+    """True iff ``relpath`` falls inside the framework-owned namespace.
+
+    Matches at ANY depth so meta-and-children installs (``api/.claude/**``,
+    ``web/CLAUDE.md``, a child ``ontology/**``) are recognised as owned, not stray — the
+    installer legitimately writes into each child repo. A genuinely stray write (a random
+    file outside any ``.claude``/``ontology``/``CLAUDE.md`` path) is still flagged.
+    """
+    parts = relpath.split("/")
+    if ".claude" in parts or "ontology" in parts:
+        return True
+    if parts[-1].startswith("CLAUDE.md"):
+        return True
+    if ".git" in parts:  # an installed .git/hooks/pre-push at any depth (meta children)
+        i = parts.index(".git")
+        return i + 1 < len(parts) and parts[i + 1] == "hooks"
+    return False
+
+
+def unexpected_paths(before: dict[str, str], after: dict[str, str]) -> list[str]:
+    """Added paths that landed OUTSIDE the framework-owned namespace (#103 no_unexpected_files)."""
+    return [p for p in added_paths(before, after) if not is_owned(p)]

--- a/framework/harness/teardown.py
+++ b/framework/harness/teardown.py
@@ -1,0 +1,72 @@
+"""Teardown drivers (#104 §2).
+
+Two mechanisms:
+
+* **drop-the-copy** (§2a, B1-B11): every fixture is a disposable tmp workdir, so teardown is
+  ``rm -rf``. Residue is zero by construction; the harness runner does this for every cell.
+
+* **manifest-driven in-place uninstall** (§2b): the reversibility PROOF. On a throwaway copy of
+  a happy-path fixture we remove the *enumerated install footprint* (the paths the install
+  added, which IS the manifest — fully knowable), restore any ``.bak`` backups, recompute the
+  ``{relpath: sha256}`` map and diff it against the pre-install snapshot. ``residue`` = the
+  symmetric difference; **pass iff 0**. A non-zero result means the installer wrote a path the
+  footprint enumeration missed (drift), which also trips ``no_unexpected_files``.
+
+No product ``uninstall`` exists (deferred #142) — this is entirely harness-side, exactly as the
+owner bound for this wave. Stdlib only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .snapshot import added_paths, snapshot, symmetric_diff
+
+
+def _restore_backups(target: Path) -> None:
+    """Restore ``<name>.bak`` → ``<name>`` for the files the installer backs up on conflict.
+
+    Happy-path fresh installs create no backups, so this is usually a no-op; it keeps the
+    uninstall correct if the proof is ever run over a conflict fixture.
+    """
+    for bak in list(target.rglob("*.bak")):
+        if ".git" in bak.parts:
+            continue
+        original = bak.with_suffix("")  # strip the trailing .bak
+        if original.name.endswith(".bak"):
+            original = bak.parent / bak.name[:-4]
+        if original.exists():
+            original.unlink()
+        bak.replace(original)
+
+
+def manifest_driven_uninstall(target: Path, pre_install: dict[str, str]) -> list[str]:
+    """Remove the install footprint and return the residue vs the pre-install snapshot.
+
+    The removal manifest is the set of files present now but absent in ``pre_install`` — the
+    install's own enumerable footprint. After removal + backup restoration we diff again;
+    an empty list proves the install was fully reversible.
+    """
+    post_install = snapshot(target)
+    footprint = added_paths(pre_install, post_install)
+    for rel in footprint:
+        p = target / rel
+        if p.is_file():
+            p.unlink()
+    _restore_backups(target)
+    _prune_empty_owned_dirs(target)
+    post_teardown = snapshot(target)
+    return symmetric_diff(pre_install, post_teardown)
+
+
+def _prune_empty_owned_dirs(target: Path) -> None:
+    """Best-effort removal of now-empty framework-owned dirs (cosmetic; residue is file-based)."""
+    for owned in (".claude", "ontology"):
+        root = target / owned
+        if not root.is_dir():
+            continue
+        for d in sorted(root.rglob("*"), key=lambda p: len(p.parts), reverse=True):
+            if d.is_dir() and not any(d.iterdir()):
+                d.rmdir()
+        if root.is_dir() and not any(root.iterdir()):
+            root.rmdir()

--- a/framework/recipes/INSTALL_TEST_METHODOLOGY.md
+++ b/framework/recipes/INSTALL_TEST_METHODOLOGY.md
@@ -216,9 +216,16 @@ acceptable alternative), written to a harness-owned results dir (path owned by #
 
 ### 3b. Metric record (one per fixture × installer × metric)
 
+> **#138 fix (implemented in #105).** The join key carries a **permutation discriminant** —
+> `record_id = "<bucket>/<installer>/<permutation>/<metric>"` — because a single bucket can assert
+> the same metric across multiple permutations (e.g. B4's gate matrix records
+> `repo_state_gate_correct` on both the *refuse* leg and the *proceed* leg). The old three-part key
+> `<bucket>/<installer>/<metric>` collided on those, so run-over-run diffs (§4) overwrote each other.
+> The colliding key is no longer emitted.
+
 ```json
 {
-  "record_id": "B4/bootstrap/repo_state_gate_correct",
+  "record_id": "B4/bootstrap/refuse/repo_state_gate_correct",
   "bucket": "B4",
   "fixture": "existing-foreign-no-claude",
   "installer": "bootstrap",
@@ -247,7 +254,7 @@ acceptable alternative), written to a harness-owned results dir (path owned by #
 
 | field | meaning |
 |-------|---------|
-| `record_id` | stable join key across runs: `"<bucket>/<installer>/<metric>"`. The comparison (§4) diffs by this key. |
+| `record_id` | stable join key across runs: `"<bucket>/<installer>/<permutation>/<metric>"` (the `<permutation>` discriminant is the #138 fix — see the callout above). The comparison (§4) diffs by this key. |
 | `bucket` / `fixture` | #103 bucket id (B1–B12) + the human fixture label the harness synthesized. |
 | `installer` | `"bootstrap"` or `"cli"`. |
 | `permutation` | the resolved install knobs for this cell (real flag names). Records *why* two cells with the same metric can differ. |

--- a/framework/tests/install_quality/runs/.gitignore
+++ b/framework/tests/install_quality/runs/.gitignore
@@ -1,0 +1,3 @@
+# Harness run envelopes (#105) are generated artifacts — the run-over-run comparison reads
+# them from here at runtime, but they are not source and must not be committed. Keep the dir.
+*.json

--- a/framework/tests/test_install_harness.py
+++ b/framework/tests/test_install_harness.py
@@ -8,6 +8,8 @@ REAL installer so the harness itself is regression-covered. Stdlib + pytest only
 
 from __future__ import annotations
 
+import importlib
+import subprocess
 import sys
 from pathlib import Path
 
@@ -16,6 +18,9 @@ import pytest
 _FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
 _REPO_ROOT = _FRAMEWORK_ROOT.parent
 sys.path.insert(0, str(_REPO_ROOT))  # make `framework.harness` importable (namespace package)
+sys.path.insert(0, str(_FRAMEWORK_ROOT / "install"))  # install_config / manifest siblings
+
+import install_config  # noqa: E402  (framework/install sibling — the resolved-config accessors)
 
 from framework.harness import buckets, compare, manifest, metrics, snapshot, teardown  # noqa: E402
 from framework.harness.records import (  # noqa: E402
@@ -132,6 +137,71 @@ def test_files_installed_complete_skips_without_manifest(tmp_path: Path) -> None
     m = metrics.m_files_installed_complete(ctx)
     if not manifest.available():
         assert m.passed is None and "pending #139" in m.notes  # neutral skip, not a fail
+
+
+# --------------------------------------------------- #139 config-shape seam (the mis-grade fix)
+
+
+def test_harness_model_map_matches_install_config() -> None:
+    """The bridge's model map MUST equal the installer's canonical map (drift guard)."""
+    assert manifest._HARNESS_MODEL_TO_INSTALL == install_config.INSTALL_MODEL_MAP
+
+
+def test_permutation_to_install_config_honors_discriminant() -> None:
+    """Regression for the silent mis-grade: the flat permutation must resolve to the NESTED
+    install-config shape #139 reads via ``get_key`` — with the discriminant actually applied,
+    NOT collapsed to the standalone+team default."""
+    default = manifest.permutation_to_install_config({"model": "single-repo", "team": True})
+    # read through the EXACT accessor #139 uses:
+    assert install_config.get_key(default, "project.model") == "standalone"
+    assert install_config.get_key(default, "team.enabled") is True
+
+    child = manifest.permutation_to_install_config({"model": "child", "team": True})
+    assert install_config.get_key(child, "project.model") == "child"
+
+    meta = manifest.permutation_to_install_config({"model": "meta-and-children", "team": True})
+    assert install_config.get_key(meta, "project.model") == "meta"
+
+    no_team = manifest.permutation_to_install_config({"model": "single-repo", "team": False})
+    assert install_config.get_key(no_team, "team.enabled") is False
+
+    # the whole point — a child / no-team permutation is DISTINCT from the standalone+team default
+    assert child != default and no_team != default
+
+
+def test_files_installed_complete_real_wiring_child_differs_from_standalone(tmp_path: Path) -> None:
+    """End-to-end through #139's ACTUAL manifest code: prove the nested shape drives distinct
+    expected sets per mode (child installs no hooks/lib; no-team drops org-artifacts). Uses the
+    real ``framework/install/manifest.py`` if merged, else vendors #139's source from its branch
+    so the wiring is proven now — before #139 lands on the base."""
+    target = _FRAMEWORK_ROOT / "install" / "manifest.py"
+    wrote = False
+    if not target.exists():
+        src = subprocess.run(
+            ["git", "-C", str(_REPO_ROOT), "show",
+             "origin/N.Rossi/0139-golden-manifest-metric-vocab:framework/install/manifest.py"],
+            capture_output=True, text=True,
+        )
+        if src.returncode != 0:
+            pytest.skip("#139 branch not fetched and manifest.py not merged — mapping unit-tested above")
+        target.write_text(src.stdout, encoding="utf-8")
+        wrote = True
+    try:
+        importlib.invalidate_caches()
+        assert manifest.available()
+        standalone = manifest.expected_install_set({"model": "single-repo", "team": True})
+        child = manifest.expected_install_set({"model": "child", "team": True})
+        no_team = manifest.expected_install_set({"model": "single-repo", "team": False})
+        assert standalone and child and no_team
+        # a child installs NO hooks of its own; standalone does — the discriminant reaches #139
+        assert ".claude/hooks/dispatcher.py" in standalone
+        assert ".claude/hooks/dispatcher.py" not in child
+        assert child < standalone      # strict subset
+        assert no_team < standalone     # team org-artifacts dropped
+    finally:
+        if wrote:
+            target.unlink()
+            importlib.invalidate_caches()
 
 
 # --------------------------------------------------------------- comparison (§4)

--- a/framework/tests/test_install_harness.py
+++ b/framework/tests/test_install_harness.py
@@ -1,0 +1,256 @@
+"""Tests for the install/test/teardown quality harness (issue #105).
+
+Covers the harness engine (snapshot, record schema + the #138 record_id fix, rollup, the #139
+manifest fail-open bridge, run-over-run comparison, teardown residue, the flavor/portability
+metric logic) plus a fast end-to-end run of a hermetic bucket + the B12 dogfood leg through the
+REAL installer so the harness itself is regression-covered. Stdlib + pytest only.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+_REPO_ROOT = _FRAMEWORK_ROOT.parent
+sys.path.insert(0, str(_REPO_ROOT))  # make `framework.harness` importable (namespace package)
+
+from framework.harness import buckets, compare, manifest, metrics, snapshot, teardown  # noqa: E402
+from framework.harness.records import (  # noqa: E402
+    MetricRecord,
+    RunEnvelope,
+    compute_rollup,
+    make_record_id,
+)
+from framework.harness.runner import DEFAULT_HERMETIC, run_matrix  # noqa: E402
+
+
+# --------------------------------------------------------------- snapshot
+
+
+def test_snapshot_hashes_files_and_skips_git_internals(tmp_path: Path) -> None:
+    (tmp_path / "a.py").write_text("x = 1\n")
+    (tmp_path / ".git" / "objects").mkdir(parents=True)
+    (tmp_path / ".git" / "objects" / "deadbeef").write_text("blob\n")
+    (tmp_path / ".git" / "hooks").mkdir()
+    (tmp_path / ".git" / "hooks" / "pre-push").write_text("#!/bin/sh\n")
+    snap = snapshot.snapshot(tmp_path)
+    assert "a.py" in snap
+    assert ".git/hooks/pre-push" in snap          # framework-owned git hook IS captured
+    assert ".git/objects/deadbeef" not in snap     # volatile git plumbing is skipped
+
+
+def test_snapshot_skips_nested_child_git(tmp_path: Path) -> None:
+    (tmp_path / "api" / ".git" / "objects").mkdir(parents=True)
+    (tmp_path / "api" / ".git" / "objects" / "x").write_text("o\n")
+    (tmp_path / "api" / ".git" / "hooks").mkdir()
+    (tmp_path / "api" / ".git" / "hooks" / "pre-push").write_text("#!/bin/sh\n")
+    snap = snapshot.snapshot(tmp_path)
+    assert "api/.git/hooks/pre-push" in snap
+    assert "api/.git/objects/x" not in snap
+
+
+def test_symmetric_diff_and_unexpected_paths() -> None:
+    before = {"a": "1", "keep": "9"}
+    after = {"keep": "9", ".claude/x": "2", "api/.claude/y": "3", "stray.txt": "4"}
+    assert snapshot.added_paths(before, after) == [".claude/x", "api/.claude/y", "stray.txt"]
+    # a removed b modified -> symmetric diff picks up a (removed) and the new paths
+    assert "a" in snapshot.symmetric_diff(before, after)
+    # only stray.txt is outside the framework-owned namespace (child .claude IS owned)
+    assert snapshot.unexpected_paths(before, after) == ["stray.txt"]
+
+
+def test_is_owned_recognises_children_and_claude_md() -> None:
+    assert snapshot.is_owned(".claude/settings.json")
+    assert snapshot.is_owned("api/.claude/settings.json")
+    assert snapshot.is_owned("web/CLAUDE.md.bak")
+    assert snapshot.is_owned("svc/ontology/domain.yaml")
+    assert not snapshot.is_owned("src/main.py")
+
+
+# --------------------------------------------------------------- records + #138
+
+
+def test_record_id_carries_permutation_discriminant() -> None:
+    """#138: two legs of the same bucket+metric MUST NOT collide."""
+    refuse = make_record_id("B4", "bootstrap", "refuse", "repo_state_gate_correct")
+    proceed = make_record_id("B4", "bootstrap", "proceed", "repo_state_gate_correct")
+    assert refuse == "B4/bootstrap/refuse/repo_state_gate_correct"
+    assert refuse != proceed  # the colliding 3-part key is never produced
+
+
+def _mk(metric: str, category: str, kind: str, value, passed, *, bucket="B1",
+        perm="default", installer="bootstrap") -> MetricRecord:
+    return MetricRecord(bucket, "fx", installer, perm, {}, metric, category, kind, value,
+                        passed, {}, {}, 0.1, "t", "sha")
+
+
+def test_rollup_metric_level_success_rate_and_parity() -> None:
+    recs = [
+        _mk("install_exit_status", "A", "pass_fail", True, True),
+        _mk("no_unexpected_files", "B", "pass_fail", 0, True),
+        _mk("settings_hooks_wired", "C", "pass_fail", False, False),
+        _mk("install_duration_s", "I", "trend", 0.5, None),       # excluded from rate
+        _mk("reinstall_parity_clean", "J", "pass_fail", True, True, bucket="B12"),
+    ]
+    roll = compute_rollup(recs)
+    # 4 graded pass_fail across the matrix (settings_hooks_wired fails) -> 3/4; trend excluded.
+    assert roll["install_success_rate"] == pytest.approx(3 / 4, abs=1e-3)
+    assert roll["reinstall_parity_clean"] is True
+    # B1 alone has 3 graded (one fails) -> 2/3
+    assert roll["per_bucket_pass_rate"]["B1"] == pytest.approx(2 / 3, abs=1e-3)
+    assert roll["trend"]["install_duration_s"]["B1"] == 0.5
+
+
+def test_run_envelope_serialises_schema() -> None:
+    env = RunEnvelope("rid", "sha", "s", "f", "0.1.0", 1, "ci", ["bootstrap"], ["B1"],
+                      [_mk("install_exit_status", "A", "pass_fail", True, True)])
+    doc = env.to_dict()
+    assert doc["schema_version"] == 1
+    assert doc["records"][0]["record_id"] == "B1/bootstrap/default/install_exit_status"
+    assert "rollup" in doc and "install_success_rate" in doc["rollup"]
+
+
+# --------------------------------------------------------------- #139 manifest bridge
+
+
+def test_manifest_bridge_fail_open_when_139_absent() -> None:
+    """Until #139 lands, the bridge returns None (metric SKIPS) rather than crashing."""
+    if manifest.available():
+        # #139 has landed — the real contract must return a set.
+        result = manifest.expected_install_set({"model": "single-repo"})
+        assert result is None or isinstance(result, set)
+    else:
+        assert manifest.expected_install_set({"model": "single-repo"}) is None
+        assert "pending #139" in manifest.PENDING_NOTE
+
+
+def test_files_installed_complete_skips_without_manifest(tmp_path: Path) -> None:
+    ctx = metrics.CellContext(workdir=tmp_path, installer="bootstrap", permutation={})
+    m = metrics.m_files_installed_complete(ctx)
+    if not manifest.available():
+        assert m.passed is None and "pending #139" in m.notes  # neutral skip, not a fail
+
+
+# --------------------------------------------------------------- comparison (§4)
+
+
+def _doc(records, isr, parity=None):
+    return {
+        "records": [r if isinstance(r, dict) else r.to_dict() for r in records],
+        "rollup": {"install_success_rate": isr, "reinstall_parity_clean": parity},
+        "run": {"run_id": "r", "finished_at": "2026-01-01T00:00:00Z"},
+    }
+
+
+def test_compare_baseline_then_regression_and_improvement() -> None:
+    base = _doc([_mk("settings_hooks_wired", "C", "pass_fail", True, True)], 1.0)
+    assert compare.compare(base, None)["verdict"] == "BASELINE"
+
+    worse = _doc([_mk("settings_hooks_wired", "C", "pass_fail", False, False)], 0.0)
+    v = compare.compare(worse, base)
+    assert v["verdict"] == "REGRESSION" and v["regressions"] == 1
+
+    better = _doc([_mk("settings_hooks_wired", "C", "pass_fail", True, True)], 1.0)
+    v2 = compare.compare(better, worse)
+    assert v2["verdict"] == "IMPROVEMENT"
+
+
+def test_compare_trend_budget() -> None:
+    base = _doc([_mk("install_duration_s", "I", "trend", 1.0, None)], None)
+    slow = _doc([_mk("install_duration_s", "I", "trend", 2.0, None)], None)  # +1.0 > max(.5,.2)
+    assert compare.compare(slow, base)["verdict"] == "REGRESSION"
+    noise = _doc([_mk("install_duration_s", "I", "trend", 1.1, None)], None)  # +0.1 within budget
+    assert compare.compare(noise, base)["verdict"] == "STABLE"
+
+
+# --------------------------------------------------------------- teardown residue (§2b)
+
+
+def test_manifest_driven_uninstall_is_zero_residue(tmp_path: Path) -> None:
+    (tmp_path / "keep.py").write_text("x = 1\n")
+    pre = snapshot.snapshot(tmp_path)
+    # simulate an install footprint
+    (tmp_path / ".claude" / "hooks").mkdir(parents=True)
+    (tmp_path / ".claude" / "hooks" / "dispatcher.py").write_text("# hook\n")
+    (tmp_path / "ontology").mkdir()
+    (tmp_path / "ontology" / "domain.yaml").write_text("x\n")
+    residue = teardown.manifest_driven_uninstall(tmp_path, pre)
+    assert residue == []
+    assert (tmp_path / "keep.py").is_file()  # untouched
+
+
+def test_manifest_driven_uninstall_flags_residue_when_backup_missing(tmp_path: Path) -> None:
+    (tmp_path / "keep.py").write_text("x = 1\n")
+    pre = snapshot.snapshot(tmp_path)
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / "f").write_text("a\n")
+    (tmp_path / "keep.py").write_text("MUTATED\n")  # install clobbered a tracked file
+    residue = teardown.manifest_driven_uninstall(tmp_path, pre)
+    assert "keep.py" in residue  # modified content is residue vs the pre-install snapshot
+
+
+# --------------------------------------------------------------- buckets matrix
+
+
+def test_buckets_matrix_shape_and_real_gating() -> None:
+    bs = {b.id: b for b in buckets.build_buckets()}
+    assert set(DEFAULT_HERMETIC) <= set(bs)
+    assert bs["B10"].real and bs["B11"].real            # real buckets flag-gated
+    assert not bs["B1"].real
+    # B4 has the two-leg gate matrix with DISTINCT permutation labels (#138 driver)
+    labels = {leg.perm_label for leg in bs["B4"].legs}
+    assert labels == {"refuse", "proceed"}
+    # every metric id referenced by a leg exists in the registry (vocabulary is #103-verbatim)
+    for b in bs.values():
+        for leg in b.legs:
+            for mid in leg.metrics:
+                assert mid in metrics.REGISTRY, f"{b.id}/{leg.perm_label}: unknown metric {mid}"
+
+
+def test_provisioners_synthesize_expected_layout(tmp_path: Path) -> None:
+    # The runner mints the workdir (mkdtemp) before calling provision; mirror that here.
+    for name, prov in (("b3", buckets._prov_single_lang), ("b8", buckets._prov_adversarial),
+                       ("b8b", buckets._prov_invalid_config)):
+        (tmp_path / name).mkdir()
+        prov(tmp_path / name, {})
+    assert (tmp_path / "b3" / "module.py").is_file()
+    assert (tmp_path / "b3" / "cli.yaml").is_file()
+    assert (tmp_path / "b8" / "ontology" / "structural").is_file()  # a FILE, not a dir
+    assert (tmp_path / "b8b" / "bad.config.json").is_file()
+
+
+def test_real_bucket_provisioner_is_a_guarded_stub(tmp_path: Path) -> None:
+    with pytest.raises(NotImplementedError, match="pinned SHA"):
+        buckets._prov_real_stub(tmp_path, {})
+
+
+# --------------------------------------------------------------- end-to-end (real installer)
+
+
+@pytest.mark.parametrize("bucket_id", ["B1", "B8b"])
+def test_run_matrix_hermetic_bucket_all_green(bucket_id: str) -> None:
+    """A fast hermetic cell driven through the REAL bootstrap installer passes every metric."""
+    env = run_matrix({"buckets": [bucket_id], "installers": ["bootstrap"], "dogfood": False})
+    doc = env.to_dict()
+    graded = [r for r in doc["records"] if r["pass"] is not None
+              and r["kind"] in ("pass_fail", "scored")]
+    assert graded, "no graded metrics produced"
+    failed = [r for r in graded if not r["pass"]]
+    assert not failed, f"unexpected failures: {[r['record_id'] for r in failed]}"
+    assert doc["rollup"]["install_success_rate"] == 1.0
+
+
+def test_run_matrix_dogfood_parity_clean() -> None:
+    """B12 inline: reinstall --check on this repo is clean and read-only (dual-deploy #116)."""
+    env = run_matrix({"buckets": ["B12"], "installers": ["bootstrap"], "dogfood": True})
+    b12 = [r for r in env.records if r.bucket == "B12"]
+    assert len(b12) == 1
+    assert b12[0].metric == "reinstall_parity_clean"
+    assert b12[0].passed is True
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary

Implements the automated **install / test / teardown quality harness** (#105) — the
integration/quality-trend layer over the unit suite. It provisions each repo-type fixture from
the #103 taxonomy, runs the **real** installer(s) with the bucket's flag permutation, asserts the
#103 metric vocabulary, tears the fixture down with a residue proof, and emits the #104
metric-record schema plus a human + machine-readable rollup.

**Entrypoint:** `python3 -m framework.harness` (dev/test tooling under `framework/harness/` — NOT
part of the installed `.claude` runtime, so `reinstall.py --check` parity is unaffected).

```
python3 -m framework.harness                 # hermetic B1-B9 + B12 dogfood, both installers
python3 -m framework.harness --quick          # fast CI smoke subset (bootstrap only)
python3 -m framework.harness --compare         # gate on the run-over-run verdict
python3 -m framework.harness --include-real    # opt-in B10/B11 (owner-gated; OFF by default)
```

### What runs by default vs flag-gated
| Bucket | Default | Installer(s) | Notes |
|--------|---------|--------------|-------|
| **B1-B9** (+B4/B7b/B8b gate/precondition/invalid legs) | ✅ run | bootstrap (full) + CLI smoke on B2/B3/B5 | hermetic, synthesized into `mktemp -d` |
| **B12** dogfood | ✅ run **inline** | `reinstall.py --check` on this repo | read-only, no fixture/teardown; guards working tree byte-identical |
| **B10 / B11** [real] | ⛔ flag-gated OFF | — | `--include-real` opts in; provisioning is a guarded `NotImplementedError` stub that clones the remote default branch at a pinned SHA into scratch — **never** the live working repo |

### Teardown proof
- **drop-the-copy** for every cell (disposable `mktemp -d`, dropped on teardown).
- **manifest-driven in-place uninstall** on a throwaway copy of B2/B6 (the reversibility proof):
  removes the install's *enumerable footprint*, restores any `.bak`, recomputes the
  `{relpath: sha256}` map and diffs it (symmetric difference) against the pre-install snapshot —
  **pass iff 0 residue**. No product `uninstall` is built (deferred #142); teardown is entirely
  harness-side, as bound for this wave.

### #138 resolution (Closes #138)
The metric-record `record_id` now carries the **permutation discriminant** —
`<bucket>/<installer>/<permutation>/<metric>` — so B4's *refuse* and *proceed* legs no longer
collide on `repo_state_gate_correct`. The colliding 3-part key is never emitted.
`INSTALL_TEST_METHODOLOGY.md` §3b updated to match.

### #139 manifest integration — status: **pending (guarded), auto-wires on land**
`files_installed_complete` is coded against Nia's `expected_install_set(config)` signature and
imported fail-open (via importlib, path-based). #139 (`framework/install/manifest.py`) is **not on
the wave branch yet**, so the metric currently **SKIPS with a "pending #139" note** (neutral —
excluded from pass rates) rather than crashing. When #139 lands it wires automatically with no
harness change. `framework/harness/manifest.py` is the single integration seam.

## Charter review

- **Identity:** committed with per-commit `-c` flags (`Tariq Morales <Tariq.Morales@gmail.com>`) +
  the two `Co-Authored-By` trailers; no global/repo git config touched; hooks never bypassed.
- **Dual-deploy invariant (#116):** the harness lives under `framework/` source, not `.claude/`
  or `framework/assets/`, so it never ships to a target repo and does not affect the canonical↔live
  mirror. `reinstall.py --check` stays clean.
- **Grounded in real behavior:** every install invocation uses actual `bootstrap.py` / `2real-team
  init` flags read from source; metrics reuse the vocabulary/assertions the unit suite already
  encodes (`test_bootstrap_smoke.py`, `test_meta_child_install.py`, `test_reinstall_parity.py`).
- **Approval gates:** this PR targets `deployments/phase5/wave-2` (not main); **not merging** —
  awaiting review.
- **Deferred / flagged for the reviewer:** (1) `cli_bridge_soft_degrade` (Nia's #104 review-note
  item 2) is **not** implemented — making the bundled assets unavailable is hard in a source
  checkout where the bridge falls back to repo `framework/`; recommend folding the id into #103 +
  wiring it when the CLI gains a testable "assets-absent" seam. (2) The `--compare` regression gate
  is implemented (§4) but not yet added as a CI job (would need a committed baseline + owner sign-off).

## Verification
- `python3 -m pytest framework/tests/ -q` → **411 passed** (base 376 + #107 + 19 new harness tests).
- `ruff check framework/` → clean.
- `python3 framework/install/reinstall.py --check` → in sync.
- Full default matrix (both installers + B12): **install_success_rate 1.00** (101/101 graded),
  `reinstall_parity_clean: true`.

Closes #105
Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTQxgBAcChxvdQJafKyMdX
