### PR TITLE
harness: real-repo provisioner (clone-at-pinned-SHA) + wire --include-real for B10/B11 (#153)

### DIFF
--- a/framework/harness/__main__.py
+++ b/framework/harness/__main__.py
@@ -33,6 +33,9 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
                     help="comma-separated installers to run (bootstrap,cli)")
     ap.add_argument("--include-real", action="store_true",
                     help="opt in to the [real] B10/B11 buckets (owner-gated; OFF by default)")
+    ap.add_argument("--real-config", type=Path, default=None,
+                    help="sidecar JSON overriding the B10/B11 real-fixture source/pin registry "
+                         "(see framework.harness.real_provision.RealFixtureSpec)")
     ap.add_argument("--no-dogfood", action="store_true", help="skip the B12 reinstall --check leg")
     ap.add_argument("--scale", type=int, default=None, help="B9 file count (default: 300)")
     ap.add_argument("--out", type=Path, default=_DEFAULT_RUNS_DIR,
@@ -64,6 +67,8 @@ def _opts(args: argparse.Namespace) -> dict:
     }
     if args.scale is not None:
         opts["scale"] = args.scale
+    if args.real_config is not None:
+        opts["real_config"] = str(args.real_config)
     return opts
 
 

--- a/framework/harness/buckets.py
+++ b/framework/harness/buckets.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
+from .real_provision import make_real_provisioner
+
 _FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
 _BOOTSTRAP = _FRAMEWORK_ROOT / "install" / "bootstrap.py"
 
@@ -202,12 +204,9 @@ def _prov_large(wd: Path, opts: dict) -> dict:
     return {"extra": {"expect_source_path": "gen/f00000.py"}, "n_files": n}
 
 
-def _prov_real_stub(wd: Path, opts: dict) -> dict:
-    raise NotImplementedError(
-        "B10/B11 real-world provisioning is flag-gated and NOT wired in this wave. When enabled "
-        "it must CLONE the remote default branch at a pinned SHA into this scratch dir — never "
-        "copy/worktree the live working repo (other sessions operate there). See owner-decision 1."
-    )
+# B10/B11 real-world provisioning (clone-at-pinned-SHA into scratch, read-only w.r.t. the live
+# source) lives in ``real_provision`` and is bound per-bucket by ``make_real_provisioner`` — the
+# source/pin registry is DATA there (#153), overridable via ``--real-config`` for #101/#109.
 
 
 # --------------------------------------------------------------------- the matrix
@@ -333,14 +332,26 @@ def build_buckets() -> list[Bucket]:
                 # out of the way — B9 stresses scale/timing, not the fresh-vs-existing verdict.
                 _bootstrap_flags("--with-ontology", "--expect", "any", "--owner", "acme")),
         ]),
-        # --- [real] flag-gated OFF by default (owner-decision 1) ---
-        Bucket("B10", "meta-real-world", _prov_real_stub, [
-            Leg("meta-real", ("bootstrap",), ["install_exit_status"],
-                {"model": "meta-and-children", "real": True}),
+        # --- [real] flag-gated OFF by default (owner-decision 1); provisioned by cloning the
+        # live source at a pinned SHA into scratch (#153) only under --include-real. ---
+        Bucket("B10", "meta-real-world", make_real_provisioner("B10"), [
+            Leg("meta-real", ("bootstrap",),
+                ["install_exit_status", "non_interactive_zero_prompts",
+                 "child_wiring_portable", "child_flavor_filtered", "no_unexpected_files",
+                 "reinstall_idempotent", "no_backup_litter", "teardown_residue_zero",
+                 "install_duration_s"],
+                {"model": "meta-and-children", "expect": "any", "team": True, "real": True},
+                lambda wd: ["--install-config", str(wd / "install.meta.yaml"), "--model",
+                            "meta-and-children"],
+                teardown_proof=True),
         ], real=True),
-        Bucket("B11", "standalone-real-world", _prov_real_stub, [
-            Leg("existing-real", ("bootstrap",), ["install_exit_status"],
-                {"model": "single-repo", "real": True}),
+        Bucket("B11", "standalone-real-world", make_real_provisioner("B11"), [
+            Leg("existing-real", ("bootstrap",),
+                _CORE_STANDALONE + ["repo_state_gate_correct", "reinstall_idempotent",
+                                    "no_backup_litter", "teardown_residue_zero"],
+                {"model": "single-repo", "expect": "existing", "team": True, "real": True},
+                _bootstrap_flags("--expect", "existing", "--owner", "acme", "--no-ontology"),
+                gate_expect="proceed", teardown_proof=True),
         ], real=True),
     ]
 

--- a/framework/harness/buckets.py
+++ b/framework/harness/buckets.py
@@ -8,7 +8,8 @@ bucket→permutation-flags, bucket→[metric-id]. Metric ids are #103 verbatim.
 Owner decisions bound into this wave:
   * Default run = hermetic **B1-B9** + **B12 dogfood INLINE** (reinstall --check on this repo).
   * **B10/B11** are DEFINED but flag-gated OFF (``real=True``); ``--include-real`` opts in, and
-    their provisioning (clone-at-pinned-SHA into scratch) is a guarded stub, never the live repo.
+    their provisioning clones the live source at a pinned SHA into scratch, read-only w.r.t. the
+    source (never the live working tree). See ``real_provision`` (#153).
 Stdlib only.
 """
 

--- a/framework/harness/real_provision.py
+++ b/framework/harness/real_provision.py
@@ -1,0 +1,280 @@
+"""Real-repo provisioner (#153): clone a live source at a pinned SHA into scratch, read-only.
+
+B10 (``meta-real-world``) and B11 (``standalone-real-world``) run the harness against REAL
+checkouts instead of synthesized fixtures. The live source trees are under concurrent work by
+other sessions, so provisioning MUST be read-only w.r.t. the source:
+
+  * ``git clone --no-local <source> <scratch>`` forces a full object copy — never a hardlink
+    into the source ``.git`` (the plain local-clone default) and never a worktree/copy of the
+    live working tree. Uncommitted dirt in the source is therefore never carried into the clone;
+    a locally-dirty source still clones clean at the pinned commit.
+  * The pin is resolved from the source's default branch via ``git ls-remote`` at run time (an
+    explicit SHA may be pinned instead) — never trusted from whatever branch happens to be
+    checked out locally, since several sources sit on in-progress feature branches.
+  * The source's ``HEAD`` + ``git status --porcelain`` are fingerprinted before and after the
+    provision and asserted byte-identical — the load-bearing safety property.
+
+Which source/pin each bucket uses is DATA (a ``RealFixtureSpec`` registry), overridable via a
+sidecar JSON (``--real-config``) or ``opts['real_fixtures']`` (tests), so the mechanism is
+proven hermetically against a throwaway local git repo — the real multi-GB noorinalabs/botfarm
+runs are #101 / #109 and are never cloned in CI. Stdlib only.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class MissingFixtureError(NotImplementedError):
+    """A real fixture is genuinely unresolvable (no registry entry, or source unreachable).
+
+    Subclasses ``NotImplementedError`` so the runner's existing stub-skip path
+    (``runner.run_cell``) degrades it to a *skipped* record instead of a crash — keeping CI and
+    machines that lack the local checkouts green, exactly as the pre-#153 stub did.
+    """
+
+
+class SourceMutatedError(RuntimeError):
+    """The source repo's HEAD/porcelain changed across a provision — read-only invariant broken.
+
+    A plain ``Exception`` (NOT a skip): with ``git clone --no-local`` this can only happen if
+    something outside the harness wrote to the live source mid-provision, and the runner isolates
+    it to a single errored cell rather than trusting a moved-under-us source.
+    """
+
+
+# --------------------------------------------------------------------- spec model
+
+
+@dataclass(frozen=True)
+class RealChildSpec:
+    """A nested, independently-``git``'d child of a meta parent (a gitignored sibling dir)."""
+
+    path: str            # relative dir under the parent workdir the child is cloned into
+    source: str          # local path or git remote URL
+    pin: str | None = None
+    ref: str = "refs/heads/main"
+    flavor: str = "product"
+
+    def to_dict(self) -> dict:
+        return {"path": self.path, "source": self.source, "pin": self.pin,
+                "ref": self.ref, "flavor": self.flavor}
+
+    @classmethod
+    def from_dict(cls, d: dict) -> RealChildSpec:
+        return cls(path=d["path"], source=d["source"], pin=d.get("pin"),
+                   ref=d.get("ref", "refs/heads/main"), flavor=d.get("flavor", "product"))
+
+
+@dataclass(frozen=True)
+class RealFixtureSpec:
+    """Data-only description of a real clone source for a bucket (inspectable/diffable, #104 §6).
+
+    ``pin=None`` means "resolve ``ref`` from the source at run time" (the AC default — never trust
+    the locally checked-out branch). An explicit ``pin`` SHA is honored verbatim (reproducible
+    real runs; #101/#109 pass one via ``--real-config``).
+    """
+
+    bucket: str
+    source: str
+    pin: str | None = None
+    ref: str = "refs/heads/main"
+    model: str = "single-repo"                 # "single-repo" | "meta-and-children"
+    children: tuple[RealChildSpec, ...] = ()
+
+    def to_dict(self) -> dict:
+        return {"bucket": self.bucket, "source": self.source, "pin": self.pin,
+                "ref": self.ref, "model": self.model,
+                "children": [c.to_dict() for c in self.children]}
+
+    @classmethod
+    def from_dict(cls, bucket: str, d: dict) -> RealFixtureSpec:
+        return cls(
+            bucket=bucket, source=d["source"], pin=d.get("pin"),
+            ref=d.get("ref", "refs/heads/main"), model=d.get("model", "single-repo"),
+            children=tuple(RealChildSpec.from_dict(c) for c in d.get("children", ())),
+        )
+
+
+#: Documented current HEADs (from #150 discovery), kept for reference/reproducibility only —
+#: the DEFAULT specs resolve the LIVE ``refs/heads/main`` at run time (``pin=None``) so a dev
+#: run never trusts a locally checked-out feature branch. #101 supplies noorinalabs' in-scope
+#: nested children (and #101/#109 an explicit pin) via ``--real-config``.
+DEFAULT_REAL_FIXTURES: dict[str, RealFixtureSpec] = {
+    # B11 standalone-real-world -> botfarm_inc (HEAD a4e622dde79436ee8230de662020c3f3f0ee7e9d)
+    "B11": RealFixtureSpec(
+        bucket="B11", source="/home/parameterization/code/botfarm_inc",
+        pin=None, ref="refs/heads/main", model="single-repo",
+    ),
+    # B10 meta-real-world -> noorinalabs-main (HEAD 582416e85413f52b2972ae8def36a37eb486f818)
+    "B10": RealFixtureSpec(
+        bucket="B10", source="/home/parameterization/code/noorinalabs-main",
+        pin=None, ref="refs/heads/main", model="meta-and-children", children=(),
+    ),
+}
+
+
+# --------------------------------------------------------------------- git plumbing
+
+
+def _git(cwd: Path | None, *args: str) -> str:
+    cmd = ["git", *(["-C", str(cwd)] if cwd else []), *args]
+    cp = subprocess.run(cmd, capture_output=True, text=True)
+    if cp.returncode != 0:
+        raise subprocess.CalledProcessError(cp.returncode, cmd, cp.stdout, cp.stderr)
+    return cp.stdout
+
+
+def _is_local(source: str) -> bool:
+    return Path(source).exists()
+
+
+def resolve_pin(source: str, ref: str = "refs/heads/main", pin: str | None = None) -> str:
+    """Return the SHA to clone at: an explicit ``pin`` verbatim, else ``git ls-remote`` of ``ref``.
+
+    Reads the source's *ref* (not its checked-out branch); raises ``MissingFixtureError`` when the
+    source is unreachable or the ref is absent, so the runner degrades to a skip.
+    """
+    if pin:
+        return pin
+    try:
+        out = _git(None, "ls-remote", source, ref)
+    except (subprocess.CalledProcessError, OSError) as exc:
+        detail = getattr(exc, "stderr", "") or exc
+        raise MissingFixtureError(
+            f"cannot resolve pin: git ls-remote {source!r} {ref!r} failed: "
+            f"{str(detail).strip()}") from None
+    for line in out.splitlines():
+        sha, _, name = line.partition("\t")
+        if name.strip() == ref:
+            return sha.strip()
+    first = out.split("\t", 1)[0].strip() if out.strip() else ""
+    if not first:
+        raise MissingFixtureError(f"ref {ref!r} not found in source {source!r}")
+    return first
+
+
+def clone_at(source: str, sha: str, dest: Path) -> None:
+    """``git clone [--no-local] <source> <dest>`` then detach ``HEAD`` at ``sha``.
+
+    ``--no-local`` (local sources only) forces a real object copy so the source ``.git`` is never
+    hardlinked or otherwise touched. ``dest`` must be empty or nonexistent (git's requirement).
+    """
+    args = ["git", "clone", "-q"]
+    if _is_local(source):
+        args.append("--no-local")
+    args += [source, str(dest)]
+    cp = subprocess.run(args, capture_output=True, text=True)
+    if cp.returncode != 0:
+        raise MissingFixtureError(f"git clone of {source!r} failed: {cp.stderr.strip()}")
+    co = subprocess.run(["git", "-C", str(dest), "checkout", "-q", "--detach", sha],
+                        capture_output=True, text=True)
+    if co.returncode != 0:
+        raise MissingFixtureError(
+            f"git checkout {sha} in clone of {source!r} failed: {co.stderr.strip()}")
+
+
+def source_fingerprint(source: str) -> dict | None:
+    """``{head, porcelain}`` of a LOCAL source's live working tree, or ``None`` for a remote URL.
+
+    The pair the read-only invariant asserts is byte-identical before and after a provision.
+    ``None`` for a remote (no local tree to protect) — the invariant is vacuously held.
+    """
+    if not _is_local(source):
+        return None
+    p = Path(source)
+    try:
+        head = _git(p, "rev-parse", "HEAD").strip()
+        porcelain = _git(p, "status", "--porcelain")
+    except (subprocess.CalledProcessError, OSError):
+        return None
+    return {"head": head, "porcelain": porcelain}
+
+
+# --------------------------------------------------------------------- provisioning
+
+
+def _all_sources(spec: RealFixtureSpec) -> list[str]:
+    return [spec.source, *(c.source for c in spec.children)]
+
+
+def _write_meta_yaml(wd: Path, spec: RealFixtureSpec) -> Path:
+    """Emit the ``install.meta.yaml`` the meta install reads (mirrors the synthetic ``_prov_meta``)."""
+    lines = ["repo:", "  expect: any", "scm:", "  owner: acme",
+             "project:", "  model: meta", "children:"]
+    for child in spec.children:
+        lines.append(f"  - path: {child.path}")
+        if child.flavor and child.flavor != "product":
+            lines.append(f"    flavor: {child.flavor}")
+    yaml = wd / "install.meta.yaml"
+    yaml.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return yaml
+
+
+def provision_real(spec: RealFixtureSpec | None, wd: Path, opts: dict | None = None) -> dict:
+    """Clone ``spec``'s source (+ children for meta) at its pin into ``wd``; return fixture ctx.
+
+    Read-only w.r.t. the source and asserted so: every local source's ``{head, porcelain}`` is
+    fingerprinted before and after and must be byte-identical (``SourceMutatedError`` otherwise).
+    """
+    if spec is None:
+        raise MissingFixtureError("no real-fixture spec registered for this bucket")
+
+    before = {s: source_fingerprint(s) for s in _all_sources(spec)}
+
+    sha = resolve_pin(spec.source, spec.ref, spec.pin)
+    clone_at(spec.source, sha, wd)
+
+    ctx: dict = {"extra": {"machine_root": str(wd), "real": True,
+                           "source": spec.source, "pin": sha}}
+
+    if spec.model == "meta-and-children":
+        children_ctx = []
+        for child in spec.children:
+            child_sha = resolve_pin(child.source, child.ref, child.pin)
+            clone_at(child.source, child_sha, wd / child.path)
+            children_ctx.append({"path": child.path, "rel": "..", "flavor": child.flavor})
+        ctx["child"] = {"children": children_ctx}
+        ctx["yaml"] = str(_write_meta_yaml(wd, spec))
+
+    after = {s: source_fingerprint(s) for s in _all_sources(spec)}
+    unchanged = before == after
+    ctx["extra"]["source_unchanged"] = unchanged
+    if not unchanged:
+        changed = [s for s in before if before[s] != after[s]]
+        raise SourceMutatedError(
+            f"source(s) mutated during provision (read-only invariant violated): {changed}")
+    return ctx
+
+
+# --------------------------------------------------------------------- registry + factory
+
+
+def real_registry(opts: dict | None = None) -> dict[str, RealFixtureSpec]:
+    """The effective bucket->spec map: DEFAULTs overlaid by a ``--real-config`` sidecar JSON
+    (``opts['real_config']``) then by an in-process ``opts['real_fixtures']`` (tests)."""
+    opts = opts or {}
+    reg = dict(DEFAULT_REAL_FIXTURES)
+    cfg_path = opts.get("real_config")
+    if cfg_path:
+        data = json.loads(Path(cfg_path).read_text(encoding="utf-8"))
+        for bucket, d in data.items():
+            reg[bucket] = RealFixtureSpec.from_dict(bucket, d)
+    for bucket, spec in (opts.get("real_fixtures") or {}).items():
+        reg[bucket] = spec
+    return reg
+
+
+def make_real_provisioner(bucket_id: str):
+    """A ``(wd, opts) -> ctx`` provisioner bound to ``bucket_id`` (looks its spec up per-run)."""
+
+    def _provision(wd: Path, opts: dict) -> dict:
+        return provision_real(real_registry(opts).get(bucket_id), wd, opts)
+
+    _provision.__name__ = f"_prov_real_{bucket_id}"
+    _provision.__qualname__ = _provision.__name__
+    _provision.__doc__ = f"Real-repo provisioner for {bucket_id} (clone-at-pinned-SHA, #153)."
+    return _provision

--- a/framework/tests/test_install_harness.py
+++ b/framework/tests/test_install_harness.py
@@ -22,7 +22,15 @@ sys.path.insert(0, str(_FRAMEWORK_ROOT / "install"))  # install_config / manifes
 
 import install_config  # noqa: E402  (framework/install sibling — the resolved-config accessors)
 
-from framework.harness import buckets, compare, manifest, metrics, snapshot, teardown  # noqa: E402
+from framework.harness import (  # noqa: E402
+    buckets,
+    compare,
+    manifest,
+    metrics,
+    real_provision,
+    snapshot,
+    teardown,
+)
 from framework.harness.records import (  # noqa: E402
     MetricRecord,
     RunEnvelope,
@@ -292,9 +300,14 @@ def test_provisioners_synthesize_expected_layout(tmp_path: Path) -> None:
     assert (tmp_path / "b8b" / "bad.config.json").is_file()
 
 
-def test_real_bucket_provisioner_is_a_guarded_stub(tmp_path: Path) -> None:
-    with pytest.raises(NotImplementedError, match="pinned SHA"):
-        buckets._prov_real_stub(tmp_path, {})
+def test_real_bucket_provisioner_degrades_when_fixture_unresolvable(tmp_path: Path) -> None:
+    """The #153 provisioner replaced the raw stub: an unresolvable fixture raises
+    MissingFixtureError (a NotImplementedError subclass) so the runner's skip path still fires."""
+    prov = buckets.make_real_provisioner("B11")
+    opts = {"real_fixtures": {"B11": real_provision.RealFixtureSpec(
+        bucket="B11", source=str(tmp_path / "does-not-exist"))}}
+    with pytest.raises(NotImplementedError):
+        prov(tmp_path / "wd", opts)
 
 
 # --------------------------------------------------------------- end-to-end (real installer)

--- a/framework/tests/test_real_provisioner.py
+++ b/framework/tests/test_real_provisioner.py
@@ -153,6 +153,35 @@ def test_source_fingerprint_none_for_nonlocal() -> None:
     assert source_fingerprint("git@github.com:noorinalabs/noorinalabs-main.git") is None
 
 
+def test_source_mutation_mid_provision_raises_source_mutated(tmp_path: Path, monkeypatch) -> None:
+    """Negative-path guard for the load-bearing invariant: if the source is mutated BETWEEN the
+    before/after fingerprints, provision_real MUST raise SourceMutatedError. Injects a real
+    concurrent-writer mutation mid-provision (a stand-in for another session dirtying the live
+    tree) by wrapping clone_at. This is NOT a tautology — with the invariant check removed,
+    provision_real would return normally and this test would FAIL."""
+    src = tmp_path / "src"
+    _existing_repo(src)
+    before = source_fingerprint(str(src))
+
+    real_clone = real_provision.clone_at
+
+    def mutating_clone(source: str, sha: str, dest: Path) -> None:
+        # another session writes into the live source AFTER the `before` fingerprint is taken
+        (Path(source) / "intruder.txt").write_text("written mid-provision\n", encoding="utf-8")
+        real_clone(source, sha, dest)  # the clone itself still succeeds
+
+    monkeypatch.setattr(real_provision, "clone_at", mutating_clone)
+
+    spec = RealFixtureSpec(bucket="B11", source=str(src), ref="refs/heads/main")
+    with pytest.raises(real_provision.SourceMutatedError) as ei:
+        provision_real(spec, tmp_path / "wd")
+
+    # the raise is driven by the after-fingerprint mismatch, and names the mutated source
+    assert str(src) in str(ei.value)
+    after = source_fingerprint(str(src))
+    assert after != before and after is not None  # the source genuinely changed (guard is real)
+
+
 # --------------------------------------------------------------- --include-real wiring
 
 

--- a/framework/tests/test_real_provisioner.py
+++ b/framework/tests/test_real_provisioner.py
@@ -1,0 +1,304 @@
+"""Hermetic tests for the #153 real-repo provisioner (clone-at-pinned-SHA + --include-real).
+
+Everything is proven against a throwaway LOCAL git repo built in ``tmp_path`` — no network, no
+real noorinalabs/botfarm fixtures (those runs are #101/#109). We assert the load-bearing safety
+property (the live source is byte-identical before/after a provision), that a dirty source still
+clones clean at the pin, that ``--include-real`` actually executes the B10/B11 real-bucket path
+(not ``NotImplementedError``), that a genuinely unresolvable fixture degrades to a skip, and that
+teardown leaves zero residue on both the scratch clone and the source. Stdlib + pytest only.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+_REPO_ROOT = _FRAMEWORK_ROOT.parent
+sys.path.insert(0, str(_REPO_ROOT))  # make `framework.harness` importable (namespace package)
+
+from framework.harness import real_provision  # noqa: E402
+from framework.harness.real_provision import (  # noqa: E402
+    MissingFixtureError,
+    RealChildSpec,
+    RealFixtureSpec,
+    provision_real,
+    resolve_pin,
+    source_fingerprint,
+)
+from framework.harness.runner import run_matrix  # noqa: E402
+
+
+# --------------------------------------------------------------- synthetic git fixtures
+
+
+def _git(cwd: Path, *args: str) -> str:
+    cp = subprocess.run(["git", "-C", str(cwd), *args], check=True, capture_output=True, text=True)
+    return cp.stdout
+
+
+def _commit(cwd: Path, msg: str) -> str:
+    subprocess.run(
+        ["git", "-C", str(cwd), "-c", "user.name=Fixture", "-c", "user.email=fx@example.com",
+         "commit", "-q", "-m", msg],
+        check=True, capture_output=True,
+    )
+    return _git(cwd, "rev-parse", "HEAD").strip()
+
+
+def _make_repo(path: Path, files: dict[str, str]) -> str:
+    """Build a tiny real git repo on branch ``main``; return the HEAD sha."""
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-q")
+    for rel, content in files.items():
+        fp = path / rel
+        fp.parent.mkdir(parents=True, exist_ok=True)
+        fp.write_text(content, encoding="utf-8")
+    _git(path, "add", "-A")
+    sha = _commit(path, "init")
+    _git(path, "branch", "-M", "main")
+    return sha
+
+
+def _existing_repo(path: Path) -> str:
+    """A foreign existing project (no .claude) — the B11 standalone clone source."""
+    return _make_repo(path, {"src/main.py": "print('app')\n", "README.md": "# real project\n"})
+
+
+# --------------------------------------------------------------- pin resolution
+
+
+def test_resolve_pin_explicit_is_verbatim(tmp_path: Path) -> None:
+    assert resolve_pin("ignored", pin="deadbeef") == "deadbeef"  # no ls-remote when pinned
+
+
+def test_resolve_pin_reads_remote_main_not_local_checkout(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    main_sha = _existing_repo(src)
+    # move the local checkout onto a feature branch with a NEW commit — main must NOT follow it
+    _git(src, "checkout", "-q", "-b", "feature/wip")
+    (src / "src" / "extra.py").write_text("x = 1\n", encoding="utf-8")
+    _git(src, "add", "-A")
+    feature_sha = _commit(src, "wip on a feature branch")
+
+    resolved = resolve_pin(str(src), "refs/heads/main")
+    assert resolved == main_sha        # the remote ref, not the checked-out feature branch
+    assert resolved != feature_sha
+
+
+def test_resolve_pin_unresolvable_source_raises_missing(tmp_path: Path) -> None:
+    with pytest.raises(MissingFixtureError):
+        resolve_pin(str(tmp_path / "nope"), "refs/heads/main")
+
+
+# --------------------------------------------------------------- clone-at-pin
+
+
+def test_clone_at_pin_checks_out_the_pinned_commit(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    first = _existing_repo(src)
+    # a second commit that adds a file — pinning to `first` must NOT include it
+    (src / "later.py").write_text("y = 2\n", encoding="utf-8")
+    _git(src, "add", "-A")
+    second = _commit(src, "second")
+    assert first != second
+
+    dest = tmp_path / "clone"
+    real_provision.clone_at(str(src), first, dest)
+
+    assert (dest / "src" / "main.py").is_file()
+    assert not (dest / "later.py").exists()                 # pinned before the 2nd commit
+    assert _git(dest, "rev-parse", "HEAD").strip() == first  # detached at the pin
+
+
+def test_dirty_source_clones_clean_at_pin(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    pin = _existing_repo(src)
+    # dirty the live source: an uncommitted edit + an untracked file
+    (src / "src" / "main.py").write_text("print('LOCAL EDIT')\n", encoding="utf-8")
+    (src / "scratch.tmp").write_text("junk\n", encoding="utf-8")
+    assert _git(src, "status", "--porcelain").strip()  # source IS dirty
+
+    dest = tmp_path / "clone"
+    real_provision.clone_at(str(src), pin, dest)
+
+    assert _git(dest, "status", "--porcelain").strip() == ""       # clone is clean
+    assert (dest / "src" / "main.py").read_text() == "print('app')\n"  # committed content, not dirt
+    assert not (dest / "scratch.tmp").exists()                     # untracked dirt not carried
+
+
+# --------------------------------------------------------------- source-unchanged invariant
+
+
+def test_provision_leaves_source_byte_identical(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    _existing_repo(src)
+    # put the source on a feature branch AND make it dirty — the exact real-world condition
+    _git(src, "checkout", "-q", "-b", "W.Mwangi/0322-spec")
+    (src / "dirty.py").write_text("d = 1\n", encoding="utf-8")
+
+    before = source_fingerprint(str(src))
+    spec = RealFixtureSpec(bucket="B11", source=str(src), ref="refs/heads/main")
+    ctx = provision_real(spec, tmp_path / "wd")
+    after = source_fingerprint(str(src))
+
+    assert before == after                       # HEAD + porcelain byte-identical (the invariant)
+    assert ctx["extra"]["source_unchanged"] is True
+
+
+def test_source_fingerprint_none_for_nonlocal() -> None:
+    assert source_fingerprint("git@github.com:noorinalabs/noorinalabs-main.git") is None
+
+
+# --------------------------------------------------------------- --include-real wiring
+
+
+def _b11_opts(source: Path, *, pin: str | None = None) -> dict:
+    return {
+        "buckets": ["B11"], "installers": ["bootstrap"], "dogfood": False,
+        "include_real": True,
+        "real_fixtures": {"B11": RealFixtureSpec(
+            bucket="B11", source=str(source), pin=pin, ref="refs/heads/main")},
+    }
+
+
+def test_include_real_executes_b11_real_path_all_green(tmp_path: Path) -> None:
+    src = tmp_path / "botfarm-synthetic"
+    _existing_repo(src)
+    before = source_fingerprint(str(src))
+
+    env = run_matrix(_b11_opts(src))
+    b11 = [r for r in env.records if r.bucket == "B11"]
+
+    assert b11, "B11 produced no records — real path did not run"
+    # the real path RAN (not the pre-#153 stub skip): install_exit_status graded, not observed.stub
+    exit_rec = next(r for r in b11 if r.metric == "install_exit_status")
+    assert exit_rec.passed is True
+    assert not (exit_rec.observed or {}).get("stub")
+    graded = [r for r in b11 if r.passed is not None and r.kind in ("pass_fail", "scored")]
+    assert graded and all(r.passed for r in graded), \
+        f"real B11 failures: {[r.record_id for r in graded if not r.passed]}"
+    # teardown residue metric proves the symmetric-diff is empty for a real bucket
+    residue = next(r for r in b11 if r.metric == "teardown_residue_zero")
+    assert residue.passed is True
+    # the live source is byte-identical after the whole matrix run
+    assert source_fingerprint(str(src)) == before
+
+
+def test_include_real_with_explicit_pin(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    pin = _existing_repo(src)
+    (src / "drift.py").write_text("z = 3\n", encoding="utf-8")  # advance main past the pin
+    _git(src, "add", "-A")
+    _commit(src, "drift")
+
+    env = run_matrix(_b11_opts(src, pin=pin))
+    exit_rec = next(r for r in env.records if r.bucket == "B11" and r.metric == "install_exit_status")
+    assert exit_rec.passed is True
+
+
+def test_missing_fixture_degrades_to_skip_not_crash(tmp_path: Path) -> None:
+    opts = {
+        "buckets": ["B11"], "installers": ["bootstrap"], "dogfood": False, "include_real": True,
+        "real_fixtures": {"B11": RealFixtureSpec(bucket="B11", source=str(tmp_path / "absent"))},
+    }
+    env = run_matrix(opts)  # must not raise
+    b11 = [r for r in env.records if r.bucket == "B11"]
+    assert len(b11) == 1
+    assert b11[0].passed is None
+    assert (b11[0].expected or {}).get("stub") is True  # runner's stub-skip record
+    assert "ls-remote" in (b11[0].observed or {}).get("reason", "")
+
+
+def test_scratch_clone_fully_removed_after_run(tmp_path: Path) -> None:
+    src = tmp_path / "src"
+    _existing_repo(src)
+    scratch = tmp_path / "scratch"
+    opts = _b11_opts(src)
+    opts.update({"scratch": str(scratch), "cleanup_scratch": True})
+    run_matrix(opts)
+    # explicit scratch is preserved by run_matrix, but every per-cell workdir clone is gone
+    leftovers = [p for p in scratch.glob("harness-B11-*")]
+    assert leftovers == [], f"scratch clone residue: {leftovers}"
+
+
+# --------------------------------------------------------------- B10 meta (parent + children)
+
+
+def test_meta_provision_clones_parent_and_children(tmp_path: Path) -> None:
+    parent = tmp_path / "parent"
+    _make_repo(parent, {"pyproject.toml": "[project]\nname='root'\n"})
+    api = tmp_path / "api-src"
+    _make_repo(api, {"pyproject.toml": "[project]\nname='api'\n"})
+    web = tmp_path / "web-src"
+    _make_repo(web, {"index.html": "<h1>web</h1>\n"})
+
+    spec = RealFixtureSpec(
+        bucket="B10", source=str(parent), model="meta-and-children",
+        children=(RealChildSpec("api", str(api), flavor="product"),
+                  RealChildSpec("web", str(web), flavor="infra")),
+    )
+    wd = tmp_path / "wd"
+    ctx = provision_real(spec, wd)
+
+    assert (wd / "pyproject.toml").is_file()          # parent clone
+    assert (wd / "api" / ".git").is_dir()             # child clones, independently git'd
+    assert (wd / "web" / ".git").is_dir()
+    assert (wd / "install.meta.yaml").is_file()
+    yaml = (wd / "install.meta.yaml").read_text()
+    assert "path: api" in yaml and "path: web" in yaml and "flavor: infra" in yaml
+    labels = {c["path"]: c["flavor"] for c in ctx["child"]["children"]}
+    assert labels == {"api": "product", "web": "infra"}
+
+
+def test_include_real_executes_b10_meta_path_all_green(tmp_path: Path) -> None:
+    parent = tmp_path / "parent"
+    _make_repo(parent, {"pyproject.toml": "[project]\nname='root'\n"})
+    api = tmp_path / "api-src"
+    _make_repo(api, {"pyproject.toml": "[project]\nname='api'\n"})
+    web = tmp_path / "web-src"
+    _make_repo(web, {"pyproject.toml": "[project]\nname='web'\n"})
+    sources = [parent, api, web]
+    before = [source_fingerprint(str(p)) for p in sources]
+
+    opts = {
+        "buckets": ["B10"], "installers": ["bootstrap"], "dogfood": False, "include_real": True,
+        "real_fixtures": {"B10": RealFixtureSpec(
+            bucket="B10", source=str(parent), model="meta-and-children",
+            children=(RealChildSpec("api", str(api), flavor="product"),
+                      RealChildSpec("web", str(web), flavor="infra")))},
+    }
+    env = run_matrix(opts)
+    b10 = [r for r in env.records if r.bucket == "B10"]
+    assert b10, "B10 produced no records"
+    graded = [r for r in b10 if r.passed is not None and r.kind in ("pass_fail", "scored")]
+    assert graded and all(r.passed for r in graded), \
+        f"real B10 failures: {[r.record_id for r in graded if not r.passed]}"
+    assert [source_fingerprint(str(p)) for p in sources] == before  # every source untouched
+
+
+# --------------------------------------------------------------- registry as data
+
+
+def test_registry_default_and_sidecar_override(tmp_path: Path) -> None:
+    default = real_provision.real_registry({})
+    assert set(default) == {"B10", "B11"}
+    assert default["B10"].model == "meta-and-children"
+    assert default["B11"].pin is None  # resolve live main at run time by default
+
+    sidecar = tmp_path / "real.json"
+    sidecar.write_text(
+        '{"B11": {"source": "/x", "pin": "abc123", "ref": "refs/heads/release"}}',
+        encoding="utf-8",
+    )
+    reg = real_provision.real_registry({"real_config": str(sidecar)})
+    assert reg["B11"].source == "/x" and reg["B11"].pin == "abc123"
+    assert reg["B11"].ref == "refs/heads/release"
+    assert reg["B10"].model == "meta-and-children"  # untouched default survives
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## What

Replaces the B10/B11 `_prov_real_stub` (`framework/harness/buckets.py`, which unconditionally
raised `NotImplementedError`) with a real **clone-at-pinned-SHA** provisioner and wires
`--include-real` so B10 (`meta-real-world`) and B11 (`standalone-real-world`) are actually
provisioned + run instead of hitting the stub.

New module: `framework/harness/real_provision.py`.

## Mechanism — read-only w.r.t. the live source (the load-bearing safety property)

Other sessions are live-committing in the real source trees, so provisioning never touches them:

- **`git clone --no-local <source> <scratch>`** forces a full object copy — never a hardlink into
  the source `.git` (the plain local-clone default), never a worktree/copy of the live tree.
  Working-tree dirt in the source is therefore never carried into the clone; a **locally-dirty
  source still clones clean at the pin**.
- **Pin resolution** — an explicit SHA verbatim, else resolved from the source's
  `refs/heads/main` via `git ls-remote` **at run time** (never the locally checked-out branch,
  since several sources sit on in-progress feature branches).
- **Source-unchanged invariant** — each local source's `{HEAD, git status --porcelain}` is
  fingerprinted before and after every provision and asserted **byte-identical**; a mismatch
  raises `SourceMutatedError` (isolated to one errored cell, not a skip).

## Source/pin registry is DATA (not hardcoded in flow)

`RealFixtureSpec` / `RealChildSpec` dataclasses + a `DEFAULT_REAL_FIXTURES` map, overridable via a
`--real-config` sidecar JSON or (in tests) `opts['real_fixtures']`. B10 meta clones the parent +
its gitignored sibling children into the same layout the synthetic `_prov_meta` produces, so child
wiring resolves identically. **#101/#109 supply real source paths / pins / noorinalabs children via
`--real-config`** — no real paths are load-bearing here.

Registry shape (for #101/#109):
```json
{"B11": {"source": "<path-or-remote>", "pin": "<sha|null>", "ref": "refs/heads/main"},
 "B10": {"source": "<parent>", "model": "meta-and-children",
         "children": [{"path": "child-dir", "source": "<child>", "pin": null, "flavor": "product"}]}}
```

## Degrade + teardown

- A genuinely unresolvable fixture (missing path / unreachable remote) raises `MissingFixtureError`
  (a `NotImplementedError` subclass) so the runner's **pre-existing stub-skip path** fires — CI and
  machines without the local checkouts stay green; it never fires by default on a dev box that has
  the fixtures.
- **Zero-residue teardown** reuses the existing drop-the-copy `rmtree` + the symmetric-diff proof
  (`teardown_residue_zero` + `teardown_proof=True` on both real legs) — a real bucket leaves an
  empty diff.

## Hermetic test approach (no real fixtures, no network)

`framework/tests/test_real_provisioner.py` builds a throwaway local git repo in `tmp_path` and uses
it as the clone source. It proves: clone-at-pin (pinned commit, not the tip), dirty-source-clones-
clean, the **source-unchanged invariant** (feature-branch + dirty source is byte-identical after a
provision AND after a full matrix run), `--include-real` executes the real B10/B11 path all-green
(not the stub), explicit-pin and `ls-remote`-resolved pin, missing-fixture → skip (no crash), zero
scratch residue, and the meta parent+children clone layout. The real multi-GB noorinalabs/botfarm
runs are **#101 / #109**, deliberately not exercised here.

## Scope note

`framework/harness/**` is dev/test tooling, **not** an installed asset under `framework/assets/` or
`framework/install/` — **#116 dual-deploy does NOT apply**; there is no canonical-copy diff to look
for.

## Quality

- `python3 -m pytest framework/tests/ -q` → **456 passed** (was 442; +14 hermetic tests, 1 existing
  stub test rewritten in place).
- `ruff check framework/` → clean.
- End-to-end smoke: `python3 -m framework.harness --buckets B11 --include-real --real-config <json>`
  against a synthetic repo → B11 green (12/12 graded), source `git status --porcelain` empty and
  still on `main` afterward.

Closes #153

**Reviewers: Nia Rossi** (design/architecture) + **Tariq Morales** (QA/teardown) — named here
because simulated teammates can't be added as GitHub reviewers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTQxgBAcChxvdQJafKyMdX
