### PR TITLE
study(harness): B11 upgrade-over-live-install on botfarm_inc (#109)

### DIFF
--- a/framework/harness/botfarm_upgrade_study.py
+++ b/framework/harness/botfarm_upgrade_study.py
@@ -1,0 +1,218 @@
+"""B11 upgrade-over-live-install study (#109): archive + fresh + restore, byte-identical.
+
+Dev tooling (NOT an installed asset; #116 dual-deploy does not apply). Exercises the #108
+repo-level consent + archive + restore flow OVER a repo that ALREADY carries its own diverged
+2real install, and proves the restore returns the managed Claude assets (``.claude/`` +
+``CLAUDE.md``) byte-identical to their pre-existing state.
+
+It is the archive/restore companion to the ``B11`` harness bucket. The bucket measures the
+*amend-in-place* upgrade (bootstrap ``--expect existing`` merges over the live install); this
+script measures the *archive-then-fresh-then-restore* disposition — the reversible path #108
+adds — and captures the symmetric-diff proof of a byte-identical restore.
+
+Read-only w.r.t. the live source: it reuses :func:`real_provision.provision_real` to clone the
+source at a pinned SHA into scratch (``git clone --no-local`` + detached checkout) and asserts
+the source ``{head, porcelain}`` is byte-unchanged across the run. It NEVER writes to the live
+tree — all archive/fresh/restore happens on the throwaway clone, torn down at the end.
+
+No hardcoded source path lives here (#155 item 2): the source/pin come from ``--source`` /
+``--pin``, else a ``--real-config`` sidecar (see
+``framework/tests/install_quality/real-config.botfarm.example.json``), else the ``B11`` entry
+of :data:`real_provision.DEFAULT_REAL_FIXTURES`. Stdlib only.
+
+    python3 -m framework.harness.botfarm_upgrade_study \
+        --source /path/to/botfarm_inc --out study.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from .real_provision import (
+    RealFixtureSpec,
+    provision_real,
+    real_registry,
+    resolve_pin,
+    source_fingerprint,
+)
+from .snapshot import snapshot, symmetric_diff
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+_BOOTSTRAP = _FRAMEWORK_ROOT / "install" / "bootstrap.py"
+_INSTALL_DIR = _FRAMEWORK_ROOT / "install"
+
+#: The managed Claude assets #108 archives/restores (mirror of repo_space.REPO_CLAUDE_ASSETS).
+_MANAGED = (".claude", "CLAUDE.md")
+
+
+def _load_repo_space():
+    """Import ``framework/install/repo_space.py`` (its relative imports need the dir on path)."""
+    if str(_INSTALL_DIR) not in sys.path:
+        sys.path.insert(0, str(_INSTALL_DIR))
+    import repo_space  # noqa: E402  (path-dependent import, by design)
+
+    return repo_space
+
+
+def _managed_scope(snap: dict) -> dict:
+    """Restrict a full-tree snapshot to the #108-managed assets (``.claude/**`` + ``CLAUDE.md``)."""
+    return {
+        rel: h
+        for rel, h in snap.items()
+        if rel == "CLAUDE.md" or rel.startswith(".claude/")
+    }
+
+
+def _roster_members(root: Path) -> list[str]:
+    p = root / ".claude" / "team" / "roster.json"
+    if not p.is_file():
+        return []
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    return sorted(data) if isinstance(data, dict) else []
+
+
+def _fresh_install(clone: Path) -> subprocess.CompletedProcess:
+    """Lay a CLEAN install over the archived (now Claude-empty) repo.
+
+    ``--expect any``: the repo still carries all of botfarm's source, so it classifies as
+    EXISTING even with ``.claude`` archived away — ``any`` keeps the repo-state gate out of the
+    way so the fresh write proceeds. Team ON so we can show the old roster is no longer loaded.
+    """
+    return subprocess.run(
+        [sys.executable, str(_BOOTSTRAP), str(clone), "--expect", "any",
+         "--owner", "acme", "--no-ontology", "--non-interactive"],
+        capture_output=True, text=True, stdin=subprocess.DEVNULL,
+    )
+
+
+def _spec_for(opts: dict, source: str | None, pin: str | None) -> RealFixtureSpec:
+    base = real_registry(opts).get("B11")
+    if base is None and source is None:
+        raise SystemExit("no B11 fixture in the registry and no --source given")
+    src = source or base.source
+    ref = base.ref if base else "refs/heads/main"
+    return RealFixtureSpec(bucket="B11", source=src, pin=pin, ref=ref, model="single-repo")
+
+
+def run_study(source: str | None, pin: str | None, opts: dict | None = None) -> dict:
+    """Clone at pin, archive, fresh-install, restore; return a JSON-able evidence record."""
+    opts = dict(opts or {})
+    repo_space = _load_repo_space()
+    spec = _spec_for(opts, source, pin)
+    resolved_pin = resolve_pin(spec.source, spec.ref, spec.pin)
+
+    scratch = Path(tempfile.mkdtemp(prefix="b11-upgrade-study-"))
+    clone = scratch / "clone"
+    ev: dict = {"source": spec.source, "ref": spec.ref, "pin": resolved_pin}
+    try:
+        fp_before = source_fingerprint(spec.source)
+        ctx = provision_real(spec, clone, opts)
+        ev["source_unchanged_after_provision"] = ctx["extra"]["source_unchanged"]
+
+        # BEFORE: the pre-existing (diverged) install, in full + managed scope.
+        before_full = snapshot(clone)
+        before_managed = _managed_scope(before_full)
+        ev["before"] = {
+            "managed_file_count": len(before_managed),
+            "present_assets": [n for n in _MANAGED if (clone / n).exists()],
+            "roster_members": _roster_members(clone),
+        }
+
+        # ARCHIVE (consent-gated) — chooser/consent_fn are the documented #108 seams.
+        prep = repo_space.prepare_for_install(
+            clone, non_interactive=False,
+            chooser=lambda: "archive", consent_fn=lambda _s: True,
+        )
+        arc = prep.archive
+        ev["archive"] = {
+            "action": prep.action,
+            "moved": list(arc.moved) if arc else [],
+            "archive_dir": str(arc.archive_dir) if arc and arc.archive_dir else None,
+        }
+        # Assets are demonstrably OUT of Claude scope now.
+        ev["post_archive"] = {
+            "root_assets_present": [n for n in _MANAGED if (clone / n).exists()],
+            "archived_assets_present": (
+                [n for n in _MANAGED if arc and arc.archive_dir and (arc.archive_dir / n).exists()]
+            ),
+            "roster_members_at_root": _roster_members(clone),  # must be [] (archived away)
+        }
+
+        # FRESH install over the cleaned slate.
+        fresh = _fresh_install(clone)
+        ev["fresh_install"] = {
+            "returncode": fresh.returncode,
+            "roster_members": _roster_members(clone),  # our team, NOT botfarm's
+        }
+        fresh_managed = _managed_scope(snapshot(clone))
+        ev["fresh_install"]["differs_from_before"] = bool(
+            symmetric_diff(before_managed, fresh_managed)
+        )
+
+        # RESTORE (overwrite the fresh install that was laid down after the archive).
+        res = repo_space.restore_assets(clone, arc.archive_dir, overwrite=True)
+        ev["restore"] = {"restored": list(res.restored), "conflicts": list(res.conflicts)}
+
+        # AFTER: prove byte-identical restore of the managed assets.
+        after_full = snapshot(clone)
+        after_managed = _managed_scope(after_full)
+        managed_diff = symmetric_diff(before_managed, after_managed)
+        ev["restore"]["managed_symmetric_diff"] = managed_diff
+        ev["restore"]["byte_identical"] = not managed_diff
+
+        # Honest out-of-scope accounting: what the fresh install left that restore does not own.
+        full_diff = symmetric_diff(before_full, after_full)
+        ev["out_of_scope_residue"] = [p for p in full_diff if p not in managed_diff]
+
+        # Read-only invariant re-check.
+        fp_after = source_fingerprint(spec.source)
+        ev["source_unchanged"] = fp_before == fp_after
+        return ev
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
+        # Teardown proof: drop-the-copy => zero residue by construction.
+        ev["teardown_scratch_removed"] = not scratch.exists()
+
+
+def _parse(argv: list[str]) -> argparse.Namespace:
+    ap = argparse.ArgumentParser(
+        prog="python3 -m framework.harness.botfarm_upgrade_study",
+        description="B11 upgrade-over-live-install archive/restore study (#109).",
+    )
+    ap.add_argument("--source", help="source repo path/URL (default: B11 registry entry)")
+    ap.add_argument("--pin", help="explicit SHA to clone (default: resolve --ref live)")
+    ap.add_argument("--real-config", type=Path, default=None,
+                    help="sidecar JSON overriding the B11 fixture source/pin")
+    ap.add_argument("--out", type=Path, default=None, help="write the evidence JSON here")
+    return ap.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse(sys.argv[1:] if argv is None else argv)
+    opts: dict = {}
+    if args.real_config is not None:
+        opts["real_config"] = str(args.real_config)
+    ev = run_study(args.source, args.pin, opts)
+
+    if args.out:
+        args.out.write_text(json.dumps(ev, indent=2) + "\n", encoding="utf-8")
+
+    ok = ev.get("restore", {}).get("byte_identical") and ev.get("source_unchanged")
+    print(json.dumps(ev, indent=2))
+    print(f"\nRESTORE byte-identical: {ev.get('restore', {}).get('byte_identical')}   "
+          f"source unchanged: {ev.get('source_unchanged')}   "
+          f"teardown clean: {ev.get('teardown_scratch_removed')}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/framework/recipes/BOTFARM_UPGRADE_STUDY.md
+++ b/framework/recipes/BOTFARM_UPGRADE_STUDY.md
@@ -1,0 +1,151 @@
+# BOTFARM_UPGRADE_STUDY — B11 upgrade-over-live-install (#109)
+
+Real-repo acceptance test for the #108 repo-level **consent + archive + restore** flow, run
+against `botfarm_inc` — a repo that **already runs its own independently-evolved 2real install**
+(its own bootstrap commit `d4c058d`, its own phase/wave history). Per the owner decision on #109
+the framing is **upgrade-over-live-install**, not a blank/foreign-repo replacement: we clone
+botfarm at its current `main` (which carries that diverged install) and prove the archive/restore
+flow returns the managed Claude assets **byte-identical**.
+
+Everything runs on a throwaway clone in scratch. The live tree is **never** modified: the
+provisioner (`framework/harness/real_provision.py`, #153) clones with `git clone --no-local` +
+detached checkout and asserts the source `{HEAD, porcelain}` is byte-unchanged before/after.
+
+## Run configuration
+
+| Item | Value |
+|------|-------|
+| Source | `/home/parameterization/code/botfarm_inc` (B11 fixture; remote `git@github.com:parametrization/botfarm_inc.git`) |
+| Pin | resolved **live** via `git ls-remote <source> refs/heads/main` at run time (`pin=null`) |
+| Resolved SHA (study run) | `2a219921df044b5e5a0f5a8bb0223988eb80d3d9` |
+| `--real-config` | `framework/tests/install_quality/real-config.botfarm.example.json` (example sidecar; machine-local path stays out of checked-in defaults, #155 item 2) |
+| Harness bucket | `B11 standalone-real-world` via `python3 -m framework.harness --include-real --buckets B11 --installers bootstrap` |
+| Archive/restore study | `python3 -m framework.harness.botfarm_upgrade_study` |
+
+> **Pin note.** The issue AC pinned `a4e622dd…`; the local `main` advanced to `2a219921…`
+> *during this session* (botfarm is under concurrent work — exactly why the pin is resolved live
+> and never trusted from a checked-out branch). Both SHAs carry the same diverged install; the
+> study is internally consistent (its own before/after are both at `2a219921`).
+
+## Two dispositions, measured separately
+
+#108 offers two dispositions for a repo that already has Claude assets. This study measures both:
+
+1. **amend-in-place** — the `B11` harness bucket (`bootstrap --expect existing`) merges the
+   framework over botfarm's live install. Gives the metric records + `install_success_rate`.
+2. **archive-then-fresh-then-restore** — the reversible path #108 adds. The study script archives
+   botfarm's entire `.claude/` + `CLAUDE.md` out of scope, lays a fresh install, then restores,
+   and proves a byte-identical restore via `snapshot()` / `symmetric_diff()`.
+
+---
+
+## BEFORE — what botfarm's existing install looks like
+
+A mature, org-scale install: **150 files** under `.claude/` + a hand-evolved `CLAUDE.md`, and a
+**12-member** roster (`Steven French, Miriam Osei, Davi Santos, Yuna Park, Tariq El-Amin, Ingrid
+Haugen, Cem Yilmaz, Kwame Mensah, Lena Volkov, Sofia Marino, Priya Raghavan, Annunaki`).
+
+### Divergence vs our `expected_install_set` (standalone + team = 67 files)
+
+| | Count | Examples |
+|---|---|---|
+| Files botfarm **has, expected set does not** (local extension) | **91** | `annunaki_log.py` / `annunaki_monitor.py` + `skills/annunaki*`; `auto_close_referenced_issues.py`, `auto_rebase_queue.py`, `autoformat.py`; `validate_orchestrator_*`, `validate_branch_freshness.py`, `validate_ci_*`, `block_gh_pr_*`; **20** extra `team/roster/*` members; **26** `hooks/tests/*`; `context/`, `plans/phase-*.md`, `team/waves/*-merge-order.json`, `skills/wave-kickoff`, `skills/wave-wrapup` |
+| Files expected set **has, botfarm is missing** (older base) | **8** | `hooks/stop_dispatcher.py`, `hooks/validate_review_comment_format.py`, `install.config.json`, `team/.charter-manifest.json`, `team/charter/charter.md`, `skills/{phase-review,retro,wave-end}/SKILL.md` |
+
+Botfarm is simultaneously **ahead** (91 files of local extension — an `annunaki` subsystem, an
+org-scale roster, phase plans, wave merge-orders) and **behind** (missing 8 files that landed in
+the framework after its `d4c058d` bootstrap, including a skills-layout migration from flat
+`skills/foo.md` to `skills/foo/SKILL.md`). This is a genuinely *diverged* install — a strong
+fixture for archive/restore.
+
+---
+
+## amend-in-place — `B11` harness records
+
+`install_success_rate = 0.75` (9/12 graded metrics; 13 records incl. 1 trend). `install_duration_s`
+trend = **0.20 s**.
+
+| Result | Metric (category) |
+|--------|-------------------|
+| PASS | `install_exit_status` (A), `non_interactive_zero_prompts` (A), `repo_state_gate_correct` (A) |
+| PASS | `no_unexpected_files` (B), `install_snapshot_recorded` (B), `files_installed_complete` (B, scored) |
+| PASS | `permissions_allowlist_present` (C) |
+| PASS | `reinstall_idempotent` (F), `no_backup_litter` (H) |
+| **FAIL** | `settings_hooks_wired` (C) — botfarm's diverged `settings.json` carries extra matchers (`SessionStart: resume/startup`, split `PostToolUse: Bash/Edit/Write`) that the merge preserves → superset, not the exact clean set |
+| **FAIL** | `config_module_lists_complete` (C) — the idempotent merge preserves botfarm's own `framework.config.json` (its `pre_bash` lacks our `validate_labels`/`block_squash_wave_merge`; `hooks.agent`/`hooks.stop` absent) rather than reconciling to canonical |
+| **FAIL** | `teardown_residue_zero` (H, scored) — residue `[.claude/settings.json]` (see finding #1 below) |
+
+The three failures are **not installer defects** — they are the signature of merging over a
+diverged live install: the merge correctly *preserves foreign* config/hooks (that survival is the
+point of `settings_merge_preserves_foreign` in B5), but that means the amend path neither reaches
+our clean-install matcher set nor upgrades stale module lists, and an in-place merge into a
+pre-existing file is not reversible by the drop-added-files teardown.
+
+---
+
+## archive-then-fresh-then-restore — byte-identical proof
+
+Evidence record (`botfarm_upgrade_study`, full JSON captured at run time):
+
+| Stage | Observation |
+|-------|-------------|
+| provision | `source_unchanged_after_provision = true` (read-only invariant held) |
+| BEFORE | 151 managed files; assets `[.claude, CLAUDE.md]`; 12-member roster |
+| **archive** | `action = archived`; moved `[.claude, CLAUDE.md]` → `.claude-backups/<UTC>/`; root assets now `[]`; roster no longer loadable at root (`[]`) |
+| fresh install | `rc = 0`; wrote a **different** roster (`Aria Okafor, Mateo Reyes, Nadia Haddad`) — proving botfarm's old roster is out of scope; `differs_from_before = true` |
+| **restore** | restored `[.claude, CLAUDE.md]`, `conflicts = []`, `managed_symmetric_diff = []` → **`byte_identical = true`** |
+| source | `source_unchanged = true` |
+| teardown | `teardown_scratch_removed = true` (drop-the-copy ⇒ zero residue by construction) |
+
+**Restore is byte-identical** for the #108-managed assets (`.claude/**` + `CLAUDE.md`): the
+symmetric-diff of the pre-existing install against the post-restore state is empty.
+
+### Honest out-of-scope accounting
+
+`symmetric_diff` over the **whole tree** (not just managed assets) leaves two residual paths the
+restore deliberately does not own:
+
+- `.claude-backups/<UTC>/archive-manifest.json` — the restore manifest sidecar (restore *moves*
+  assets back but leaves its own manifest + the now-empty backup dir).
+- `.git/hooks/pre-push` — installed by the fresh-install leg; `restore_assets` is scoped to
+  `.claude/` + `CLAUDE.md` and does not remove it.
+
+Neither is a managed asset, so "byte-identical restore" holds for what #108 guarantees; a fully
+pristine repo would additionally prune the emptied `.claude-backups/` and the fresh `pre-push`
+(see findings for #149).
+
+---
+
+## Reproduce
+
+```bash
+# amend-in-place metric records
+python3 -m framework.harness --include-real --buckets B11 --installers bootstrap --no-dogfood \
+    --real-config framework/tests/install_quality/real-config.botfarm.example.json
+
+# archive → fresh → restore byte-identical study
+python3 -m framework.harness.botfarm_upgrade_study \
+    --real-config framework/tests/install_quality/real-config.botfarm.example.json --out study.json
+```
+
+Hermetic coverage (no real botfarm, CI-safe): `framework/tests/test_botfarm_upgrade_study.py`.
+
+## Durability / fidelity findings (recorded for #149)
+
+See the PR / #109 report and the #149 comment. Summary:
+
+1. **In-place merge into a pre-existing `settings.json` is not reversible** by the manifest-driven
+   teardown (drives the `teardown_residue_zero` failure). The merge modifies the pre-existing file
+   with **no `.bak`** (`no_backup_litter` passes), so teardown — which only removes *added* files
+   and restores `.bak`s — cannot recover the original bytes. The reversible answer is the #108
+   archive path, proven byte-identical here.
+2. **Restore leaves out-of-scope residue** (`.git/hooks/pre-push`, emptied `.claude-backups/`).
+3. **`.claude-backups/` is not gitignored**, so archive-then-fresh surfaces it as untracked in a
+   real working tree.
+4. **`atomic_io.atomic_write_text` has a parent-dir fsync gap** — it fsyncs the temp file and
+   `os.replace`s, but never fsyncs the *parent directory*, so a crash right after the rename can
+   lose the directory entry (manifest present-but-not-durable). `archive_assets` compounds this:
+   the asset `shutil.move`s and the manifest write are individually non-atomic w.r.t. a crash
+   *between* them, so a crash could strand a half-archive with no manifest → unrestorable.
+5. **The amend path silently leaves stale config module lists** — an "upgrade" via amend does not
+   reconcile `framework.config.json` hook lists to canonical (drives `config_module_lists_complete`).

--- a/framework/tests/install_quality/real-config.botfarm.example.json
+++ b/framework/tests/install_quality/real-config.botfarm.example.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Example --real-config sidecar for the B11 upgrade-over-live-install study (#109). Absolute paths are machine-local, so they live HERE (a doc/example), never in a checked-in default (#155 item 2). pin=null resolves refs/heads/main live via `git ls-remote` at run time (the local tree is under concurrent work, so the pin is NOT trusted from whatever branch is checked out). Usage: python3 -m framework.harness --include-real --buckets B11 --installers bootstrap --real-config framework/tests/install_quality/real-config.botfarm.example.json   OR   python3 -m framework.harness.botfarm_upgrade_study --real-config <this file>",
+  "B11": {
+    "source": "/home/parameterization/code/botfarm_inc",
+    "pin": null,
+    "ref": "refs/heads/main",
+    "model": "single-repo"
+  }
+}

--- a/framework/tests/test_botfarm_upgrade_study.py
+++ b/framework/tests/test_botfarm_upgrade_study.py
@@ -1,0 +1,85 @@
+"""Hermetic test for the #109 B11 upgrade-over-live-install study (archive + fresh + restore).
+
+Proven against a throwaway LOCAL git repo carrying a synthetic *pre-existing* ``.claude`` install
+(the stand-in for botfarm's own diverged install) — no network, no real botfarm fixture (that run
+is #109 proper). Asserts the load-bearing claim: after archive → fresh install → restore, the
+managed Claude assets are byte-identical to their pre-existing state, the old assets are moved out
+of Claude scope mid-flow, the live source is untouched, and the scratch clone is torn down clean.
+Stdlib + pytest only.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+_REPO_ROOT = _FRAMEWORK_ROOT.parent
+sys.path.insert(0, str(_REPO_ROOT))  # make `framework.harness` importable (namespace package)
+
+from framework.harness.botfarm_upgrade_study import run_study  # noqa: E402
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(cwd), *args], check=True, capture_output=True)
+
+
+def _repo_with_preexisting_install(path: Path) -> None:
+    """A foreign existing project that ALREADY carries its own diverged .claude install."""
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "src").mkdir()
+    (path / "src" / "main.py").write_text("print('app')\n", encoding="utf-8")
+    (path / "CLAUDE.md").write_text("# botfarm's own hand-evolved CLAUDE.md\n", encoding="utf-8")
+    claude = path / ".claude"
+    (claude / "team" / "roster").mkdir(parents=True)
+    (claude / "team" / "roster.json").write_text(
+        '{"Diverged Owner": "owner", "Diverged Eng": "engineer"}\n', encoding="utf-8"
+    )
+    (claude / "settings.json").write_text('{"foreignKey": "keep-me"}\n', encoding="utf-8")
+    (claude / "hooks").mkdir()
+    (claude / "hooks" / "custom_botfarm_hook.py").write_text("# their own hook\n", encoding="utf-8")
+    _git(path, "init", "-q")
+    _git(path, "add", "-A")
+    subprocess.run(
+        ["git", "-C", str(path), "-c", "user.name=Fx", "-c", "user.email=fx@e.com",
+         "commit", "-q", "-m", "botfarm diverged install"],
+        check=True, capture_output=True,
+    )
+    _git(path, "branch", "-M", "main")
+
+
+def test_upgrade_study_restores_byte_identical(tmp_path: Path) -> None:
+    src = tmp_path / "botfarm-synthetic"
+    _repo_with_preexisting_install(src)
+
+    ev = run_study(source=str(src), pin=None)
+
+    # source cloned read-only and left byte-identical
+    assert ev["source_unchanged_after_provision"] is True
+    assert ev["source_unchanged"] is True
+
+    # BEFORE: the diverged install was present
+    assert set(ev["before"]["present_assets"]) == {".claude", "CLAUDE.md"}
+    assert ev["before"]["roster_members"] == ["Diverged Eng", "Diverged Owner"]
+
+    # ARCHIVE moved both managed assets out of Claude scope
+    assert ev["archive"]["action"] == "archived"
+    assert set(ev["archive"]["moved"]) == {".claude", "CLAUDE.md"}
+    assert ev["post_archive"]["root_assets_present"] == []
+    assert ev["post_archive"]["roster_members_at_root"] == []  # old roster no longer loaded
+    assert set(ev["post_archive"]["archived_assets_present"]) == {".claude", "CLAUDE.md"}
+
+    # FRESH install laid down a different (clean) install
+    assert ev["fresh_install"]["returncode"] == 0
+    assert ev["fresh_install"]["differs_from_before"] is True
+    assert ev["fresh_install"]["roster_members"] != ev["before"]["roster_members"]
+
+    # RESTORE returns the managed assets byte-identical
+    assert set(ev["restore"]["restored"]) == {".claude", "CLAUDE.md"}
+    assert ev["restore"]["conflicts"] == []
+    assert ev["restore"]["managed_symmetric_diff"] == []
+    assert ev["restore"]["byte_identical"] is True
+
+    # teardown drops the scratch clone -> zero residue by construction
+    assert ev["teardown_scratch_removed"] is True


### PR DESCRIPTION
## Summary

Real-repo acceptance test for the #108 repo-level **consent + archive + restore** flow, run
against `botfarm_inc` — which already runs its own **independently-evolved 2real install**. Per the
owner decision on #109 the framing is **upgrade-over-live-install**. All work is on a read-only
clone (via #153 `real_provision`, `git clone --no-local` + source-unchanged invariant); the live
`botfarm_inc` tree is never modified.

Adds harness-side dev tooling + a study doc; **no installed assets change** (#116 N/A). Any
durability fix lands under #149.

### What's here
- `framework/harness/botfarm_upgrade_study.py` — reproducer: clone at a live-resolved pin →
  archive `.claude/` + `CLAUDE.md` out of scope → fresh install → restore → prove byte-identical.
- `framework/recipes/BOTFARM_UPGRADE_STUDY.md` — before/after study (tables + run evidence).
- `framework/tests/install_quality/real-config.botfarm.example.json` — example `--real-config`
  sidecar (machine-local path kept out of checked-in defaults, #155 item 2).
- `framework/tests/test_botfarm_upgrade_study.py` — hermetic smoke test (synthetic install; CI-safe).

## Run evidence

- **Pin** resolved live via `git ls-remote <source> refs/heads/main` → `2a219921df04…` (the local
  `main` advanced from the AC's `a4e622dd…` during the session — botfarm is under concurrent work,
  hence live resolution). Both SHAs carry the same diverged install.
- **amend-in-place `B11` bucket** (`bootstrap --expect existing`): `install_success_rate = 0.75`
  (9/12 graded; 13 records incl. 1 trend). 3 failures are the signature of merging over a diverged
  install (foreign settings/config preserved; in-place `settings.json` merge not reversible by
  teardown) — not installer defects.
- **botfarm's install**: 150 `.claude/**` files + hand-evolved `CLAUDE.md`, 12-member roster. vs
  our `expected_install_set` (67): **91 files ahead** (annunaki subsystem, org roster, phase plans,
  wave merge-orders, 26 hook tests), **8 files behind** (older base: `stop_dispatcher.py`,
  `.charter-manifest.json`, `skills/*/SKILL.md` layout migration).

## Restore byte-identical proof

| Stage | Observation |
|-------|-------------|
| provision | `source_unchanged_after_provision = true` |
| archive | moved `[.claude, CLAUDE.md]` → `.claude-backups/<UTC>/`; root assets `[]`; old roster no longer loadable |
| fresh install | `rc=0`; wrote a different roster (proves old assets out of scope) |
| **restore** | `managed_symmetric_diff = []` → **`byte_identical = true`** |
| source / teardown | `source_unchanged = true`; scratch clone removed (zero residue) |

Out-of-scope residue honestly reported: `.git/hooks/pre-push` + emptied `.claude-backups/` (restore
is scoped to `.claude/` + `CLAUDE.md`).

## Durability / fidelity findings (recorded for #149)
1. In-place merge into a pre-existing `settings.json` is not reversible by manifest-driven teardown
   (no `.bak`; drives `teardown_residue_zero`).
2. Restore leaves out-of-scope residue (`pre-push`, emptied `.claude-backups/`).
3. `.claude-backups/` is not gitignored.
4. `atomic_io.atomic_write_text` parent-dir fsync gap; `archive_assets` non-atomic between the
   asset move and the manifest write (crash could strand a half-archive with no manifest).
5. Amend path silently leaves stale config module lists (drives `config_module_lists_complete`).

## Quality
- `ruff check framework/` clean; `python3 -m pytest framework/tests/ -q` → **458 passed**.

Closes #109

Reviewers: Paloma Gupta + Tariq Morales
