### PR TITLE
docs: document the v0.5.0 + Phase 6 installer surface (#152)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,76 @@ cd python && pytest tests/
 
 # Node (83+ tests)
 cd node && npm test
+
+# Framework runtime tests (stdlib-only hooks/libs/installer)
+python3 -m pytest framework/tests/ -q
 ```
+
+### Install / test / teardown quality harness
+
+Beyond the unit tests, the installer surface has a dedicated install → assert → teardown
+harness that runs the **real** installers (`framework/install/bootstrap.py` and the
+`2real-team init` bridge) against synthesized repo-type fixtures, measures per-metric pass
+rates, and proves teardown leaves **zero residue**:
+
+```bash
+# Fast CI smoke — a subset (B1,B2,B4,B8b) through bootstrap only:
+python3 -m framework.harness --quick
+
+# Full hermetic matrix (default buckets B1-B9 + B12), gated against the prior run:
+python3 -m framework.harness --compare
+
+# Opt into the [real] B10/B11 buckets (see below):
+python3 -m framework.harness --include-real
+```
+
+It emits per-bucket / per-category pass rates plus `install_success_rate` and
+`reinstall_parity_clean`, writes a machine-readable run envelope JSON under
+`framework/tests/install_quality/runs/`, and **exits non-zero** on any failed graded metric (or
+a `REGRESSION` verdict under `--compare`), so CI can gate on it.
+
+Key flags:
+
+| Flag | Effect |
+|------|--------|
+| `--quick` | Fast subset (`B1,B2,B4,B8b`) through the bootstrap installer only — CI smoke |
+| `--compare` | Diff against the newest prior run in `--out` and gate on the run-over-run verdict |
+| `--include-real` | Opt in to the `[real]` B10/B11 buckets (owner-gated; **OFF by default**) |
+| `--real-config PATH` | Sidecar JSON overriding the B10/B11 real-fixture source/pin registry |
+| `--buckets IDS` | Comma-separated bucket ids to run (default: hermetic B1-B9 + B12) |
+| `--installers LIST` | Which installers to exercise (`bootstrap,cli`; default both) |
+| `--scale N` | B9 synthesized file count (default 300) |
+| `--no-dogfood` | Skip the B12 `reinstall --check` leg |
+| `--compare` + `--json` | Also print the full machine JSON to stdout |
+
+**Real-repo mode (`--include-real`, Phase 6).** B10 (`meta-real-world`) and B11
+(`standalone-real-world`) run the harness against **real checkouts** instead of synthesized
+fixtures. They are defined but **flag-gated OFF** — `--include-real` opts in. The provisioner
+(`framework/harness/real_provision.py`) is read-only w.r.t. the source: it `git clone
+--no-local`s the source at a **pinned SHA** (resolved via `git ls-remote`, or an explicit pin)
+into a scratch dir, and fingerprints the source `HEAD` + `git status --porcelain` before and
+after to assert the live tree is untouched. Which source/pin each bucket uses is DATA (a
+`RealFixtureSpec` registry) overridable via the `--real-config` sidecar, so the mechanism is
+proven hermetically against a throwaway git repo — the large real runs
+(`noorinalabs`/`botfarm`, #101/#109) are never cloned in CI.
+
+### Install-completeness & parity guards
+
+The harness relies on two standalone drift guards you can also run directly:
+
+```bash
+# Golden install manifest — verify the expected-install-set snapshot is in sync (exit 1 on drift):
+python3 framework/install/manifest.py --check
+
+# Reinstall parity — report canonical → live .claude/** drift, write nothing (exit 1 on drift):
+python3 framework/install/reinstall.py --check
+```
+
+`manifest.py` derives the *exact* `.claude/**` set a correct install produces from
+`framework/assets/**` + the resolved config (never a hand-listed literal), so the harness's
+completeness checks cannot disagree with what the installer copies. `reinstall.py` enforces the
+#116 dual-deploy rule — that this repo's live `.claude/**` copy of byte-mirrored assets stays in
+sync with canonical `framework/assets/**`. See `framework/README.md` for the full contract.
 
 ## Linting
 
@@ -54,6 +123,14 @@ cd node && npx tsc --noEmit
   presets/       # JSON preset definitions (team shapes)
   skills/        # Skill template files
   examples/      # Example YAML config files
+  framework/     # Config-driven runtime + installer (stdlib-only; see framework/README.md)
+    assets/        # What the bootstrapper installs into <repo>/.claude/ (hooks, lib, skills)
+    config/        # framework.config schema + install.config default
+    install/       # The installer: bootstrap.py, roster_gen.py, install_config, miniyaml,
+                   #   manifest.py (golden manifest), user_space/consent/backup/repo_space
+                   #   (consented user + repo install), atomic_io, reinstall.py (#116 parity)
+    harness/       # Install/test/teardown quality harness (python3 -m framework.harness)
+    tests/         # Framework runtime tests (python3 -m pytest framework/tests/)
   python/        # Python CLI (typer, pydantic, chevron)
     src/real_team/
       cli.py         # CLI commands

--- a/README.md
+++ b/README.md
@@ -246,6 +246,63 @@ commit in another.
 | `product` | The full harness: SessionStart (ontology refresh), pre/post Bash dispatchers, file-edit tracking |
 | `infra` | Commit-safety + CI subset: pre/post **Bash** dispatchers only — no ontology/session extras |
 
+### User-level install (`--user-space`)
+
+The simulated-team workflow depends on a few **harness-global** Claude settings that live in
+`~/.claude/settings.json`, not in any repo — chiefly the agent-teams flag
+(`env.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`), plus `teammateMode: auto`, the worktree
+isolation base `worktree.baseRef: fresh`, and the framework's `~/.claude` permission globs. A
+fresh clone produces a correct project `.claude/` but a harness that cannot spawn a team until
+those are present. Opt into the consented user-level install to fill that gap:
+
+```bash
+python3 framework/install/bootstrap.py /path/to/repo --owner my-org --user-space
+```
+
+The step is **safe by construction** — check-existing first, consent-gated, merge-only:
+
+- **Consent before any write.** It prints exactly which file and which keys it would add, and
+  writes only on an explicit interactive `y`. `--non-interactive` (and any non-TTY / CI run)
+  **skips it entirely** — it never touches user space unprompted.
+- **Idempotent, no-clobber.** A key already present and **equal** to the desired value is a
+  no-op (not even offered); if every key already matches, nothing is written. A key present
+  with a **different** value is surfaced as a conflict and **left exactly as-is** — your value
+  is never overwritten. List values (e.g. `permissions.allow`) are **unioned**, never replaced.
+- **Backed up + atomic.** Before amending an existing `settings.json` it is copied to a
+  timestamped `.bak` sibling, and the new file is written atomically (see *Atomic settings
+  writes* below), so an interrupted write can never strand a half-written settings file.
+
+### Repo-level backup, archive, and restore
+
+When an install would touch a repo that already carries its own Claude assets (a repo-root
+`.claude/` or `CLAUDE.md`), the installer offers the same consent UX for the repo's own
+assets. With explicit consent you choose between two dispositions:
+
+- **Keep & amend** (default, non-destructive) — leave the existing assets in place; the
+  bootstrapper's idempotent merge / skip-if-exists steps augment them. This is the safe default
+  for `--non-interactive`, non-TTY, and CI.
+- **Archive & fresh** — MOVE the existing `.claude/` and `CLAUDE.md` **out of Claude's load
+  scope** into a timestamped `.claude-backups/<UTC>/` directory, leaving a clean slate for a
+  fresh install. The archive directory is deliberately named `.claude-backups/` (it is neither
+  `.claude/` nor `CLAUDE.md`, and is not named `.claude*`) so Claude does **not** load the
+  archived copy — an archived asset is inert and cannot shadow the fresh install. A restore
+  manifest is written alongside the moved files.
+
+**Restore procedure.** The archive is fully restorable: every asset is moved byte-identical and
+`.claude-backups/<UTC>/` records what came from where. To roll back, move the archived
+`.claude/` and `CLAUDE.md` from `.claude-backups/<UTC>/` back to the repo root. The
+`restore_assets` helper in `framework/install/repo_space.py` does exactly this and refuses to
+clobber a currently-present target unless you opt into overwrite.
+
+### Atomic settings writes
+
+Every settings / manifest file the installer writes goes through `atomic_write_text`
+(`framework/install/atomic_io.py`): the full contents are written to a uniquely-named temp file
+in the **same** directory, flushed and `fsync`ed, then `os.replace`d onto the target. Because
+`os.replace` is an atomic rename, any concurrent reader — or a post-crash observer — sees either
+the old file intact or the complete new file, **never a truncated in-between**. This protects
+`settings.json` (and the repo-archive restore manifest) on every destructive install path.
+
 ## AI Persona Generation
 
 Generate culturally diverse, role-appropriate personas using Claude:

--- a/framework/README.md
+++ b/framework/README.md
@@ -86,9 +86,33 @@ framework/
       ontology-librarian/SKILL.md   # ONTOLOGY: read-only two-layer staleness + lookup
       ontology-rebuild/SKILL.md     # ONTOLOGY: reconcile the semantic overlay from code
     settings.template.json          # the dispatcher wiring the bootstrap merges
-  install/
+  install/                          # the stdlib-only installer (runs before any dep is present)
     bootstrap.py                    # deterministic installer (new or existing repo)
     roster_gen.py                   # repo-introspecting roster generator (used by bootstrap)
+    child_install.py                # meta/child model: hook-less child layout pointing at the parent
+    install_config.py               # unified install.config.yaml load / merge / validate pipeline
+    miniyaml.py                     # minimal stdlib-only YAML-subset parser (keeps install/ dep-free)
+    manifest.py                     # GOLDEN MANIFEST: expected_install_set(config); `--check` drift guard
+    golden-manifest.json            # generated expected-install-set snapshot (do NOT hand-edit)
+    user_space.py                   # CONSENTED, idempotent ~/.claude/settings.json merge (--user-space, #107)
+    consent.py                      # explicit opt-in gate for any write touching user/repo Claude assets
+    backup.py                       # timestamped, restorable .bak sibling before a consent-gated write
+    repo_space.py                   # repo-level backup / archive-then-fresh / restore of .claude assets (#108)
+    atomic_io.py                    # atomic_write_text: temp→fsync→os.replace, never a truncated settings file
+    reinstall.py                    # self-host parity: refresh .claude/** from canonical; `--check` drift guard (#116)
+  harness/                          # install / test / teardown quality harness (`python3 -m framework.harness`, #105)
+    __main__.py                     # CLI entry (--quick / --compare / --include-real / --buckets / --installers / --scale)
+    runner.py                       # provision → install → assert → teardown per matrix cell
+    buckets.py                      # repo-type buckets as DATA (B1-B12; B10/B11 are the [real] buckets)
+    installers.py                   # real installer invocations (bootstrap argparse + 2real-team init bridge)
+    metrics.py                      # per-metric measurement (#103 A-J vocabulary)
+    records.py                      # metric-record schema + run-envelope rollup
+    snapshot.py                     # {relpath: sha256} fixture snapshots — teardown's ground truth
+    teardown.py                     # teardown drivers (prove zero residue after an install)
+    compare.py                      # run-over-run REGRESSION / IMPROVEMENT / STABLE verdict
+    manifest.py                     # bridge to install/manifest.py's expected_install_set
+    real_provision.py               # B10/B11: clone a live source at a pinned SHA into scratch, read-only (#153)
+    botfarm_upgrade_study.py        # B11 upgrade-over-live-install study (dev tooling, #109)
   recipes/                          # per-artifact recipe docs (Purpose/enforces/config/adapt)
   tests/
     test_bootstrap_smoke.py         # installs into a tmp repo + fires the gate end-to-end
@@ -175,6 +199,39 @@ framework/`) and the CLI invokes the bundled `install/bootstrap.py --no-team`
 (the CLI already wrote the roster). So a single `init` lays down a complete,
 runnable `.claude/` — hooks, libs, lifecycle, the skill, config, and the
 dispatcher wiring — not templates alone.
+
+## Install-completeness & parity guards
+
+Two mechanical guards keep the installed tree honest — an install neither drops a file it
+should write nor drifts from the canonical source:
+
+- **Golden install manifest** (`install/manifest.py`). `expected_install_set(config)` is the
+  single source of truth for *exactly* which `.claude/**` files a correct install of a given
+  resolved config produces. The set is **derived from** `assets/**` + the config (it reuses
+  `bootstrap.py`'s own asset iterators), never a hand-listed literal, so it cannot silently
+  disagree with what the installer copies. The generated snapshot lives at
+  `install/golden-manifest.json` (regenerate with `python3 framework/install/manifest.py`;
+  do not hand-edit). `python3 framework/install/manifest.py --check` verifies the snapshot is
+  in sync and **exits 1 on drift**. The coupling test `tests/test_golden_manifest.py` performs
+  a real `bootstrap.py` install into a tmp dir and asserts the produced tree equals the
+  manifest, which is what keeps it honest. (Data-driven persona cards under
+  `.claude/team/roster/` are intentionally not enumerated.)
+- **Reinstall parity** (`install/reinstall.py`). This repo is both the framework source and a
+  live consumer of it (dogfood), so byte-copied assets exist in two trees: canonical
+  `framework/assets/**` and the live runtime `.claude/**`. `python3 framework/install/
+  reinstall.py` regenerates the live copy from canonical; `--check` reports drift and **exits
+  1** without writing (paired with the `test_reinstall_parity.py` CI gate). Hooks/lib are wired
+  in place (canonical-by-reference, cannot drift) and the charter is hand-evolvable, so only
+  byte-mirrored asset classes (today `skills/`) are in scope. This is the #116 dual-deploy
+  rule's enforcement half.
+
+## Install / test / teardown quality harness
+
+`python3 -m framework.harness` drives an install → assert → teardown matrix over repo-type
+buckets, emits per-bucket / per-category pass rates plus `install_success_rate` and
+`reinstall_parity_clean`, and exits non-zero on any failed graded metric so CI can gate on it.
+See `CONTRIBUTING.md` › *Running Tests* for the flag reference (`--quick`, `--compare`,
+`--include-real`, `--buckets`, `--installers`, `--scale`).
 
 ## What's covered vs. what's next
 


### PR DESCRIPTION
## What this documents

The entire installer surface shipped in **v0.5.0**, plus the brand-new **Phase 6
`--include-real`** real-repo harness mode, had zero user/developer-doc coverage. This PR
documents it in the natural homes the v0.5.0 coverage audit identified (docs-only, no runtime
change).

### `README.md` — `## Install configuration`
- **`### User-level install (`--user-space`)`** — the consented, idempotent
  `~/.claude/settings.json` install: agent-teams flag (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`),
  `teammateMode: auto`, `worktree.baseRef: fresh`, `~/.claude` permission globs. Documents
  check-existing-first / no-op-on-match / never-clobber-a-conflict / union-lists, and that
  `--non-interactive` (and any non-TTY/CI) skips it.
- **`### Repo-level backup, archive, and restore`** — consent + keep-&-amend (default,
  non-destructive) vs. archive-&-fresh into `.claude-backups/<UTC>/` (deliberately out of
  Claude's load scope), with the **restore procedure**.
- **`### Atomic settings writes`** — temp → `fsync` → `os.replace` protecting `settings.json`
  on the destructive install paths.

### `framework/README.md` — `## Layout`
- Enumerate **all** `install/` modules (was only `bootstrap.py` + `roster_gen.py`): added
  `child_install`, `install_config`, `miniyaml`, `manifest` + `golden-manifest.json`,
  `user_space`, `consent`, `backup`, `repo_space`, `atomic_io`, `reinstall`.
- Added the full **`harness/`** tree.
- New **Install-completeness & parity guards** section (golden manifest + `manifest.py --check`;
  `reinstall.py --check`) and a **quality-harness** pointer section.

### `CONTRIBUTING.md`
- **`## Running Tests`** — `python3 -m framework.harness` incl. the new **`--include-real`**
  real-repo mode (clone-at-pinned-SHA, read-only against source, opt-in) + a flag table + the
  `manifest.py`/`reinstall.py --check` guards.
- **`## Project Structure`** — added `framework/install/` and `framework/harness/`.

## Verification
- Every CLI flag verified against the actual argparse/source (`bootstrap.py`, `harness/__main__.py`,
  `manifest.py`, `reinstall.py`, `real_provision.py`). No documented-but-nonexistent flags.
- `ruff check framework/` clean; `python3 -m pytest framework/tests/ -q` → **460 passed**.
- Code fences balanced (top-level README is the PyPI long description).

## #116 dual-deploy
Not applicable: `README.md`, `framework/README.md`, `CONTRIBUTING.md` are repo docs, **not**
installed `.claude/**` assets. No canonical `framework/assets/` copy exists for them.

Closes #152

Reviewers: Tariq Morales + Paloma Gupta

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTQxgBAcChxvdQJafKyMdX
