### PR TITLE
fix(install): durability hardening from #101/#109 real runs (#149)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ node/*.tgz
 .claude/settings.local.json
 # Agent worktree checkouts (isolation dirs, never committed)
 .claude/worktrees/
+# Consent-gated archive-then-fresh backups (repo_space.py archive/restore, #108/#149);
+# a restore/archive must not leave untracked noise in the working tree.
+.claude-backups/
 
 # ---- Editor / OS ----
 .DS_Store

--- a/framework/harness/metrics.py
+++ b/framework/harness/metrics.py
@@ -510,7 +510,18 @@ def m_teardown_residue_zero(ctx: CellContext) -> Measurement:
 
 def m_no_backup_litter(ctx: CellContext) -> Measurement:
     # A happy-path fresh install (no conflict) must create zero .bak* files.
-    baks = [p.name for p in ctx.workdir.rglob("*.bak*") if ".git" not in p.parts]
+    # Scope detection to files the INSTALLER created: a .bak already present in the
+    # pre-install snapshot (ctx.before) is the source repo's own checked-in backup — e.g.
+    # noorinalabs's `errors.jsonl.bak.*` from #101 — not installer litter, so exclude it by
+    # diffing against the pre-install snapshot rather than counting every `.bak*` in the tree.
+    preexisting = set(ctx.before)
+    baks = []
+    for p in ctx.workdir.rglob("*.bak*"):
+        if ".git" in p.parts or not p.is_file():
+            continue
+        if p.relative_to(ctx.workdir).as_posix() in preexisting:
+            continue  # checked into the fixture before install — the repo's litter, not ours
+        baks.append(p.name)
     ok = not baks
     return Measurement(len(baks), ok, {"bak_files": 0}, {"bak_count": len(baks), "baks": baks[:20]})
 

--- a/framework/install/atomic_io.py
+++ b/framework/install/atomic_io.py
@@ -11,16 +11,22 @@ a backup, but the write itself should never be able to strand a half-file.
 the SAME directory, flushes + fsyncs it, then ``os.replace``s it onto the target.
 ``os.replace`` is an atomic rename on POSIX (and same-volume on Windows), so any
 concurrent reader — and any post-crash observer — sees either the old file intact
-or the complete new file, never a truncated in-between. Stdlib-only.
+or the complete new file, never a truncated in-between. After the replace we also
+fsync the *parent directory* so the rename's new directory entry is durable across a
+power loss — fsyncing the temp file persists its bytes, but not the entry that names
+them under the target, so a crash right after the rename could otherwise lose the
+file on some filesystems. The dir-fsync is best-effort / fail-open: platforms that
+cannot open a directory for fsync (notably Windows) skip it silently and never crash
+the install. Stdlib-only.
 
 Public API
 ==========
 ``atomic_write_text(path, text, *, encoding="utf-8") -> None``
     Create ``path``'s parent if needed, write ``text`` to a temp file in the same
     directory (so the final rename stays on one filesystem and is therefore
-    atomic), then ``os.replace`` it into place. The temp file is removed on any
-    error before the replace, so a failed write leaves neither a stray temp nor a
-    damaged target.
+    atomic), then ``os.replace`` it into place and fsync the parent directory so the
+    rename is durable. The temp file is removed on any error before the replace, so a
+    failed write leaves neither a stray temp nor a damaged target.
 """
 
 from __future__ import annotations
@@ -28,6 +34,28 @@ from __future__ import annotations
 import os
 import tempfile
 from pathlib import Path
+
+
+def _fsync_dir(directory: Path) -> None:
+    """Best-effort fsync of ``directory`` so a rename into it survives a power loss.
+
+    ``os.replace`` puts the new name in the directory, but that directory entry may live
+    only in the OS cache until the *directory itself* is fsynced; a crash in that window can
+    lose the rename even though the file's bytes were fsynced. Opening the dir and fsyncing
+    its fd flushes the entry. Fail-open by contract: platforms/filesystems that cannot open a
+    directory for reading (notably Windows) or cannot fsync one are a silent no-op — hard
+    durability is best-effort and must never crash the install.
+    """
+    try:
+        dir_fd = os.open(str(directory), os.O_RDONLY)
+    except OSError:
+        return  # e.g. Windows: cannot open a directory as a file descriptor
+    try:
+        os.fsync(dir_fd)
+    except OSError:
+        pass  # some filesystems reject fsync on a directory fd — durability stays best-effort
+    finally:
+        os.close(dir_fd)
 
 
 def atomic_write_text(path: Path | str, text: str, *, encoding: str = "utf-8") -> None:
@@ -49,3 +77,5 @@ def atomic_write_text(path: Path | str, text: str, *, encoding: str = "utf-8") -
         except OSError:
             pass
         raise
+    # Durably persist the rename's directory entry (best-effort; never crashes the install).
+    _fsync_dir(path.parent)

--- a/framework/install/repo_space.py
+++ b/framework/install/repo_space.py
@@ -148,6 +148,13 @@ def archive_assets(repo_root: Path | str, *, now: datetime | None = None) -> Arc
     Deliberately relocates (moves, not copies) each asset OUT of Claude's load scope so
     the archived copy is inert. The archive dir is non-clobbering (a numeric suffix is
     added if the same-second dir exists). ``now`` is injectable for deterministic tests.
+
+    The manifest is written **before** the first ``shutil.move`` — it is the archive's
+    recovery index, so it must happen-before the point of no return. If the process crashes
+    mid-move, the manifest already names every intended member; :func:`restore_assets` then
+    moves back whatever reached the archive and skips members that never left the repo root
+    (they are still in place, untouched), so a partial archive is always recoverable rather
+    than stranded/unrestorable. (#149 durability finding 3.)
     """
     root = Path(repo_root)
     present = _present_assets(root)
@@ -164,16 +171,10 @@ def archive_assets(repo_root: Path | str, *, now: datetime | None = None) -> Arc
         n += 1
     archive_dir.mkdir(parents=True)
 
-    entries: list[dict] = []
-    moved: list[str] = []
-    for name in present:
-        src = root / name
-        dst = archive_dir / name
-        is_dir = src.is_dir()
-        shutil.move(str(src), str(dst))
-        entries.append({"name": name, "type": "dir" if is_dir else "file"})
-        moved.append(name)
-
+    # Record types from the still-in-place assets, then persist the manifest BEFORE moving.
+    entries = [
+        {"name": name, "type": "dir" if (root / name).is_dir() else "file"} for name in present
+    ]
     manifest = {
         "version": MANIFEST_VERSION,
         "archived_utc": stamp,
@@ -182,6 +183,12 @@ def archive_assets(repo_root: Path | str, *, now: datetime | None = None) -> Arc
     }
     manifest_path = archive_dir / MANIFEST_NAME
     atomic_write_text(manifest_path, json.dumps(manifest, indent=2) + "\n")
+
+    moved: list[str] = []
+    for name in present:
+        shutil.move(str(root / name), str(archive_dir / name))
+        moved.append(name)
+
     return ArchiveResult(archive_dir=archive_dir, moved=moved, manifest_path=manifest_path)
 
 
@@ -195,6 +202,14 @@ def restore_assets(
     e.g. a fresh install laid down after the archive); without it the member is left in
     the archive and reported as a conflict. Restoring is idempotent for already-restored
     members (a missing archive member is skipped).
+
+    **Scope is deliberately exact — the managed assets only.** Restore moves back exactly the
+    manifest's members (``.claude/`` + ``CLAUDE.md``) and touches nothing else. It does NOT
+    return the working tree to a globally pristine state: out-of-scope artifacts a fresh
+    install may have left (e.g. ``.git/hooks/pre-push``) and the now-emptied
+    ``.claude-backups/<UTC>/`` container are intentionally left in place — pruning them is a
+    separate "return to pristine" concern, not this restore's contract (#149 finding 4). The
+    ``test_restore_scope_is_exactly_managed_assets`` test asserts this boundary.
     """
     root = Path(repo_root)
     archive_dir = Path(archive_dir)

--- a/framework/tests/test_install_harness.py
+++ b/framework/tests/test_install_harness.py
@@ -270,6 +270,33 @@ def test_manifest_driven_uninstall_flags_residue_when_backup_missing(tmp_path: P
     assert "keep.py" in residue  # modified content is residue vs the pre-install snapshot
 
 
+# ------------------------------------- #149 finding: no_backup_litter scopes to installer output
+
+
+def test_no_backup_litter_ignores_preexisting_checked_in_baks(tmp_path: Path) -> None:
+    """A `.bak` present in the pre-install snapshot is the fixture's litter, not the installer's.
+
+    #101's noorinalabs run flagged the source repo's OWN checked-in `errors.jsonl.bak.*` as
+    installer litter. The metric now diffs against ``ctx.before`` (the pre-install snapshot),
+    so a pre-existing `.bak` passes but a NEW one the install created fails.
+    """
+    # A `.bak` checked into the fixture BEFORE install (captured in the pre-install snapshot).
+    preexisting = tmp_path / ".claude" / "annunaki"
+    preexisting.mkdir(parents=True)
+    (preexisting / "errors.jsonl.bak.20260429").write_text("old\n", encoding="utf-8")
+    before = snapshot.snapshot(tmp_path)
+
+    ctx = metrics.CellContext(workdir=tmp_path, installer="bootstrap", permutation={}, before=before)
+    m = metrics.m_no_backup_litter(ctx)
+    assert m.passed is True and m.value == 0  # the repo's own checked-in .bak is not our litter
+
+    # A NEW .bak the install produced (absent from `before`) is still flagged.
+    (tmp_path / "CLAUDE.md.20260705T000000Z.bak").write_text("backup\n", encoding="utf-8")
+    m2 = metrics.m_no_backup_litter(ctx)
+    assert m2.passed is False and m2.value == 1
+    assert m2.observed["baks"] == ["CLAUDE.md.20260705T000000Z.bak"]
+
+
 # --------------------------------------------------------------- buckets matrix
 
 

--- a/framework/tests/test_repo_space.py
+++ b/framework/tests/test_repo_space.py
@@ -20,6 +20,7 @@ Stdlib + pytest only.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -394,6 +395,55 @@ def test_atomic_write_dir_fsync_is_fail_open(tmp_path: Path, monkeypatch) -> Non
     monkeypatch.setattr(atomic_io.os, "open", _open_raising)
     atomic_io.atomic_write_text(target, "data")  # must not raise
     assert target.read_text() == "data"  # write still succeeded
+
+
+def _dir_fsync_supported(directory: Path) -> bool:
+    """True iff this platform can open+fsync a directory fd (fail-open guard, mirrors the code)."""
+    try:
+        fd = os.open(str(directory), os.O_RDONLY)
+    except OSError:
+        return False
+    try:
+        os.fsync(fd)
+    except OSError:
+        return False
+    finally:
+        os.close(fd)
+    return True
+
+
+def test_atomic_write_really_fsyncs_the_parent_directory(tmp_path: Path, monkeypatch) -> None:
+    """The success path fsyncs a fd that REALLY refers to the parent dir — not just 'some fsync'.
+
+    Non-tautological guard for #149 finding 2 (the durability syscall itself, not its wiring):
+    a spy on ``os.fsync`` records the inode behind every fsynced fd and correlates it to the
+    parent directory's inode. Gutting the ``os.fsync(dir_fd)`` line inside ``_fsync_dir`` makes
+    THIS test fail (the parent-dir inode is never fsynced). Skips cleanly on platforms that
+    cannot fsync a directory fd, matching the code's own fail-open behaviour.
+    """
+    target = tmp_path / "sub" / "out.json"
+    parent = target.parent
+    parent.mkdir(parents=True)
+    if not _dir_fsync_supported(parent):
+        pytest.skip("platform cannot fsync a directory fd (dir-fsync unsupported)")
+
+    parent_ino = os.stat(str(parent)).st_ino
+    fsynced_inodes: list[int] = []
+    real_fsync = atomic_io.os.fsync
+
+    def _fsync_spy(fd):
+        try:
+            fsynced_inodes.append(os.fstat(fd).st_ino)
+        except OSError:
+            pass
+        return real_fsync(fd)  # delegate to the real syscall — durability still happens
+
+    monkeypatch.setattr(atomic_io.os, "fsync", _fsync_spy)
+    atomic_io.atomic_write_text(target, '{"a": 1}\n')
+
+    # The PARENT DIRECTORY's fd was fsynced (correlated by inode), not merely the temp file.
+    assert parent_ino in fsynced_inodes, "parent-dir fd was never fsynced (durability syscall dropped)"
+    assert target.read_text() == '{"a": 1}\n'
 
 
 # ------------------------------------------- #149 finding 3: interrupted archive is recoverable

--- a/framework/tests/test_repo_space.py
+++ b/framework/tests/test_repo_space.py
@@ -345,3 +345,120 @@ def test_user_space_write_is_atomic_and_crash_safe(tmp_path: Path, monkeypatch) 
         user_space.install_user_space(home=home, non_interactive=False, consent_fn=lambda _s: True)
 
     assert path.read_bytes() == before  # settings.json never truncated by the failed write
+
+
+# ---------------------------------------------- #149 finding 2: parent-dir fsync durability
+
+
+def test_atomic_write_fsyncs_parent_dir_after_replace(tmp_path: Path, monkeypatch) -> None:
+    """After the atomic rename, the target's PARENT DIR is fsynced so the rename is durable.
+
+    Fsyncing only the temp file persists its bytes but not the directory entry that names
+    them under the target; a crash right after ``os.replace`` could lose the rename. The fix
+    (#149 finding 2) fsyncs the parent dir — force that path and assert it fires on the
+    target's parent, and that it happens AFTER the replace.
+    """
+    target = tmp_path / "sub" / "out.json"
+    events: list[tuple[str, Path]] = []
+    real_replace = atomic_io.os.replace
+
+    def _replace_spy(src, dst):
+        events.append(("replace", Path(dst)))
+        return real_replace(src, dst)
+
+    def _fsync_dir_spy(directory):
+        events.append(("fsync_dir", Path(directory)))
+
+    monkeypatch.setattr(atomic_io.os, "replace", _replace_spy)
+    monkeypatch.setattr(atomic_io, "_fsync_dir", _fsync_dir_spy)
+    atomic_io.atomic_write_text(target, '{"a": 1}\n')
+
+    assert ("fsync_dir", target.parent) in events  # the parent dir was fsynced
+    # ...and strictly after the rename (durability of the entry, not the bytes).
+    assert events.index(("replace", target)) < events.index(("fsync_dir", target.parent))
+    assert target.read_text() == '{"a": 1}\n'
+
+
+def test_atomic_write_dir_fsync_is_fail_open(tmp_path: Path, monkeypatch) -> None:
+    """Hard durability is best-effort: a dir that can't be opened/fsynced never crashes the write."""
+    target = tmp_path / "out.json"
+
+    # Simulate a platform where opening a directory fd is unsupported (e.g. Windows).
+    real_open = atomic_io.os.open
+
+    def _open_raising(path, *a, **k):
+        if Path(path) == target.parent:
+            raise OSError("cannot open directory as fd")
+        return real_open(path, *a, **k)
+
+    monkeypatch.setattr(atomic_io.os, "open", _open_raising)
+    atomic_io.atomic_write_text(target, "data")  # must not raise
+    assert target.read_text() == "data"  # write still succeeded
+
+
+# ------------------------------------------- #149 finding 3: interrupted archive is recoverable
+
+
+def test_archive_writes_manifest_before_moving_and_is_recoverable(tmp_path: Path, monkeypatch) -> None:
+    """A crash MID-move leaves a manifested, fully-restorable archive — never a stranded half.
+
+    The manifest is written before the first ``shutil.move``, so if the process dies after
+    moving ``.claude`` but before ``CLAUDE.md``, restore reads the (complete) manifest, moves
+    ``.claude`` back, and skips the member still sitting untouched at the repo root — restoring
+    the original state byte-for-byte.
+    """
+    original = _seed_repo(tmp_path)
+    real_move = repo_space.shutil.move
+    calls = {"n": 0}
+
+    def _move_then_boom(src, dst):
+        calls["n"] += 1
+        if calls["n"] >= 2:  # move the first asset, crash on the second
+            raise RuntimeError("simulated interrupt mid-archive")
+        return real_move(src, dst)
+
+    monkeypatch.setattr(repo_space.shutil, "move", _move_then_boom)
+    with pytest.raises(RuntimeError):
+        repo_space.archive_assets(tmp_path)
+
+    # The manifest exists and names EVERY intended member despite the crash (written first).
+    archive_dirs = list((tmp_path / repo_space.BACKUPS_DIRNAME).iterdir())
+    assert len(archive_dirs) == 1
+    archive_dir = archive_dirs[0]
+    manifest = json.loads((archive_dir / repo_space.MANIFEST_NAME).read_text())
+    assert {e["name"] for e in manifest["entries"]} == {".claude", "CLAUDE.md"}
+
+    # Recovery: restore off the manifest reconstructs the original repo byte-for-byte.
+    monkeypatch.setattr(repo_space.shutil, "move", real_move)  # undo the fault injection
+    repo_space.restore_assets(tmp_path, archive_dir)
+    assert _snapshot(tmp_path, (".claude", "CLAUDE.md")) == original
+
+
+# ---------------------------- #149 finding 4: restore scope is exactly the managed assets
+
+
+def test_restore_scope_is_exactly_managed_assets(tmp_path: Path) -> None:
+    """Restore touches ONLY .claude/ + CLAUDE.md; out-of-scope residue is intentionally left.
+
+    Restore is deliberately not a "return to globally pristine" op: a fresh install's
+    ``.git/hooks/pre-push`` and the emptied ``.claude-backups/`` container remain by design
+    (#149 finding 4). This asserts the exact managed boundary.
+    """
+    _seed_repo(tmp_path)
+    # Out-of-scope artifacts that a fresh install / the archive itself would leave behind.
+    hooks = tmp_path / ".git" / "hooks"
+    hooks.mkdir(parents=True)
+    (hooks / "pre-push").write_text("#!/bin/sh\n", encoding="utf-8")
+    sibling = tmp_path / "README.md"
+    sibling.write_text("unrelated\n", encoding="utf-8")
+
+    archived = repo_space.archive_assets(tmp_path)
+    result = repo_space.restore_assets(tmp_path, archived.archive_dir)
+
+    # The managed assets came back...
+    assert set(result.restored) == {".claude", "CLAUDE.md"}
+    # ...and the out-of-scope artifacts are untouched (neither pruned nor clobbered).
+    assert (hooks / "pre-push").read_text() == "#!/bin/sh\n"
+    assert sibling.read_text() == "unrelated\n"
+    # The archive container is intentionally left in place (emptied, not removed).
+    assert (tmp_path / repo_space.BACKUPS_DIRNAME).is_dir()


### PR DESCRIPTION
## Durability + fidelity hardening from the #101/#109 real-repo runs (#149)

Triaged the durability findings from the noorinalabs (#101) and botfarm_inc (#109) real
runs; landed the clear wins with tests and split the two redesign-sized items out as
tracked deferrals (comment on #149).

### Fixes (one test per fix)

- **`atomic_io.atomic_write_text` parent-dir fsync gap** (finding 2) — after `os.replace`
  we now fsync the target's parent directory so the rename's directory entry is durable
  across a power loss (fsyncing the temp file persisted the bytes but not the name). New
  `_fsync_dir` helper is best-effort / fail-open: platforms that can't open a directory fd
  (Windows) or fsync one are a silent no-op and never crash the install.
- **`repo_space.archive_assets` non-atomic move-then-manifest** (finding 3) — the restore
  manifest is now written **before** the first `shutil.move`, so a crash mid-archive leaves
  a fully manifest-recoverable archive instead of a stranded, unrestorable half. `restore`
  moves back whatever reached the archive and skips members still untouched at the repo root.
- **`no_backup_litter` counted the source repo's own checked-in `.bak`** (from #101) — the
  harness metric now diffs `.bak*` against the pre-install snapshot (`ctx.before`), so a
  fixture's own `errors.jsonl.bak.*` no longer reads as installer litter; only installer-
  created backups count.
- **`.claude-backups/` not gitignored** (finding 5) — added to the repo-root `.gitignore`
  so archive/restore leaves no untracked noise.
- **Restore out-of-scope residue** (finding 4) — documented that restore's managed scope is
  exactly `.claude/` + `CLAUDE.md`; `.git/hooks/pre-push` and the emptied `.claude-backups/`
  container are intentionally left (pruning to "globally pristine" is a separate concern). A
  test asserts the boundary is exact.

### Deferred (redesign-sized; tracked in a comment on #149, no parallel issue)

1. In-place `settings.json` merge not reversible by manifest-driven teardown (finding 1) —
   changing the amend contract to drop a `.bak`/restore entry for any pre-existing file it
   mutates.
2. B10 "pre-existing-framework baseline mode" metric-modeling — grading install-over-existing
   correctly across the metric set.

(Original Phase-5 issue-body items 2 & 3 — content-based foreign-asset detection and
child/meta golden-manifest snapshots — are out of this PR's scope and stay open on #149.)

### Verification

- `python3 -m pytest framework/tests/ -q` → **465 passed** (base 460 on `c1fe0b2`, +5 new).
- `ruff check framework/` → clean.
- **#116**: all edits are installer (`framework/install`) / dev tooling (`framework/harness`)
  / tests / repo-root `.gitignore` — no `.claude/**` runtime asset touched, so reinstall-
  parity does not apply.

Addresses #149

Reviewers: Paloma Gupta + Tariq Morales
