### PR TITLE
harness(tech-debt): enforce lifecycle kickoff-persistence — fail loud if state.json does not advance current_wave

### DIFF
--- a/.claude/skills/wave-start/SKILL.md
+++ b/.claude/skills/wave-start/SKILL.md
@@ -159,13 +159,23 @@ go-ahead. **Only after** the User approves, record the kickoff transition live:
 
 ```bash
 python3 "$LIB/lifecycle.py" wave kickoff "$W" --merge-model "$MERGE_MODEL"
+
+# Guard (#168): fail loudly if the write above did not actually land — the exact Wave 1
+# failure was a wave running its entire life un-stamped (state.json stuck at the prior
+# wave) because this step silently didn't persist. Do NOT proceed past a non-zero exit.
+python3 "$LIB/lifecycle.py" wave assert-kickoff "$W" || {
+  echo "STOP: kickoff did NOT persist to state.json — the wave cannot proceed un-stamped."
+  echo "Re-run the kickoff command above, then re-check with 'wave assert-kickoff' before continuing."
+  exit 1
+}
 ```
 
 This stamps `wave_{W}_kicked_off_at`, declares `wave_{W}_merge_model`, and re-points
 `current_wave`. Confirm the model with the User first: a wave whose per-issue PRs base on
 the integration branch is `wave-branch`; one whose PRs base straight on the default branch
 is `direct-to-main`. Do **not** run this before the go-ahead — it marks the wave as
-officially started and work beginning.
+officially started and work beginning. The `assert-kickoff` guard immediately after is not
+optional — it is what makes the un-stamped-wave failure mode impossible.
 
 ### 8. Report
 
@@ -187,3 +197,5 @@ officially started and work beginning.
   re-runs
 - Wave kickoff (Step 7) is an approval gate: the plan is presented and the `wave kickoff`
   lifecycle transition fires only on the User's explicit go-ahead
+- Kickoff persistence is enforced, not manual: `wave assert-kickoff` (#168) fails the step
+  loudly if `current_wave` did not actually advance — no more silent un-stamped waves

--- a/framework/assets/lib/lifecycle.py
+++ b/framework/assets/lib/lifecycle.py
@@ -39,6 +39,7 @@ CLI::
   lifecycle.py wave start    <W> [--at TS] [--state PATH]
   lifecycle.py wave scope    <W> --repos a,b,c [--phase P] [--at TS] [--state PATH]
   lifecycle.py wave kickoff  <W> [--merge-model M] [--at TS] [--state PATH]
+  lifecycle.py wave assert-kickoff <W> [--state PATH]
   lifecycle.py wave wrapup   <W> [--pr-count N] [--cr-cycles N]
                                   [--concentration P] [--at TS] [--state PATH]
   lifecycle.py merge-model get <W> [--state PATH]
@@ -375,6 +376,50 @@ def kickoff_wave(
     return persist(path, pairs)
 
 
+def kickoff_persisted(state: dict, wave: str) -> tuple[bool, str]:
+    """Verify ``kickoff_wave``'s state write actually landed (issue #168).
+
+    Guards the exact Wave 1 failure mode: a wave can be officially kicked off
+    (team spawned, branch cut, work underway) while the ``kickoff_wave`` state
+    write is skipped or lost — so ``current_wave`` never advances and
+    ``state.json`` sits un-stamped for the wave's entire life, discovered only
+    at retro/wrapup reconciliation. Checks the three facts ``kickoff_wave``
+    persists together: the ``current_wave`` pointer, the wave's ``_active``
+    flag, and its ``_kicked_off_at`` timestamp. Pure — no I/O — so it is a real
+    unit-testable guard; the CLI (``wave assert-kickoff``) and the wave-start
+    skill's kickoff step both call it to fail loudly rather than silently
+    proceeding un-stamped. Returns ``(ok, message)``; never raises.
+    """
+    label = _wave_label(wave)
+    key_active = f"wave_{wave}_active"
+    key_kicked = f"wave_{wave}_kicked_off_at"
+
+    current = state.get("current_wave")
+    active = state.get(key_active)
+    kicked_at = state.get(key_kicked)
+
+    problems = []
+    if current != label:
+        problems.append(f"current_wave is {current!r}, expected {label!r}")
+    if active is not True:
+        problems.append(f"{key_active} is {active!r}, expected true")
+    if not kicked_at:
+        problems.append(f"{key_kicked} is missing")
+
+    if problems:
+        return False, (
+            f"wave {wave} kickoff was NOT persisted to state.json: "
+            + "; ".join(problems)
+            + ". A wave cannot proceed un-stamped (this is the Wave 1 failure mode — "
+            "officially kicked off while state.json never advanced). Re-run "
+            f"`lifecycle.py wave kickoff {wave}` and re-check with `wave assert-kickoff`."
+        )
+    return True, (
+        f"wave {wave} kickoff persisted "
+        f"(current_wave={label}, {key_active}=true, {key_kicked}={kicked_at})"
+    )
+
+
 def wrapup_wave(
     path: Path,
     wave: str,
@@ -443,6 +488,16 @@ def _cmd_wave_kickoff(args: argparse.Namespace) -> int:
     return kickoff_wave(
         resolve_state_path(args.state), args.wave, merge_model=args.merge_model, at=args.at
     )
+
+
+def _cmd_wave_assert_kickoff(args: argparse.Namespace) -> int:
+    state = load_state(resolve_state_path(args.state))
+    ok, message = kickoff_persisted(state, args.wave)
+    if ok:
+        print(message)
+        return 0
+    print(f"ERROR: {message}", file=sys.stderr)
+    return 1
 
 
 def _cmd_wave_wrapup(args: argparse.Namespace) -> int:
@@ -528,6 +583,14 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--at", default=None)
     _state_opt(p)
     p.set_defaults(func=_cmd_wave_kickoff)
+
+    p = wsub.add_parser(
+        "assert-kickoff",
+        help="fail loudly (exit 1) if kickoff's state write did not persist (#168)",
+    )
+    p.add_argument("wave")
+    _state_opt(p)
+    p.set_defaults(func=_cmd_wave_assert_kickoff)
 
     p = wsub.add_parser("wrapup", help="close a wave: counters + completed_at")
     p.add_argument("wave")

--- a/framework/assets/skills/wave-start/SKILL.md
+++ b/framework/assets/skills/wave-start/SKILL.md
@@ -159,13 +159,23 @@ go-ahead. **Only after** the User approves, record the kickoff transition live:
 
 ```bash
 python3 "$LIB/lifecycle.py" wave kickoff "$W" --merge-model "$MERGE_MODEL"
+
+# Guard (#168): fail loudly if the write above did not actually land — the exact Wave 1
+# failure was a wave running its entire life un-stamped (state.json stuck at the prior
+# wave) because this step silently didn't persist. Do NOT proceed past a non-zero exit.
+python3 "$LIB/lifecycle.py" wave assert-kickoff "$W" || {
+  echo "STOP: kickoff did NOT persist to state.json — the wave cannot proceed un-stamped."
+  echo "Re-run the kickoff command above, then re-check with 'wave assert-kickoff' before continuing."
+  exit 1
+}
 ```
 
 This stamps `wave_{W}_kicked_off_at`, declares `wave_{W}_merge_model`, and re-points
 `current_wave`. Confirm the model with the User first: a wave whose per-issue PRs base on
 the integration branch is `wave-branch`; one whose PRs base straight on the default branch
 is `direct-to-main`. Do **not** run this before the go-ahead — it marks the wave as
-officially started and work beginning.
+officially started and work beginning. The `assert-kickoff` guard immediately after is not
+optional — it is what makes the un-stamped-wave failure mode impossible.
 
 ### 8. Report
 
@@ -187,3 +197,5 @@ officially started and work beginning.
   re-runs
 - Wave kickoff (Step 7) is an approval gate: the plan is presented and the `wave kickoff`
   lifecycle transition fires only on the User's explicit go-ahead
+- Kickoff persistence is enforced, not manual: `wave assert-kickoff` (#168) fails the step
+  loudly if `current_wave` did not actually advance — no more silent un-stamped waves

--- a/framework/tests/test_lifecycle.py
+++ b/framework/tests/test_lifecycle.py
@@ -149,6 +149,61 @@ def test_persist_preserves_existing_and_is_valid_json(tmp_path: Path) -> None:
     assert s["wave_16_active"] is True
 
 
+# --------------------------------------------------------------- kickoff persistence guard (#168)
+
+
+def test_assert_kickoff_persisted_traps_the_wave1_failure() -> None:
+    """Load-bearing: the guard MUST trip when kickoff's state write is skipped.
+
+    Reproduces the exact Wave 1 shape: `current_wave` is stuck at a PRIOR wave
+    (the actual symptom reported at retro) and none of wave 7's own kickoff keys
+    were ever written — because the kickoff state write silently never ran.
+    If `kickoff_persisted` is reverted to a stub that always returns True (or
+    only checks one of the three facts it must check), this assertion fails —
+    that is what makes it load-bearing rather than tautological.
+    """
+    skipped_state = {
+        "current_wave": "wave-5",  # never advanced past the PRIOR wave
+        "global_wave_seq": 7,
+        "wave_7_phase": 6,
+        # no wave_7_active, no wave_7_kicked_off_at — kickoff never persisted
+    }
+    ok, msg = lifecycle.kickoff_persisted(skipped_state, "7")
+    assert ok is False
+    assert "NOT persisted" in msg
+    assert "current_wave is 'wave-5'" in msg
+
+    # Now the fix lands for real: kickoff_wave runs and stamps the state file.
+    landed_path_state = dict(skipped_state)
+    landed_path_state["current_wave"] = "wave-7"
+    landed_path_state["wave_7_active"] = True
+    landed_path_state["wave_7_kicked_off_at"] = "2026-07-06T00:00:00Z"
+    ok2, msg2 = lifecycle.kickoff_persisted(landed_path_state, "7")
+    assert ok2 is True
+    assert "persisted" in msg2
+
+
+def test_assert_kickoff_persisted_true_after_real_kickoff_wave(tmp_path: Path) -> None:
+    """End-to-end: run the real start/scope/kickoff sequence and check the guard passes."""
+    state = tmp_path / "state.json"
+    lifecycle.start_wave(state, "7", at="2026-07-06T00:00:00Z")
+    lifecycle.scope_wave(state, "7", ["acme"], phase=6, at="2026-07-06T00:05:00Z")
+    lifecycle.kickoff_wave(state, "7", merge_model="wave-branch", at="2026-07-06T00:10:00Z")
+
+    ok, _ = lifecycle.kickoff_persisted(json.loads(state.read_text()), "7")
+    assert ok is True
+
+
+def test_assert_kickoff_persisted_false_when_active_flag_missing() -> None:
+    """Partial persistence (pointer moved, active flag/timestamp lost) still trips."""
+    ok, msg = lifecycle.kickoff_persisted(
+        {"current_wave": "wave-7"}, "7"
+    )
+    assert ok is False
+    assert "wave_7_active" in msg
+    assert "wave_7_kicked_off_at" in msg
+
+
 # --------------------------------------------------------------- CLI
 
 
@@ -182,3 +237,29 @@ def test_cli_state_path_and_wave_flow(tmp_path: Path) -> None:
 
     # invalid model rejected at the CLI (argparse choices)
     assert run("merge-model", "set", "1", "bogus", "--state", str(state)).returncode != 0
+
+
+def test_cli_assert_kickoff_exit_codes(tmp_path: Path) -> None:
+    """`wave assert-kickoff` is the sub-command the skill's kickoff step gates on."""
+    state = tmp_path / "lc.json"
+
+    def run(*a: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(_FRAMEWORK_ROOT / "assets" / "lib" / "lifecycle.py"), *a],
+            capture_output=True, text=True,
+        )
+
+    # start + scope only (no kickoff yet) → assert-kickoff fails loudly (exit 1, stderr).
+    assert run("wave", "start", "9", "--at", "2026-07-06T00:00:00Z", "--state", str(state)).returncode == 0
+    r = run("wave", "assert-kickoff", "9", "--state", str(state))
+    assert r.returncode == 1
+    assert "ERROR" in r.stderr and "NOT persisted" in r.stderr
+
+    # kickoff lands → assert-kickoff now passes (exit 0).
+    assert run(
+        "wave", "kickoff", "9", "--merge-model", "wave-branch",
+        "--at", "2026-07-06T00:10:00Z", "--state", str(state),
+    ).returncode == 0
+    r = run("wave", "assert-kickoff", "9", "--state", str(state))
+    assert r.returncode == 0
+    assert "persisted" in r.stdout

--- a/framework/tests/test_wave_skill_lifecycle_wiring.py
+++ b/framework/tests/test_wave_skill_lifecycle_wiring.py
@@ -80,6 +80,27 @@ def test_wave_start_drives_allocate_start_scope_kickoff(tree: Path) -> None:
 
 
 @pytest.mark.parametrize("tree", _SKILL_TREES, ids=lambda p: f"{p.parent.name}/{p.name}")
+def test_wave_start_gates_kickoff_on_assert_kickoff(tree: Path) -> None:
+    """#168: the kickoff step must be immediately followed by the persistence guard.
+
+    Wave 1's failure was silent — `wave kickoff` ran (or didn't) and nothing checked
+    whether the write actually landed. Both dual-deploy copies must invoke
+    `lifecycle.py wave assert-kickoff` right after `wave kickoff`, and STOP (non-zero
+    exit) rather than silently continuing when it fails.
+    """
+    text = _skill_text(tree, "wave-start")
+    assert 'lifecycle.py" wave assert-kickoff' in text, (
+        "wave-start does not invoke the `lifecycle.py wave assert-kickoff` guard"
+    )
+    kickoff_idx = text.index('lifecycle.py" wave kickoff')
+    guard_idx = text.index('lifecycle.py" wave assert-kickoff')
+    assert guard_idx > kickoff_idx, "assert-kickoff guard must come AFTER the kickoff write"
+    # The guard must actually stop the step, not just print a warning.
+    guard_block = text[guard_idx : guard_idx + 300]
+    assert "exit 1" in guard_block, "assert-kickoff failure does not exit non-zero"
+
+
+@pytest.mark.parametrize("tree", _SKILL_TREES, ids=lambda p: f"{p.parent.name}/{p.name}")
 def test_wave_end_drives_wrapup_and_merge_model(tree: Path) -> None:
     text = _skill_text(tree, "wave-end")
     assert 'lifecycle.py" wave wrapup' in text, "wave-end does not invoke `lifecycle.py wave wrapup`"


### PR DESCRIPTION
## Summary

Wave 1 ran its **entire life un-stamped** — `state.json` stuck at `wave-5` — because the
kickoff transition's state write silently never landed, discovered only at wrapup and
requiring a full retroactive `allocate→start→scope→kickoff→wrapup` reconciliation. This
adds a guard so a wave can no longer proceed un-stamped:

- **`lifecycle.py`**: new pure `kickoff_persisted(state, wave) -> (ok, message)` — checks
  the three facts `kickoff_wave` persists together (`current_wave` pointer, `wave_{W}_active`,
  `wave_{W}_kicked_off_at`). Exposed as a new CLI sub-command `wave assert-kickoff <W>
  [--state PATH]` (exit 0 + message on success, exit 1 + `ERROR:` on stderr on failure).
- **wave-start skill** (both `.claude/skills/wave-start/SKILL.md` and
  `framework/assets/skills/wave-start/SKILL.md` — #116 dual-deploy parity): step 7's kickoff
  now runs `wave assert-kickoff "$W"` immediately after `wave kickoff` and `exit 1`s with a
  STOP message if it fails, instead of silently continuing.

### Where the guard lives and why
Put the check in `lifecycle.py` as a pure `state -> (bool, str)` function rather than only
in the skill's bash, so it's directly unit-testable (no subprocess/tmp-file plumbing needed
for the core logic) and reusable from any kickoff-driving surface. The CLI sub-command is a
thin wrapper the skill (or any future caller) shells out to.

### Load-bearing test
`test_assert_kickoff_persisted_traps_the_wave1_failure` (+ 3 companion tests) in
`framework/tests/test_lifecycle.py`. Verified by hand: patching the guard's `if problems:`
branch to `if False and problems:` (simulating a reverted/no-op guard) breaks
`test_assert_kickoff_persisted_traps_the_wave1_failure`,
`test_assert_kickoff_persisted_false_when_active_flag_missing`, and
`test_cli_assert_kickoff_exit_codes` (3 of 4 new tests fail); reverting the patch makes all
4 pass again. `test_wave_start_gates_kickoff_on_assert_kickoff` in
`test_wave_skill_lifecycle_wiring.py` additionally proves the skill wiring (guard present,
placed after `wave kickoff`, and actually `exit 1`s) in **both** dual-deploy copies.

### Safety
No mutation of the real `.claude/state.json` — all tests operate on `tmp_path` fixture state
files or in-memory dicts.

## Test plan
- [x] `ruff check framework/` — all checks passed
- [x] `ENVIRONMENT=test python -m pytest framework/tests/` — 472 passed (up from 466 baseline)
- [x] Manual revert check: broke 3/4 new tests when the guard was neutered, all pass restored

Closes #168

Co-Authored-By: Nia Rossi <Nia.Rossi@gmail.com>
