### PR TITLE
fix(trust-signals): durable review-catch ledger survives verdict amend-in-place (#164)

### DIFF
--- a/framework/assets/lib/trust_signals.py
+++ b/framework/assets/lib/trust_signals.py
@@ -26,6 +26,35 @@ Two cleanly separated layers:
     is a pure function so the model is unit-testable, and usable standalone on a
     hand-built signal dict, without touching the SCM at all.
 
+Durable review-catch ledger (#164)
+-----------------------------------
+The charter's verdict-amendment convention has a reviewer edit their blocking
+``Request``/``Must-fix:`` comment **in place** to ``Replied``/``Must-fix: None``
+once the fix lands. Because extraction used to derive ``must_fix_caught`` /
+``must_fix_received`` purely by re-parsing the PR's *current* comment bodies,
+an amendment silently erased the historic catch — the reviewer's signal
+vanished and, if they authored no PRs of their own, they dropped out of the
+engineer map entirely (Phase 6 Wave 1: the wave's standout reviewer scored
+``must_fix_caught=0``).
+
+Fix (design option (b) from #164/#165 — chosen over reading GitHub comment
+edit-history or a distinct ``Replied``-follow-up convention change: it needs no
+new SCM/API dependency and keeps the signal durable at the moment it is
+created): :func:`record_review_catch` durably appends one entry per
+changes-requested verdict to ``wave_{wave}_review_catches`` in the project
+state file, **at issue time** — i.e. the moment the blocking verdict comment is
+posted, before any later amendment can erase it. :func:`extract_signals` reads
+this ledger (:func:`_review_catches_for_wave`) and, for any PR that has >=1
+recorded catch, treats the ledger as **authoritative** for that PR's
+changes-requested accounting instead of re-deriving it from the (possibly
+already-amended) live comment body. A PR with no ledger entry falls back to the
+legacy live-comment-parsing path unchanged, so projects/waves that predate this
+ledger keep scoring exactly as before.
+
+CLI: ``trust_signals.py record-catch <wave> --repo O/N --pr P --requestor R
+--requestee E`` — meant to be invoked immediately after posting a blocking
+verdict comment (see the module CLI section below).
+
 Signals per engineer (all integers, all countable from the merged-PR set):
 
   ===========================  ============================================
@@ -54,6 +83,12 @@ CLI:
                                                                 # proposed deltas
                                                                 # + forced
                                                                 # negative line
+  trust_signals.py record-catch <wave> --repo O/N --pr P --requestor R
+                                 --requestee E [--at TS] [--status PATH]
+                                                                # durably record
+                                                                # one changes-
+                                                                # requested catch
+                                                                # at issue time
 """
 
 from __future__ import annotations
@@ -64,15 +99,22 @@ import re
 import subprocess
 import sys
 from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 
 # The shared config loader lives in the framework's hooks dir. This lib lives in
 # the sibling lib/ dir; mirror pr_ci_state.py's lib->hooks import bridge so the
-# scoring half stays importable wherever the framework is deployed.
-_HOOKS_DIR = Path(__file__).resolve().parent.parent / "hooks"
+# scoring half stays importable wherever the framework is deployed. lifecycle.py
+# is a same-dir sibling (both land side-by-side in the bundled framework tree
+# too — see lifecycle.py's own self-insert), so this dir is put on the path
+# explicitly rather than relying on script-adjacent defaults.
+_LIB_DIR = Path(__file__).resolve().parent
+_HOOKS_DIR = _LIB_DIR.parent / "hooks"
 sys.path.insert(0, str(_HOOKS_DIR))
+sys.path.insert(0, str(_LIB_DIR))
 
 from _framework_config import config  # noqa: E402
+from lifecycle import persist as _persist_state  # noqa: E402
 
 # Every gh subprocess call carries a timeout so a hung network call can never
 # wedge the tool indefinitely.
@@ -455,6 +497,70 @@ def _kickoff_ts(wave: str, status_path: Path | None) -> str | None:
     return str(val) if val else None
 
 
+def _now_iso(at: str | None = None) -> str:
+    """An ISO-8601 UTC timestamp; ``at`` overrides for deterministic tests."""
+    if at:
+        return at
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _review_catches_for_wave(wave: str, status_path: Path | None) -> list[dict]:
+    """The durable per-PR must-fix catch ledger for *wave* (#164).
+
+    Reads ``wave_<id>_review_catches`` — a list of ``{"repo", "pr",
+    "requestor", "requestee", "recorded_at"}`` entries appended by
+    :func:`record_review_catch` at issue time. Absent/unreadable state file, or
+    no entries recorded for this wave, → ``[]`` (fail-open: a project/wave that
+    never called :func:`record_review_catch` falls back entirely to the legacy
+    live-comment-parsing path in :func:`extract_signals`).
+    """
+    if status_path is None:
+        return []
+    try:
+        data = json.loads(Path(status_path).read_text())
+    except (OSError, json.JSONDecodeError, ValueError):
+        return []
+    val = data.get(f"wave_{wave}_review_catches")
+    return list(val) if isinstance(val, list) else []
+
+
+def record_review_catch(
+    status_path: str | Path,
+    wave: str,
+    *,
+    repo: str,
+    pr: int,
+    requestor: str,
+    requestee: str | None = None,
+    at: str | None = None,
+) -> list[dict]:
+    """Durably record one changes-requested catch **at issue time** (#164).
+
+    Call this the moment a blocking (``Request`` + enumerated ``Must-fix:``)
+    verdict comment is posted — before any later in-place amendment to
+    ``Replied``/``Must-fix: None`` can erase the historic signal. The entry is
+    appended (never deduplicated: N calls for the same PR/reviewer are N
+    distinct changes-requested cycles) to ``wave_<id>_review_catches`` in the
+    project state file via :func:`lifecycle.persist`, which preserves the
+    file's compact-inline shape and validates JSON before and after the write.
+
+    Returns the full updated list for that wave (post-append).
+    """
+    status_path = Path(status_path)
+    key = f"wave_{wave}_review_catches"
+    existing = _review_catches_for_wave(wave, status_path)
+    entry = {
+        "repo": repo,
+        "pr": int(pr),
+        "requestor": requestor,
+        "requestee": requestee,
+        "recorded_at": _now_iso(at),
+    }
+    updated = [*existing, entry]
+    _persist_state(status_path, {key: updated})
+    return updated
+
+
 def _pr_comment_bodies(repo: str, number: int) -> list[str]:
     """Every issue-comment body on a PR (verdict comments live here)."""
     raw = _run_gh(
@@ -625,6 +731,77 @@ def _canonicalizer(cfg):
     return canon
 
 
+def _account_pr(
+    signals: dict[str, Signals],
+    canon,
+    *,
+    author: str,
+    repo: str,
+    number: int,
+    comment_bodies: list[str],
+    ci_red: bool,
+    review_catches: list[dict] | None = None,
+) -> None:
+    """Fold one merged PR's contribution into *signals* (mutates in place).
+
+    Pure aside from the ``canon`` callable (itself pure) — no I/O. Shared by
+    :func:`extract_signals` (live gh-backed) and tests (hand-built PR data), so
+    the two never drift.
+
+    ``review_catches`` is the full wave-scoped durable ledger (#164,
+    :func:`_review_catches_for_wave`); entries are filtered here to this
+    ``(repo, number)``. When that filtered set is non-empty it is
+    **authoritative** for this PR's changes-requested accounting
+    (``must_fix_received`` / ``must_fix_caught`` / ``rework_cycles``) — it
+    supersedes re-deriving those from ``comment_bodies``, so a verdict comment
+    later amended in place (the charter's amendment convention) cannot erase a
+    catch that was durably recorded at issue time. A PR with no ledger entries
+    falls back to the legacy live-comment-parsing path unchanged. False-positive
+    detection is untouched by the ledger — it is always read from the live
+    comment body (a retraction is itself only ever expressed there).
+    """
+
+    def bucket(name: str) -> Signals:
+        return signals.setdefault(canon(name), Signals())
+
+    author_sig = bucket(author)
+    author_sig.prs_merged += 1
+    author_sig.authored_prs.append(number)
+
+    if ci_red:
+        author_sig.ci_red_merges += 1
+
+    verdicts = parse_verdicts(comment_bodies)
+    catches = [
+        c
+        for c in (review_catches or [])
+        if c.get("repo") == repo and str(c.get("pr")) == str(number)
+    ]
+
+    pr_had_changes_requested = False
+    if catches:
+        for c in catches:
+            pr_had_changes_requested = True
+            author_sig.must_fix_received += 1
+            requestor = c.get("requestor")
+            if requestor:
+                bucket(requestor).must_fix_caught += 1
+    else:
+        for v in verdicts:
+            if v.changes_requested:
+                pr_had_changes_requested = True
+                author_sig.must_fix_received += 1
+                if v.requestor:
+                    bucket(v.requestor).must_fix_caught += 1
+
+    for v in verdicts:
+        if v.false_positive and v.requestor:
+            bucket(v.requestor).review_false_positives += 1
+
+    if pr_had_changes_requested:
+        author_sig.rework_cycles += 1
+
+
 def extract_signals(
     wave: str,
     status_path: Path | None = None,
@@ -644,39 +821,31 @@ def extract_signals(
     ``Tariq Morales`` in another, and ``Tariq Morales (QA)`` in a third folds to a
     single ledger entry instead of splitting their signals across variants. A
     name absent from the roster passes through unchanged (fail-open).
+
+    Per-PR changes-requested accounting prefers the durable review-catch ledger
+    (:func:`_review_catches_for_wave`, #164) over live comment parsing when the
+    ledger has entries for a PR — see :func:`_account_pr`.
     """
     cfg = cfg or config()
     prs = merged_prs(wave, status_path, label=label, cfg=cfg)
     canon = _canonicalizer(cfg)
+    review_catches = _review_catches_for_wave(wave, status_path)
     signals: dict[str, Signals] = {}
-
-    def _bucket(name: str) -> Signals:
-        return signals.setdefault(canon(name), Signals())
 
     for pr in prs:
         author = pr.get("commit_author_name") or "(unknown)"
         repo = pr["repo"]
         number = pr["number"]
-
-        author_sig = _bucket(author)
-        author_sig.prs_merged += 1
-        author_sig.authored_prs.append(number)
-
-        if _pr_ci_is_red(repo, number):
-            author_sig.ci_red_merges += 1
-
-        verdicts = parse_verdicts(_pr_comment_bodies(repo, number))
-        pr_had_changes_requested = False
-        for v in verdicts:
-            if v.changes_requested:
-                pr_had_changes_requested = True
-                author_sig.must_fix_received += 1
-                if v.requestor:
-                    _bucket(v.requestor).must_fix_caught += 1
-            if v.false_positive and v.requestor:
-                _bucket(v.requestor).review_false_positives += 1
-        if pr_had_changes_requested:
-            author_sig.rework_cycles += 1
+        _account_pr(
+            signals,
+            canon,
+            author=author,
+            repo=repo,
+            number=number,
+            comment_bodies=_pr_comment_bodies(repo, number),
+            ci_red=_pr_ci_is_red(repo, number),
+            review_catches=review_catches,
+        )
 
     return signals
 
@@ -872,6 +1041,26 @@ def _cmd_score(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_record_catch(args: argparse.Namespace) -> int:
+    if args.status is None:
+        print(
+            "ERROR: --status (or configured paths.state_file) is required",
+            file=sys.stderr,
+        )
+        return 2
+    updated = record_review_catch(
+        args.status,
+        args.wave,
+        repo=args.repo,
+        pr=args.pr,
+        requestor=args.requestor,
+        requestee=args.requestee,
+        at=args.at,
+    )
+    print(json.dumps(updated, indent=2, sort_keys=True))
+    return 0
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
@@ -897,6 +1086,34 @@ def _build_parser() -> argparse.ArgumentParser:
     p_score = sub.add_parser("score", help="emit signals + proposed deltas as JSON")
     _add_common(p_score)
     p_score.set_defaults(func=_cmd_score)
+
+    p_catch = sub.add_parser(
+        "record-catch",
+        help="durably record a changes-requested catch at issue time (#164)",
+    )
+    p_catch.add_argument("wave", help="iteration / wave id")
+    p_catch.add_argument("--repo", required=True, help="owner/name")
+    p_catch.add_argument("--pr", required=True, type=int, help="PR number")
+    p_catch.add_argument(
+        "--requestor",
+        required=True,
+        help="reviewer identity, as in the verdict comment's Requestor: field",
+    )
+    p_catch.add_argument(
+        "--requestee",
+        default=None,
+        help="PR-author identity, as in the verdict comment's Requestee: field",
+    )
+    p_catch.add_argument(
+        "--at", default=None, help="ISO-8601 UTC timestamp override (tests)"
+    )
+    p_catch.add_argument(
+        "--status",
+        type=Path,
+        default=_default_status(),
+        help="path to the project state file (default: config paths.state_file)",
+    )
+    p_catch.set_defaults(func=_cmd_record_catch)
     return parser
 
 

--- a/framework/tests/test_trust_signals.py
+++ b/framework/tests/test_trust_signals.py
@@ -719,3 +719,383 @@ def test_base_resolves_phase4_wave1_from_global_wave_2(tmp_path) -> None:
         wave_ordinal=ts._wave_ordinal_for_wave("3", state),
     )
     assert base3 == "deployments/phase4/wave-2"
+
+
+# ===========================================================================
+# Durable review-catch ledger (#164): the charter's amendment convention has a
+# reviewer edit a blocking Must-fix comment IN PLACE to Replied/Must-fix: None
+# once the fix lands. Re-deriving must_fix_caught/must_fix_received purely
+# from the (now-amended) live comment body erases the historic catch and can
+# drop the reviewer out of the engineer map entirely — exactly what happened
+# to Tariq in Phase 6 Wave 6 (see wave_6_counter_corrections in state.json).
+# ===========================================================================
+
+
+# --------------------------------------------------------------- _review_catches_for_wave
+
+
+def test_review_catches_for_wave_missing_file_is_empty(tmp_path) -> None:
+    assert ts._review_catches_for_wave("6", tmp_path / "absent.json") == []
+
+
+def test_review_catches_for_wave_no_status_path_is_empty() -> None:
+    assert ts._review_catches_for_wave("6", None) == []
+
+
+def test_review_catches_for_wave_missing_key_is_empty(tmp_path) -> None:
+    state = tmp_path / "state.json"
+    state.write_text(json.dumps({"wave_6_changes_requested_cycles": 3}))
+    assert ts._review_catches_for_wave("6", state) == []
+
+
+def test_review_catches_for_wave_reads_recorded_entries(tmp_path) -> None:
+    state = tmp_path / "state.json"
+    entries = [
+        {
+            "repo": "acme/proj",
+            "pr": 154,
+            "requestor": "Tariq Morales",
+            "requestee": "Paloma Gupta",
+        }
+    ]
+    state.write_text(json.dumps({"wave_6_review_catches": entries}))
+    assert ts._review_catches_for_wave("6", state) == entries
+
+
+# --------------------------------------------------------------- record_review_catch
+
+
+def test_record_review_catch_appends_and_persists_to_disk(tmp_path) -> None:
+    state = tmp_path / "state.json"
+    # The real state file is always written one-key-per-line (see lifecycle's
+    # _initial_text / upsert_status_keys' compact-inline shape) — mirror that
+    # here since record_review_catch's write path (lifecycle.persist) upserts
+    # text-level and expects that shape, not a single-line json.dumps blob.
+    state.write_text(json.dumps({"wave_6_active": True}, indent=2) + "\n")
+
+    updated = ts.record_review_catch(
+        state,
+        "6",
+        repo="acme/proj",
+        pr=154,
+        requestor="Tariq Morales",
+        requestee="Paloma Gupta",
+        at="2026-07-06T00:00:00Z",
+    )
+    expected = [
+        {
+            "repo": "acme/proj",
+            "pr": 154,
+            "requestor": "Tariq Morales",
+            "requestee": "Paloma Gupta",
+            "recorded_at": "2026-07-06T00:00:00Z",
+        }
+    ]
+    assert updated == expected
+
+    # Round-trips through disk and preserves the pre-existing key untouched.
+    on_disk = json.loads(state.read_text())
+    assert on_disk["wave_6_active"] is True
+    assert on_disk["wave_6_review_catches"] == expected
+
+
+def test_record_review_catch_accumulates_across_calls_not_deduplicated(tmp_path) -> None:
+    # Each call is one catch event — repeated must-fix rounds on the same PR
+    # by the same reviewer are distinct cycles, never collapsed.
+    state = tmp_path / "state.json"
+    state.write_text(json.dumps({}))
+    ts.record_review_catch(
+        state, "6", repo="acme/proj", pr=154, requestor="Tariq Morales",
+        requestee="Paloma Gupta", at="t1",
+    )
+    updated = ts.record_review_catch(
+        state, "6", repo="acme/proj", pr=156, requestor="Tariq Morales",
+        requestee="Ibrahim El-Amin", at="t2",
+    )
+    assert [c["pr"] for c in updated] == [154, 156]
+    assert ts._review_catches_for_wave("6", state) == updated
+
+
+def test_record_review_catch_seeds_empty_state_file(tmp_path) -> None:
+    state = tmp_path / "state.json"
+    updated = ts.record_review_catch(
+        state, "6", repo="acme/proj", pr=154, requestor="Tariq Morales",
+        requestee="Paloma Gupta", at="2026-07-06T00:00:00Z",
+    )
+    assert json.loads(state.read_text())["wave_6_review_catches"] == updated
+
+
+# --------------------------------------------------------------- _account_pr ledger-authoritative accounting
+
+# The exact shape from the Wave 6 defect: Tariq's blocking review, later
+# amended IN PLACE (same comment) to Replied/Must-fix: None once Paloma's fix
+# landed. Live parsing alone now reads this PR as clean.
+_AMENDED_CLEAN_BODY = """Requestor: Tariq Morales (QA)
+Requestee: Paloma Gupta
+RequestOrReplied: Replied
+
+Fix confirmed — all resolved.
+
+Must-fix: None
+"""
+
+# The same PR's review BEFORE the amendment — still live/pending.
+_LIVE_PENDING_BODY = """Requestor: Tariq Morales
+Requestee: Paloma Gupta
+RequestOrReplied: Request
+
+Must-fix:
+1. still needs a fix
+"""
+
+
+def test_account_pr_ledger_authoritative_over_amended_comment() -> None:
+    # THE #164 fix, isolated: a ledger entry recorded at issue time still
+    # produces the catch even though the live comment now reads clean.
+    signals: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        signals,
+        lambda n: n,
+        author="Paloma Gupta",
+        repo="acme/proj",
+        number=154,
+        comment_bodies=[_AMENDED_CLEAN_BODY],
+        ci_red=False,
+        review_catches=[
+            {
+                "repo": "acme/proj",
+                "pr": 154,
+                "requestor": "Tariq Morales",
+                "requestee": "Paloma Gupta",
+            }
+        ],
+    )
+    assert signals["Paloma Gupta"].must_fix_received == 1
+    assert signals["Paloma Gupta"].rework_cycles == 1
+    assert signals["Tariq Morales"].must_fix_caught == 1
+
+
+def test_account_pr_without_ledger_reproduces_the_164_defect() -> None:
+    # Documents the PRE-fix behavior directly: an EMPTY ledger (a wave that
+    # never called record_review_catch) falls back to live-comment parsing,
+    # so the amended body reads as fully clean and the reviewer never
+    # appears — exactly the bug #164 reported.
+    signals: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        signals,
+        lambda n: n,
+        author="Paloma Gupta",
+        repo="acme/proj",
+        number=154,
+        comment_bodies=[_AMENDED_CLEAN_BODY],
+        ci_red=False,
+        review_catches=[],
+    )
+    assert signals["Paloma Gupta"].must_fix_received == 0
+    assert "Tariq Morales (QA)" not in signals
+
+
+def test_account_pr_ledger_present_does_not_double_count_still_pending_review() -> None:
+    # A ledger entry recorded at issue time plus a STILL-LIVE (not yet
+    # amended) Must-fix comment for the same PR must count as ONE catch, not
+    # two — the ledger supersedes live parsing entirely for a PR it covers.
+    signals: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        signals,
+        lambda n: n,
+        author="Paloma Gupta",
+        repo="acme/proj",
+        number=154,
+        comment_bodies=[_LIVE_PENDING_BODY],
+        ci_red=False,
+        review_catches=[
+            {
+                "repo": "acme/proj",
+                "pr": 154,
+                "requestor": "Tariq Morales",
+                "requestee": "Paloma Gupta",
+            }
+        ],
+    )
+    assert signals["Paloma Gupta"].must_fix_received == 1
+    assert signals["Tariq Morales"].must_fix_caught == 1
+
+
+def test_account_pr_ledger_scoped_to_matching_repo_and_pr_only() -> None:
+    # A ledger entry for a DIFFERENT PR must not leak into this one's
+    # accounting — the filter is (repo, pr)-scoped.
+    signals: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        signals,
+        lambda n: n,
+        author="Paloma Gupta",
+        repo="acme/proj",
+        number=154,
+        comment_bodies=[_AMENDED_CLEAN_BODY],
+        ci_red=False,
+        review_catches=[
+            {
+                "repo": "acme/proj",
+                "pr": 999,
+                "requestor": "Tariq Morales",
+                "requestee": "Someone Else",
+            }
+        ],
+    )
+    assert signals["Paloma Gupta"].must_fix_received == 0
+
+
+# --------------------------------------------------------------- extract_signals end-to-end (load-bearing)
+
+
+def test_extract_signals_amend_in_place_does_not_erase_catch(tmp_path, monkeypatch) -> None:
+    """LOAD-BEARING: end to end through the real extract_signals entrypoint
+    (the CLI's extract/score subcommands call exactly this). A reviewer amends
+    their blocking verdict comment in place after the fix lands — the charter
+    convention — so gh now serves only the clean, amended body. Without the
+    #164 fix (revert _account_pr's ledger branch, or pass review_catches=[]
+    from extract_signals) this fails: must_fix_received drops to 0 and
+    "Tariq Morales" never appears in the signals map at all.
+    """
+    state = tmp_path / "state.json"
+    state.write_text(
+        json.dumps(
+            {
+                "wave_6_review_catches": [
+                    {
+                        "repo": "acme/proj",
+                        "pr": 154,
+                        "requestor": "Tariq Morales",
+                        "requestee": "Paloma Gupta",
+                    }
+                ]
+            }
+        )
+    )
+
+    monkeypatch.setattr(
+        ts,
+        "merged_prs",
+        lambda wave, status_path=None, *, label=None, cfg=None: [
+            {"repo": "acme/proj", "number": 154, "commit_author_name": "Paloma Gupta"}
+        ],
+    )
+    monkeypatch.setattr(
+        ts, "_pr_comment_bodies", lambda repo, number: [_AMENDED_CLEAN_BODY]
+    )
+    monkeypatch.setattr(ts, "_pr_ci_is_red", lambda repo, number: False)
+
+    sigs = ts.extract_signals("6", state, cfg=_Cfg({}))
+
+    assert sigs["Paloma Gupta"].must_fix_received == 1
+    assert sigs["Paloma Gupta"].rework_cycles == 1
+    assert sigs["Tariq Morales"].must_fix_caught == 1
+
+
+def test_wave6_fixture_rescoring_with_amended_catches(tmp_path, monkeypatch) -> None:
+    """Reproduces the exact Phase 6 Wave 6 scenario recorded in
+    wave_6_counter_corrections (state.json): PRs #154/#156/#160, all caught by
+    Tariq Morales, all amended in place to Replied/Must-fix: None after their
+    fixes landed. Pre-#164 this recomputed to must_fix_caught=0 for Tariq (he
+    dropped out of the engineer map entirely) and an aggregate
+    changes_requested_cycles of 0 — vs. the wrapup-recorded 3, the exact
+    divergence the state.json note records as a manual correction. With the
+    ledger populated (as record_review_catch would have done at issue time)
+    the scorer now recomputes the true count with no manual correction needed.
+    """
+    state = tmp_path / "state.json"
+    state.write_text(
+        json.dumps(
+            {
+                "wave_6_review_catches": [
+                    {
+                        "repo": "acme/proj",
+                        "pr": 154,
+                        "requestor": "Tariq Morales",
+                        "requestee": "Paloma Gupta",
+                    },
+                    {
+                        "repo": "acme/proj",
+                        "pr": 156,
+                        "requestor": "Tariq Morales",
+                        "requestee": "Ibrahim El-Amin",
+                    },
+                    {
+                        "repo": "acme/proj",
+                        "pr": 160,
+                        "requestor": "Tariq Morales",
+                        "requestee": "Nia Rossi",
+                    },
+                ]
+            }
+        )
+    )
+
+    fake_prs = [
+        {"repo": "acme/proj", "number": 154, "commit_author_name": "Paloma Gupta"},
+        {"repo": "acme/proj", "number": 156, "commit_author_name": "Ibrahim El-Amin"},
+        {"repo": "acme/proj", "number": 160, "commit_author_name": "Nia Rossi"},
+    ]
+    bodies_by_pr = {
+        154: [_AMENDED_CLEAN_BODY],
+        156: [_AMENDED_CLEAN_BODY.replace("Paloma Gupta", "Ibrahim El-Amin")],
+        160: [_AMENDED_CLEAN_BODY.replace("Paloma Gupta", "Nia Rossi")],
+    }
+
+    monkeypatch.setattr(
+        ts, "merged_prs", lambda wave, status_path=None, *, label=None, cfg=None: fake_prs
+    )
+    monkeypatch.setattr(
+        ts, "_pr_comment_bodies", lambda repo, number: bodies_by_pr[number]
+    )
+    monkeypatch.setattr(ts, "_pr_ci_is_red", lambda repo, number: False)
+
+    sigs = ts.extract_signals("6", state, cfg=_Cfg({}))
+
+    assert sigs["Tariq Morales"].must_fix_caught == 3
+    assert sigs["Paloma Gupta"].must_fix_received == 1
+    assert sigs["Ibrahim El-Amin"].must_fix_received == 1
+    assert sigs["Nia Rossi"].must_fix_received == 1
+
+    # Aggregate consistency: the wrapup-recorded changes_requested_cycles (3)
+    # now matches what the scorer recomputes, with no manual correction.
+    aggregate_changes_requested_cycles = sum(s.rework_cycles for s in sigs.values())
+    assert aggregate_changes_requested_cycles == 3
+
+
+# --------------------------------------------------------------- CLI record-catch
+
+
+def test_cli_record_catch_appends_to_state_file(tmp_path) -> None:
+    state = tmp_path / "state.json"
+    state.write_text(json.dumps({}))
+
+    rc = ts.main(
+        [
+            "record-catch",
+            "6",
+            "--repo",
+            "acme/proj",
+            "--pr",
+            "154",
+            "--requestor",
+            "Tariq Morales",
+            "--requestee",
+            "Paloma Gupta",
+            "--at",
+            "2026-07-06T00:00:00Z",
+            "--status",
+            str(state),
+        ]
+    )
+    assert rc == 0
+    on_disk = json.loads(state.read_text())
+    assert on_disk["wave_6_review_catches"] == [
+        {
+            "repo": "acme/proj",
+            "pr": 154,
+            "requestor": "Tariq Morales",
+            "requestee": "Paloma Gupta",
+            "recorded_at": "2026-07-06T00:00:00Z",
+        }
+    ]


### PR DESCRIPTION
## Summary

`trust_signals.extract_signals` used to re-derive `must_fix_caught`/`must_fix_received`
purely by parsing each PR's **current** comment bodies. The charter's amendment convention
has a reviewer edit their blocking `Must-fix` comment **in place** to `Replied`/`Must-fix:
None` once the fix lands, so the historic catch silently vanished — and a reviewer who
authored no PRs of their own dropped out of the engineer map **entirely**. This is exactly
what happened to Tariq in Phase 6 Wave 6 (`wave_6_counter_corrections` in `state.json`):
`must_fix_caught=0`, hand-reconstructed at retro from PR timelines.

## Design decision: option (b) — durable issue-time ledger

Chosen over the two other directions named in #164/#165:
- (a) reading GitHub comment edit-history — rejected: adds a new SCM/API dependency to what
  is currently a pure scorer.
- (c) a distinct `Replied` follow-up instead of amending in place — rejected: changes the
  charter convention, two comments per cycle, and doesn't fix history that's already amended.

**Chosen (b):** `record_review_catch()` durably appends one entry per changes-requested
verdict to `wave_{wave}_review_catches` in the project state file **at issue time** — the
moment the blocking verdict comment is posted, before any later amendment can erase it — via
`lifecycle.persist` (preserves the file's compact-inline shape; validates JSON before/after).

`extract_signals` now reads this ledger (`_review_catches_for_wave`) and, for any PR with
≥1 recorded catch, treats it as **authoritative** for that PR's changes-requested accounting
instead of re-deriving it from the (possibly already-amended) live comment body. A PR with no
ledger entry falls back to the legacy live-comment-parsing path unchanged — every existing
wave/project keeps scoring exactly as before (zero regression risk for waves that never call
the new recorder).

The per-PR accounting loop is extracted out of `extract_signals` into a shared `_account_pr`
helper so `extract_signals` and the tests exercise the identical logic (no drift between what
ships and what's tested). A `record-catch` CLI subcommand is the concrete issue-time call
site (`trust_signals.py record-catch <wave> --repo O/N --pr P --requestor R --requestee E`).

## Files touched
- `framework/assets/lib/trust_signals.py` — `_review_catches_for_wave`, `record_review_catch`,
  `_account_pr` (extracted + ledger-aware), `extract_signals` (wired to the ledger),
  `record-catch` CLI subcommand, updated module docstring.
- `framework/tests/test_trust_signals.py` — 14 new tests (ledger read/write round-trip,
  ledger-authoritative accounting, no-double-count guard, repo/pr-scoping guard, CLI,
  end-to-end `extract_signals` regression, and a synthetic Wave-6 fixture reproducing the
  real #154/#156/#160/Tariq scenario from `wave_6_counter_corrections`).

## Load-bearing test
`test_extract_signals_amend_in_place_does_not_erase_catch` — exercises the real
`extract_signals` entrypoint end to end (the same one `extract`/`score` CLI subcommands call)
against an amended-in-place comment body, with the catch pre-recorded in the ledger.
Verified load-bearing by reverting the fix (forcing `_account_pr`'s ledger-derived `catches`
list to always be `[]`) and re-running: this test **and** its Wave-6-fixture sibling
(`test_wave6_fixture_rescoring_with_amended_catches`) both fail with the exact #164 symptom —
`must_fix_received` drops to 0 and `"Tariq Morales"` `KeyError`s out of the signals map
entirely. Reverted the revert before committing.

## Acceptance criteria
- [x] A wave with N amended must-fix cycles scores `must_fix_caught=N` for the reviewer and
      `must_fix_received` for the authors — proven by the 3-PR Wave-6 fixture.
- [x] The Wave-6 data re-scores correctly as a fixture (`test_wave6_fixture_rescoring_with_amended_catches`).
- [x] Aggregate `changes_requested_cycles` stays consistent — `sum(s.rework_cycles for s in
      sigs.values()) == 3`, matching the wrapup-recorded `wave_6_changes_requested_cycles: 3`.
- [x] Load-bearing (revert→fail) test proving the amend-then-rescore path.

## Dual-deploy (#116)
Not applicable — confirmed `ls .claude/lib` has no runtime copy in this repo; `framework/assets/lib`
is the single canonical location for this module.

## CI
- `ruff check framework/` → all checks passed
- `ENVIRONMENT=test python -m pytest framework/tests/` → 480 passed (was 466; +14 new tests)

Closes #164
