### PR TITLE
process: hard pre-review gate — new behavior needs a load-bearing test (#167)

### DIFF
--- a/.claude/framework.config.json
+++ b/.claude/framework.config.json
@@ -44,6 +44,7 @@
       "validate_labels",
       "validate_review_comment_format",
       "validate_workflow_paths_coverage",
+      "require_load_bearing_test",
       "validate_pr_ci_status",
       "block_squash_wave_merge"
     ],

--- a/.claude/team/charter/hooks.md
+++ b/.claude/team/charter/hooks.md
@@ -6,7 +6,10 @@ hooks, installed under `.claude/hooks/` and wired through dispatchers in
 in `.claude/framework.config.json` name the active modules per event, and each hook
 reads its policy values (owner `parametrization`, default branch `main`,
 reviewer count, identity roster, …) from that same config. All hooks are
-stdlib-only and fail open — a broken hook never blocks unrelated work.
+stdlib-only, and fail open by default — a broken hook never blocks unrelated
+work — with one deliberate exception: `require_load_bearing_test` (see below and
+[pull-requests.md § Pre-Review Self-Check](pull-requests.md)) fails **closed** on
+the review-request path, by owner-approved design (#167).
 
 ## Rule → Enforcement Map
 
@@ -21,6 +24,7 @@ stdlib-only and fail open — a broken hook never blocks unrelated work.
 | Labels must exist ([issues.md](issues.md)) | `validate_labels` | PreToolUse (Bash) | Validates `--label` values before `gh issue create` |
 | Verdict-comment grammar ([issues.md](issues.md)) | `validate_review_comment_format` | PreToolUse (Bash) | Blocks a `gh pr comment` / `gh issue comment` whose body attempts the charter header but is malformed (missing field or unknown `RequestOrReplied` token) — keeps the shape `trust_signals.py` parses reliable (#98) |
 | CI covers what a PR touches ([pull-requests.md](pull-requests.md)) | `validate_workflow_paths_coverage` | PreToolUse (Bash) | Blocks `gh pr create` when changed workflow-relevant paths escape every CI `paths:` filter |
+| New behavior needs a load-bearing test ([pull-requests.md § Pre-Review Self-Check](pull-requests.md)) | `require_load_bearing_test` | PreToolUse (Bash) | **HARD, fail-CLOSED** — blocks `gh pr create`/`gh pr ready` when the diff adds a substantive line to a behavior file with no accompanying test-file change (or when the diff itself can't be verified). Bypass only via a validated `LOAD_BEARING_TEST_EXCEPTION=<class>:<rationale>` naming a class configured under `policy.load_bearing_test_exceptions` (#167) |
 | Push unpiped ([pull-requests.md](pull-requests.md)) | `warn_pipe_mask_rc` | PostToolUse (Bash) | Flags `git push` / `gh pr merge` piped through rc-masking commands |
 | Shell safety | `warn_zsh_wordsplit` | PreToolUse (Bash) | Advisory on bash-isms under zsh (when `shell: zsh`) |
 | Ontology stays fresh | `ontology_tracker` / `ontology_refresh` | PostToolUse / SessionStart | Tracks semantic-overlay drift; regenerates the structural index (inert until an ontology dir exists) |

--- a/.claude/team/charter/pull-requests.md
+++ b/.claude/team/charter/pull-requests.md
@@ -22,6 +22,40 @@ gh pr create --base <integration-branch> --title "<short title>" --body-file /tm
 - Push unpiped — piping `git push` through `tail`/`head` masks a rejected push
   behind the pipe's exit code (flagged — see [hooks.md](hooks.md)).
 
+## Pre-Review Self-Check: Every New Behavior Needs a Load-Bearing Test
+
+**Before requesting review, every new behavior must have a load-bearing test —
+one that FAILS if the behavior it covers is reverted.** A test that passes
+whether or not the behavior exists (tautological, or asserting on a mock instead
+of the real code path) does not satisfy this.
+
+This is a **hard, fail-closed gate** (owner decision, 2026-07-06, #167 — one of
+three Wave-1 retro process proposals, meta #165): all three Wave-1 must-fixes were
+new behavior shipped without a revert→fail test, caught only at QA. The
+`require_load_bearing_test` hook (see [hooks.md](hooks.md)) enforces the
+mechanical precondition at `gh pr create`/`gh pr ready` time — it blocks when the
+diff adds a substantive line to a behavior file with no accompanying test-file
+change in the same diff, and blocks (rather than the usual fail-open posture) when
+the diff itself cannot be verified (network/API failure, unresolvable repo/head).
+
+The hook is a lightweight, deterministic proxy — file-presence plus a substantive
+added line, not a semantic proof. It CANNOT verify that a touched test is actually
+load-bearing for the specific new behavior, or execute a real revert→fail
+simulation. That judgment remains the author's self-check duty before requesting
+review, and QA's review-time verification (see § Review Workflow below) holds the
+same bar the hook only approximates.
+
+**Override:** short of a deliberate, documented exception, this gate cannot be
+bypassed. If a class is configured under `policy.load_bearing_test_exceptions`
+(empty by default — no bypass exists until a repo configures at least one),
+prefix the command:
+
+```bash
+LOAD_BEARING_TEST_EXCEPTION="<class>:<rationale>" gh pr create ...
+```
+
+Every attempt — authorized or not — is logged to the events log for audit.
+
 **PR body template:**
 
 ```markdown

--- a/framework/assets/hooks/_framework_config.py
+++ b/framework/assets/hooks/_framework_config.py
@@ -64,6 +64,10 @@ _DEFAULTS: dict[str, Any] = {
         "reviewers_required": 1,
         "merge_model": "direct-to-main",
         "admin_merge_exceptions": {},
+        # Load-bearing-test pre-review gate (#167): map of <class> -> rationale
+        # naming the only bypass classes require_load_bearing_test.py accepts via
+        # LOAD_BEARING_TEST_EXCEPTION=<class>:<rationale>. Empty = no bypass.
+        "load_bearing_test_exceptions": {},
         # Lifecycle-skill knobs (#86): per-wave tech-debt intake (/plan-phase),
         # phase-exit tech-debt gate (/phase-review), retro counter-drift
         # tolerances (/wave-retro).
@@ -95,6 +99,7 @@ _DEFAULTS: dict[str, Any] = {
             "validate_labels",
             "validate_review_comment_format",
             "validate_workflow_paths_coverage",
+            "require_load_bearing_test",
             "validate_pr_ci_status",
             "block_squash_wave_merge",
         ],

--- a/framework/assets/hooks/require_load_bearing_test.py
+++ b/framework/assets/hooks/require_load_bearing_test.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: HARD pre-review gate — new behavior needs a load-bearing test.
+
+Story: Phase 6 Wave 2 S2, issue #167 (meta #165). All three Wave-1 must-fixes were
+the same failure class: new behavior shipped without a revert->fail (load-bearing)
+test, caught only at QA review. This hook moves that check to the left of review by
+gating the review-request action itself (`gh pr create` / `gh pr ready`).
+
+Fail-CLOSED, by design (contrast with the rest of this repo's hooks)
+=====================================================================
+
+Every other hook in this dispatcher fails OPEN on an infrastructure failure (a
+missing module, a `gh api` timeout, an unresolvable repo) per the framework's
+documented stdlib-only / fail-open philosophy (see `_framework_config.py` and
+`charter/hooks.md`). This gate is the deliberate, owner-approved exception for the
+review-request path (#167): an unverifiable PR diff must not silently pass a check
+whose entire purpose is to stop unverified behavior from reaching review. So:
+
+  - Cannot resolve `--repo` / head branch -> BLOCK (not allow).
+  - `gh api compare` fails (network, auth, rate limit) -> BLOCK (not allow).
+  - Diff shows a "new behavior" file with no accompanying test-file change -> BLOCK.
+
+The only way past any of the three is the documented override (see below) — never
+a silent bypass.
+
+Detection signal (v1 — lightweight, deterministic, NOT semantic)
+==================================================================
+
+This hook cannot literally revert the PR's source and re-run the test suite inside
+a PreToolUse gate (too slow/fragile for a hard interactive gate, and out of scope
+per the story's "keep it lightweight and deterministic" guidance). It instead
+enforces the mechanical PRECONDITION for a load-bearing test to exist at all: if
+the diff (base...head) adds a substantive line to a *behavior* file (a `.py` file
+under one of `_BEHAVIOR_ROOTS`, excluding test files), the SAME diff must also add
+a substantive line to a *test* file. "Substantive" excludes blank lines and
+Python-comment-only lines, so pure formatting/comment churn doesn't count on
+either side of that ledger.
+
+This is a proxy, not a proof: it cannot verify the touched test is actually
+load-bearing (revert->fail) or that it covers the specific new behavior — that
+judgment call remains the author's self-check duty (the story's documented
+pre-review gate, see charter/pull-requests.md) and QA's review-time verification
+(charter/pull-requests.md § Review Workflow). What it DOES mechanically guarantee:
+a PR cannot open review claiming "new behavior, zero test changes" — the single
+failure pattern that produced all three Wave-1 must-fixes.
+
+Out of scope for v1
+====================
+
+- Non-Python behavior surfaces (shell scripts, TS/JS, YAML-driven config) are not
+  scanned — `_is_behavior_path` only recognizes `.py` files under the configured
+  roots. A PR that only changes those is invisible to this gate (same "out of
+  scope" posture as the sibling `validate_workflow_paths_coverage` hook).
+- Does not verify the touched test asserts anything about the touched behavior
+  (no call-graph / coverage correlation) — file presence + a substantive added
+  line is the entire signal.
+- Does not execute a revert->fail simulation. See "Detection signal" above.
+
+Override — deliberate, documented, audited
+============================================
+
+Mirrors the existing `ADMIN_MERGE_EXCEPTION` convention in
+`validate_pr_ci_status.py` exactly, under a distinct env var so the two gates'
+override audiences never collide:
+
+    LOAD_BEARING_TEST_EXCEPTION="<class>:<rationale>" gh pr create ...
+
+`<class>` must be a key in `policy.load_bearing_test_exceptions` (a map of
+class -> human rationale, empty by default — no bypass exists unless a repo
+configures at least one class) and `<rationale>` must be non-empty. An
+unrecognized/missing class, or no exceptions configured at all, blocks — the
+override is validated, not a free escape hatch. Every attempted override (valid
+or not) is logged via `_framework_log.log_pretooluse_block` for the audit trail.
+
+Fires on
+========
+    PreToolUse Bash
+Matches:
+    gh pr create [--repo OWNER/REPO] [--base BASE] [--head BRANCH] [...]
+    gh pr ready [<number>] [--repo OWNER/REPO]
+
+Command-shape detection, `--repo`/`--base`/`--head` extraction, and the compare-API
+fetch shape are reused from the sibling `validate_workflow_paths_coverage` module
+(same command surface, same "PreToolUse Bash / gh pr create|ready" gate) rather
+than re-implemented — `validate_pr_ci_status.py` already establishes this
+cross-hook-module reuse pattern (it imports `_build_coverage_signal` from the same
+module) so the parsing logic has exactly one source of truth.
+
+Exit codes:
+    0 — allow (not a `gh pr create`/`gh pr ready`, no behavior file with a
+        substantive added line in the diff, a test file was touched alongside it,
+        or a validated override was supplied)
+    2 — block (new behavior without an accompanying test-file change, an
+        unverifiable diff, or an invalid/unconfigured override attempt)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _framework_config import config  # noqa: E402
+from _framework_log import log_pretooluse_block  # noqa: E402
+from _shell_parse import resolve_invocation_cwd  # noqa: E402
+from validate_workflow_paths_coverage import (  # noqa: E402
+    _is_gh_pr_gate_command,
+    _resolve_base,
+    _resolve_head,
+    _resolve_repo,
+)
+
+# --- Path classification -----------------------------------------------------
+
+#: Repo-relative path prefixes treated as "behavior" surfaces for this gate's v1
+#: scope. A `.py` file under one of these (and not a test file — see
+#: `_is_test_path`) counts as "new behavior" when it gains a substantive line.
+_BEHAVIOR_ROOTS = (
+    "framework/assets/hooks/",
+    "framework/assets/lib/",
+    "framework/install/",
+    "framework/harness/",
+    "python/src/",
+)
+
+_TEST_DIR_RE = re.compile(r"(?:^|/)tests?/")
+_TEST_BASENAME_RE = re.compile(r"^(test_.+|.+_test)\.py$")
+
+
+def _is_test_path(path: str) -> bool:
+    """True if `path` is a test file: under a `test(s)/` dir, or `test_*.py` /
+    `*_test.py` / `conftest.py` by name — anywhere, not just under a tests dir
+    (mirrors how pytest itself discovers test modules)."""
+    basename = path.rsplit("/", 1)[-1]
+    if basename == "conftest.py":
+        return True
+    if _TEST_BASENAME_RE.match(basename):
+        return True
+    return bool(_TEST_DIR_RE.search(path))
+
+
+def _is_behavior_path(path: str) -> bool:
+    """True if `path` is a `.py` behavior file in scope for this gate (v1)."""
+    if not path.endswith(".py"):
+        return False
+    if _is_test_path(path):
+        return False
+    if path.rsplit("/", 1)[-1] == "__init__.py":
+        return False
+    return any(path.startswith(root) for root in _BEHAVIOR_ROOTS)
+
+
+# --- Diff-substance parsing ---------------------------------------------------
+
+#: A blank line or a Python-comment-only line (v1 scope is Python; see module
+#: docstring). Lines matching this are NOT "substantive" on either side of the
+#: behavior/test ledger — pure formatting/comment churn never trips the gate.
+_TRIVIAL_ADDED_LINE_RE = re.compile(r"^\s*(#.*)?$")
+
+
+def _added_substantive_lines(patch: str | None) -> list[str]:
+    """Return the added (`+`-prefixed) lines of a unified diff `patch` that are
+    NOT blank/comment-only. Empty list for a missing/binary/trivial patch."""
+    if not patch:
+        return []
+    lines: list[str] = []
+    for raw in patch.splitlines():
+        if raw.startswith("+++"):
+            continue
+        if not raw.startswith("+"):
+            continue
+        content = raw[1:]
+        if _TRIVIAL_ADDED_LINE_RE.match(content):
+            continue
+        lines.append(content)
+    return lines
+
+
+def _fetch_compare_files(repo: str, base: str, head: str) -> list[dict] | None:
+    """Return the `.files` array of `gh api repos/{repo}/compare/{base}...{head}`.
+
+    Each entry carries at least `filename`, `status`, and (for text files) `patch`.
+    Returns None on any failure — caller treats that as fail-CLOSED (see module
+    docstring), unlike the sibling coverage hook's fail-open API-failure posture.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{repo}/compare/{base}...{head}", "--jq", ".files"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        data = json.loads(result.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(data, list):
+        return None
+    return data
+
+
+def _scan_diff(files: list[dict]) -> tuple[list[str], bool]:
+    """Return (behavior_files_with_substance, test_file_touched_with_substance)."""
+    behavior_files: list[str] = []
+    test_touched = False
+    for entry in files:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("status") == "removed":
+            continue
+        filename = entry.get("filename", "")
+        if not isinstance(filename, str) or not filename:
+            continue
+        added = _added_substantive_lines(entry.get("patch"))
+        if not added:
+            continue
+        if _is_test_path(filename):
+            test_touched = True
+        elif _is_behavior_path(filename):
+            behavior_files.append(filename)
+    return behavior_files, test_touched
+
+
+# --- Override validation (mirrors ADMIN_MERGE_EXCEPTION in
+#     validate_pr_ci_status.py, under a distinct env var / config key) --------
+
+_OVERRIDE_ENV_VAR = "LOAD_BEARING_TEST_EXCEPTION"
+
+
+def _override_raw(input_data: dict) -> str:
+    raw = (input_data.get("env", {}) or {}).get(_OVERRIDE_ENV_VAR)
+    if raw is None:
+        raw = os.environ.get(_OVERRIDE_ENV_VAR, "")
+    return (raw or "").strip()
+
+
+def _validate_override(input_data: dict) -> bool | None:
+    """Return True (valid), False (attempted but invalid), or None (not attempted)."""
+    raw = _override_raw(input_data)
+    if not raw:
+        return None
+    exceptions = config(input_data).get("policy.load_bearing_test_exceptions", {}) or {}
+    cls, sep, rationale = raw.partition(":")
+    cls, rationale = cls.strip(), rationale.strip()
+    if not exceptions or not sep or cls not in exceptions or not rationale:
+        return False
+    return True
+
+
+def _invalid_override_reason(input_data: dict) -> str:
+    exceptions = config(input_data).get("policy.load_bearing_test_exceptions", {}) or {}
+    valid_list = ", ".join(sorted(exceptions)) if exceptions else "(none configured)"
+    raw = _override_raw(input_data)
+    return (
+        f"BLOCKED: {_OVERRIDE_ENV_VAR} was set but is not a valid override.\n"
+        f'Set {_OVERRIDE_ENV_VAR}="<class>:<rationale>" where <class> is one of: '
+        f"{valid_list}, and <rationale> is a non-empty justification (logged for audit).\n"
+        "With no classes configured under `policy.load_bearing_test_exceptions`, no "
+        "override exists — this gate cannot be bypassed silently.\n"
+        f"Received {_OVERRIDE_ENV_VAR}={raw!r}."
+    )
+
+
+# --- Decision assembly ---------------------------------------------------------
+
+
+def _fail_closed_reason(detail: str) -> str:
+    return (
+        f"BLOCKED (fail-closed): the load-bearing-test pre-review gate could not "
+        f"verify this PR's diff ({detail}).\n\n"
+        "Unlike most hooks in this repo, this gate is intentionally fail-CLOSED "
+        "for the review-request path (S2, #167) — an unverifiable diff must not "
+        "silently pass a check whose entire purpose is to stop unverified new "
+        "behavior from reaching review.\n\n"
+        "Retry once the underlying issue (network / gh auth / rate limit / "
+        "unresolvable --repo or --head) is resolved, or — if you are certain "
+        "every new behavior in this PR has a load-bearing (revert->fail) test — "
+        "use the documented override:\n"
+        f'  {_OVERRIDE_ENV_VAR}="<class>:<rationale>" gh pr create ...\n'
+        "where <class> is a key configured under `policy.load_bearing_test_exceptions`."
+    )
+
+
+def _no_test_reason(behavior_files: list[str], repo: str, base: str, head: str) -> str:
+    files_list = "\n  - ".join(behavior_files)
+    return (
+        f"BLOCKED: this PR ({repo} {base}...{head}) adds new behavior to "
+        f"{len(behavior_files)} file(s) with no accompanying test-file change in "
+        f"the same diff:\n  - {files_list}\n\n"
+        "Pre-review self-check gate (charter/pull-requests.md § Pre-Review "
+        "Self-Check, #167): every new behavior needs a load-bearing (revert->fail) "
+        "test — one that FAILS if the behavior it covers is reverted. All three "
+        "Wave-1 must-fixes were this exact class, caught only at QA; this gate "
+        "moves the check to PR-open time.\n\n"
+        "Add or extend a test that exercises the new behavior, then retry "
+        "`gh pr create`/`gh pr ready`. If this really is test-exempt (e.g. a pure "
+        "refactor with no behavior change — note this v1 gate cannot tell that "
+        "apart from new behavior with a missing test), use the documented "
+        "override:\n"
+        f'  {_OVERRIDE_ENV_VAR}="<class>:<rationale>" gh pr create ...\n'
+        "where <class> is a key configured under `policy.load_bearing_test_exceptions`."
+    )
+
+
+def _blocked_with_override_check(input_data: dict, command: str, reason: str) -> dict:
+    """Apply the override to a would-be block. Every path (authorized override,
+    invalid override, or the original block) is logged for the audit trail."""
+    verdict = _validate_override(input_data)
+    if verdict is True:
+        raw = _override_raw(input_data)
+        log_pretooluse_block(
+            "require_load_bearing_test",
+            command,
+            f"LOAD-BEARING-TEST EXCEPTION AUTHORIZED (audit): {raw}",
+            input_data=input_data,
+        )
+        return {
+            "decision": "allow",
+            "systemMessage": f"Load-bearing-test pre-review gate overridden: {raw}",
+        }
+    if verdict is False:
+        invalid_reason = _invalid_override_reason(input_data)
+        log_pretooluse_block(
+            "require_load_bearing_test", command, invalid_reason, input_data=input_data
+        )
+        return {"decision": "block", "reason": invalid_reason}
+    log_pretooluse_block("require_load_bearing_test", command, reason, input_data=input_data)
+    return {"decision": "block", "reason": reason}
+
+
+def check(input_data: dict) -> dict | None:
+    """Dispatcher-compatible entry. None to allow, dict to block/warn."""
+    tool_name = input_data.get("tool_name", "")
+    if tool_name != "Bash":
+        return None
+    command = input_data.get("tool_input", {}).get("command", "")
+    if not _is_gh_pr_gate_command(command):
+        return None
+
+    cwd = resolve_invocation_cwd(input_data)
+    repo = _resolve_repo(command, cwd=cwd)
+    base = _resolve_base(command)
+    head = _resolve_head(command, cwd=cwd)
+    if not repo or not head:
+        return _blocked_with_override_check(
+            input_data,
+            command,
+            _fail_closed_reason("could not resolve --repo/--head for this command"),
+        )
+
+    files = _fetch_compare_files(repo, base, head)
+    if files is None:
+        return _blocked_with_override_check(
+            input_data,
+            command,
+            _fail_closed_reason(f"`gh api compare {repo} {base}...{head}` failed"),
+        )
+
+    behavior_files, test_touched = _scan_diff(files)
+    if not behavior_files or test_touched:
+        return None
+
+    return _blocked_with_override_check(
+        input_data, command, _no_test_reason(behavior_files, repo, base, head)
+    )
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        sys.exit(0)
+    result = check(input_data)
+    if result is None:
+        sys.exit(0)
+    print(json.dumps(result))
+    if result.get("decision") == "block":
+        sys.exit(2)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/framework/assets/team/charter/hooks.md
+++ b/framework/assets/team/charter/hooks.md
@@ -6,7 +6,10 @@ hooks, installed under `.claude/hooks/` and wired through dispatchers in
 in `.claude/framework.config.json` name the active modules per event, and each hook
 reads its policy values (owner `{{owner}}`, default branch `{{default_branch}}`,
 reviewer count, identity roster, …) from that same config. All hooks are
-stdlib-only and fail open — a broken hook never blocks unrelated work.
+stdlib-only, and fail open by default — a broken hook never blocks unrelated
+work — with one deliberate exception: `require_load_bearing_test` (see below and
+[pull-requests.md § Pre-Review Self-Check](pull-requests.md)) fails **closed** on
+the review-request path, by owner-approved design (#167).
 
 ## Rule → Enforcement Map
 
@@ -21,6 +24,7 @@ stdlib-only and fail open — a broken hook never blocks unrelated work.
 | Labels must exist ([issues.md](issues.md)) | `validate_labels` | PreToolUse (Bash) | Validates `--label` values before `gh issue create` |
 | Verdict-comment grammar ([issues.md](issues.md)) | `validate_review_comment_format` | PreToolUse (Bash) | Blocks a `gh pr comment` / `gh issue comment` whose body attempts the charter header but is malformed (missing field or unknown `RequestOrReplied` token) — keeps the shape `trust_signals.py` parses reliable (#98) |
 | CI covers what a PR touches ([pull-requests.md](pull-requests.md)) | `validate_workflow_paths_coverage` | PreToolUse (Bash) | Blocks `gh pr create` when changed workflow-relevant paths escape every CI `paths:` filter |
+| New behavior needs a load-bearing test ([pull-requests.md § Pre-Review Self-Check](pull-requests.md)) | `require_load_bearing_test` | PreToolUse (Bash) | **HARD, fail-CLOSED** — blocks `gh pr create`/`gh pr ready` when the diff adds a substantive line to a behavior file with no accompanying test-file change (or when the diff itself can't be verified). Bypass only via a validated `LOAD_BEARING_TEST_EXCEPTION=<class>:<rationale>` naming a class configured under `policy.load_bearing_test_exceptions` (#167) |
 | Push unpiped ([pull-requests.md](pull-requests.md)) | `warn_pipe_mask_rc` | PostToolUse (Bash) | Flags `git push` / `gh pr merge` piped through rc-masking commands |
 | Shell safety | `warn_zsh_wordsplit` | PreToolUse (Bash) | Advisory on bash-isms under zsh (when `shell: zsh`) |
 | Ontology stays fresh | `ontology_tracker` / `ontology_refresh` | PostToolUse / SessionStart | Tracks semantic-overlay drift; regenerates the structural index (inert until an ontology dir exists) |

--- a/framework/assets/team/charter/pull-requests.md
+++ b/framework/assets/team/charter/pull-requests.md
@@ -22,6 +22,40 @@ gh pr create --base <integration-branch> --title "<short title>" --body-file /tm
 - Push unpiped — piping `git push` through `tail`/`head` masks a rejected push
   behind the pipe's exit code (flagged — see [hooks.md](hooks.md)).
 
+## Pre-Review Self-Check: Every New Behavior Needs a Load-Bearing Test
+
+**Before requesting review, every new behavior must have a load-bearing test —
+one that FAILS if the behavior it covers is reverted.** A test that passes
+whether or not the behavior exists (tautological, or asserting on a mock instead
+of the real code path) does not satisfy this.
+
+This is a **hard, fail-closed gate** (owner decision, 2026-07-06, #167 — one of
+three Wave-1 retro process proposals, meta #165): all three Wave-1 must-fixes were
+new behavior shipped without a revert→fail test, caught only at QA. The
+`require_load_bearing_test` hook (see [hooks.md](hooks.md)) enforces the
+mechanical precondition at `gh pr create`/`gh pr ready` time — it blocks when the
+diff adds a substantive line to a behavior file with no accompanying test-file
+change in the same diff, and blocks (rather than the usual fail-open posture) when
+the diff itself cannot be verified (network/API failure, unresolvable repo/head).
+
+The hook is a lightweight, deterministic proxy — file-presence plus a substantive
+added line, not a semantic proof. It CANNOT verify that a touched test is actually
+load-bearing for the specific new behavior, or execute a real revert→fail
+simulation. That judgment remains the author's self-check duty before requesting
+review, and QA's review-time verification (see § Review Workflow below) holds the
+same bar the hook only approximates.
+
+**Override:** short of a deliberate, documented exception, this gate cannot be
+bypassed. If a class is configured under `policy.load_bearing_test_exceptions`
+(empty by default — no bypass exists until a repo configures at least one),
+prefix the command:
+
+```bash
+LOAD_BEARING_TEST_EXCEPTION="<class>:<rationale>" gh pr create ...
+```
+
+Every attempt — authorized or not — is logged to the events log for audit.
+
 **PR body template:**
 
 ```markdown

--- a/framework/config/framework.config.example.json
+++ b/framework/config/framework.config.example.json
@@ -38,6 +38,7 @@
       "wave-merge": "the wave->main wrapup merge (orchestrator-merged)",
       "emergency": "[EMERGENCY]-prefixed restore work"
     },
+    "load_bearing_test_exceptions": {},
     "tech_debt_intake_pct": 20,
     "tech_debt_exit_ratio_pct": 10,
     "retro_counter_drift_abs": 2,
@@ -66,6 +67,7 @@
       "validate_labels",
       "validate_review_comment_format",
       "validate_workflow_paths_coverage",
+      "require_load_bearing_test",
       "validate_pr_ci_status",
       "block_squash_wave_merge"
     ],

--- a/framework/config/framework.config.schema.json
+++ b/framework/config/framework.config.schema.json
@@ -107,6 +107,12 @@
           "default": {},
           "description": "Map of <class> -> <human rationale> naming the only admin-merge bypass classes the CI gate accepts via ADMIN_MERGE_EXCEPTION=<class>:<rationale>. Empty = no admin bypass allowed."
         },
+        "load_bearing_test_exceptions": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "default": {},
+          "description": "Map of <class> -> <human rationale> naming the only bypass classes the load-bearing-test pre-review gate (require_load_bearing_test.py, #167) accepts via LOAD_BEARING_TEST_EXCEPTION=<class>:<rationale> on `gh pr create`/`gh pr ready`. Empty = no bypass allowed (the gate is a hard, unconditional block until a class is configured)."
+        },
         "tech_debt_intake_pct": {
           "type": "integer",
           "default": 20,
@@ -172,7 +178,7 @@
         "pre_bash": {
           "type": "array",
           "items": { "type": "string" },
-          "default": ["block_no_verify", "block_git_config", "no_worktree_self_delete", "warn_zsh_wordsplit", "validate_labels", "validate_review_comment_format", "validate_workflow_paths_coverage", "validate_pr_ci_status", "block_squash_wave_merge"],
+          "default": ["block_no_verify", "block_git_config", "no_worktree_self_delete", "warn_zsh_wordsplit", "validate_labels", "validate_review_comment_format", "validate_workflow_paths_coverage", "require_load_bearing_test", "validate_pr_ci_status", "block_squash_wave_merge"],
           "description": "Ordered PreToolUse/Bash checks. Cheap/local first, network-calling (gh) last. First block wins."
         },
         "post_bash": {

--- a/framework/install/bootstrap.py
+++ b/framework/install/bootstrap.py
@@ -135,6 +135,7 @@ def _schema_defaults() -> dict:
                 "validate_labels",
                 "validate_review_comment_format",
                 "validate_workflow_paths_coverage",
+                "require_load_bearing_test",
                 "validate_pr_ci_status",
                 "block_squash_wave_merge",
             ],

--- a/framework/tests/test_require_load_bearing_test.py
+++ b/framework/tests/test_require_load_bearing_test.py
@@ -1,0 +1,264 @@
+"""Tests for require_load_bearing_test — the S2 (#167) hard pre-review gate.
+
+Exercised entirely via check() with `_fetch_compare_files` monkeypatched (no
+network) and an injected config (tmp_path/.claude/framework.config.json) for the
+override tests. `--repo`/`--head` are passed explicitly on the command so repo/head
+resolution never shells out to git. Stdlib + pytest only.
+
+The load-bearing (revert->fail) property for this suite: `test_blocks_new_behavior_
+without_test_file` and `test_blocks_when_diff_unverifiable` fail if the core
+`check()` gate in require_load_bearing_test.py is neutered to always return None
+(verified manually during development — see PR description for the revert
+transcript). They are NOT tautological: each asserts a specific `"block"` decision
+with reason content tied to the exact code path under test, not merely "no
+exception raised".
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_FRAMEWORK_ROOT / "assets" / "hooks"))
+
+import _framework_config  # noqa: E402
+import require_load_bearing_test as rlbt  # noqa: E402
+
+
+def _bash(command: str, *, cwd: str | None = None, env: dict | None = None) -> dict:
+    d: dict = {"tool_name": "Bash", "tool_input": {"command": command}}
+    if cwd is not None:
+        d["cwd"] = cwd
+    if env is not None:
+        d["env"] = env
+    return d
+
+
+def _write_config(tmp: Path, *, exceptions: dict | None = None) -> None:
+    claude = tmp / ".claude"
+    claude.mkdir(parents=True, exist_ok=True)
+    (claude / "framework.config.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "scm": {"provider": "github", "owner": "acme"},
+                "policy": {"load_bearing_test_exceptions": exceptions or {}},
+            }
+        )
+    )
+    _framework_config.clear_cache()
+
+
+_CREATE_CMD = 'gh pr create --repo acme/demo --base main --head feat --title x --body y'
+
+
+def _fake_files(entries: list[dict]):
+    return lambda repo, base, head: entries
+
+
+def _behavior_entry(patch: str, filename: str = "framework/assets/hooks/foo.py") -> dict:
+    return {"filename": filename, "status": "modified", "patch": patch}
+
+
+def _test_entry(patch: str, filename: str = "framework/tests/test_foo.py") -> dict:
+    return {"filename": filename, "status": "modified", "patch": patch}
+
+
+_SUBSTANTIVE_PATCH = "@@ -1,2 +1,3 @@\n line1\n+def new_behavior():\n+    return 42\n"
+_TRIVIAL_PATCH = "@@ -1,1 +1,3 @@\n line1\n+   \n+# just a comment\n"
+
+
+# --------------------------------------------------------------- command matching
+
+
+def test_non_gh_pr_create_ignored(monkeypatch) -> None:
+    monkeypatch.setattr(rlbt, "_fetch_compare_files", _fake_files([_behavior_entry(_SUBSTANTIVE_PATCH)]))
+    assert rlbt.check(_bash("gh pr list")) is None
+    assert rlbt.check(_bash("gh pr view 5")) is None
+    assert rlbt.check(_bash("git push origin feat")) is None
+
+
+# --------------------------------------------------------------- core diff-substance gate
+
+
+def test_no_behavior_file_allows(monkeypatch) -> None:
+    monkeypatch.setattr(
+        rlbt, "_fetch_compare_files", _fake_files([{"filename": "README.md", "status": "modified", "patch": "@@ -1 +1,2 @@\n-old\n+new\n"}])
+    )
+    assert rlbt.check(_bash(_CREATE_CMD)) is None
+
+
+def test_blocks_new_behavior_without_test_file(monkeypatch) -> None:
+    """The core gate: new behavior, zero test-file changes -> hard block."""
+    monkeypatch.setattr(rlbt, "_fetch_compare_files", _fake_files([_behavior_entry(_SUBSTANTIVE_PATCH)]))
+    r = rlbt.check(_bash(_CREATE_CMD))
+    assert r is not None
+    assert r["decision"] == "block"
+    assert "framework/assets/hooks/foo.py" in r["reason"]
+    assert "load-bearing" in r["reason"].lower()
+
+
+def test_allows_when_test_file_touched_alongside(monkeypatch) -> None:
+    monkeypatch.setattr(
+        rlbt,
+        "_fetch_compare_files",
+        _fake_files([_behavior_entry(_SUBSTANTIVE_PATCH), _test_entry(_SUBSTANTIVE_PATCH)]),
+    )
+    assert rlbt.check(_bash(_CREATE_CMD)) is None
+
+
+def test_trivial_behavior_patch_does_not_trip_gate(monkeypatch) -> None:
+    """A behavior file with only blank/comment added lines is not 'new behavior'."""
+    monkeypatch.setattr(rlbt, "_fetch_compare_files", _fake_files([_behavior_entry(_TRIVIAL_PATCH)]))
+    assert rlbt.check(_bash(_CREATE_CMD)) is None
+
+
+def test_trivial_test_patch_does_not_satisfy_gate(monkeypatch) -> None:
+    """A test file touched with only blank/comment lines does not count as 'test touched'."""
+    monkeypatch.setattr(
+        rlbt,
+        "_fetch_compare_files",
+        _fake_files([_behavior_entry(_SUBSTANTIVE_PATCH), _test_entry(_TRIVIAL_PATCH)]),
+    )
+    r = rlbt.check(_bash(_CREATE_CMD))
+    assert r is not None and r["decision"] == "block"
+
+
+def test_removed_file_ignored(monkeypatch) -> None:
+    monkeypatch.setattr(
+        rlbt,
+        "_fetch_compare_files",
+        _fake_files([{"filename": "framework/assets/hooks/foo.py", "status": "removed", "patch": _SUBSTANTIVE_PATCH}]),
+    )
+    assert rlbt.check(_bash(_CREATE_CMD)) is None
+
+
+def test_non_python_and_out_of_scope_paths_ignored(monkeypatch) -> None:
+    monkeypatch.setattr(
+        rlbt,
+        "_fetch_compare_files",
+        _fake_files(
+            [
+                {"filename": "framework/assets/hooks/foo.sh", "status": "modified", "patch": _SUBSTANTIVE_PATCH},
+                {"filename": "intake/candidate/foo.py", "status": "modified", "patch": _SUBSTANTIVE_PATCH},
+                {"filename": "framework/assets/hooks/__init__.py", "status": "modified", "patch": _SUBSTANTIVE_PATCH},
+            ]
+        ),
+    )
+    assert rlbt.check(_bash(_CREATE_CMD)) is None
+
+
+def test_conftest_and_test_dir_recognized_as_test(monkeypatch) -> None:
+    monkeypatch.setattr(
+        rlbt,
+        "_fetch_compare_files",
+        _fake_files(
+            [
+                _behavior_entry(_SUBSTANTIVE_PATCH),
+                {"filename": "framework/tests/conftest.py", "status": "modified", "patch": _SUBSTANTIVE_PATCH},
+            ]
+        ),
+    )
+    assert rlbt.check(_bash(_CREATE_CMD)) is None
+
+
+# --------------------------------------------------------------- fail-closed posture
+
+
+def test_blocks_when_repo_unresolvable(tmp_path: Path) -> None:
+    # tmp_path is not a git repo, so --repo-less resolution via `git remote get-url
+    # origin` fails -> repo stays unresolvable -> fail-closed block.
+    r = rlbt.check(_bash("gh pr create --head feat --title x --body y", cwd=str(tmp_path)))
+    assert r is not None and r["decision"] == "block"
+    assert "fail-closed" in r["reason"].lower()
+
+
+def test_blocks_when_diff_unverifiable(monkeypatch) -> None:
+    monkeypatch.setattr(rlbt, "_fetch_compare_files", lambda repo, base, head: None)
+    r = rlbt.check(_bash(_CREATE_CMD))
+    assert r is not None and r["decision"] == "block"
+    assert "fail-closed" in r["reason"].lower()
+
+
+# --------------------------------------------------------------- override
+
+
+def test_override_valid_class_allows(monkeypatch, tmp_path: Path) -> None:
+    _write_config(tmp_path, exceptions={"tech-debt-cleanup": "pure refactor, no behavior change"})
+    monkeypatch.setattr(rlbt, "_fetch_compare_files", _fake_files([_behavior_entry(_SUBSTANTIVE_PATCH)]))
+    r = rlbt.check(
+        _bash(
+            _CREATE_CMD,
+            cwd=str(tmp_path),
+            env={"LOAD_BEARING_TEST_EXCEPTION": "tech-debt-cleanup:pure refactor, no behavior change"},
+        )
+    )
+    assert r is not None
+    assert r["decision"] == "allow"
+    assert "overridden" in r["systemMessage"].lower()
+    _framework_config.clear_cache()
+
+
+def test_override_unknown_class_blocks(monkeypatch, tmp_path: Path) -> None:
+    _write_config(tmp_path, exceptions={"tech-debt-cleanup": "rationale"})
+    monkeypatch.setattr(rlbt, "_fetch_compare_files", _fake_files([_behavior_entry(_SUBSTANTIVE_PATCH)]))
+    r = rlbt.check(
+        _bash(_CREATE_CMD, cwd=str(tmp_path), env={"LOAD_BEARING_TEST_EXCEPTION": "bogus-class:some reason"})
+    )
+    assert r is not None and r["decision"] == "block"
+    assert "not a valid override" in r["reason"]
+    _framework_config.clear_cache()
+
+
+def test_override_empty_rationale_blocks(monkeypatch, tmp_path: Path) -> None:
+    _write_config(tmp_path, exceptions={"tech-debt-cleanup": "rationale"})
+    monkeypatch.setattr(rlbt, "_fetch_compare_files", _fake_files([_behavior_entry(_SUBSTANTIVE_PATCH)]))
+    r = rlbt.check(
+        _bash(_CREATE_CMD, cwd=str(tmp_path), env={"LOAD_BEARING_TEST_EXCEPTION": "tech-debt-cleanup:"})
+    )
+    assert r is not None and r["decision"] == "block"
+    _framework_config.clear_cache()
+
+
+def test_override_no_exceptions_configured_blocks(monkeypatch, tmp_path: Path) -> None:
+    """Default posture (no config at all): zero classes configured -> no bypass exists."""
+    _write_config(tmp_path, exceptions={})
+    monkeypatch.setattr(rlbt, "_fetch_compare_files", _fake_files([_behavior_entry(_SUBSTANTIVE_PATCH)]))
+    r = rlbt.check(
+        _bash(_CREATE_CMD, cwd=str(tmp_path), env={"LOAD_BEARING_TEST_EXCEPTION": "anything:rationale"})
+    )
+    assert r is not None and r["decision"] == "block"
+    assert "none configured" in r["reason"].lower()
+    _framework_config.clear_cache()
+
+
+# --------------------------------------------------------------- pure helpers
+
+
+def test_is_behavior_path() -> None:
+    assert rlbt._is_behavior_path("framework/assets/hooks/foo.py")
+    assert rlbt._is_behavior_path("python/src/real_team/cli.py")
+    assert not rlbt._is_behavior_path("framework/tests/test_foo.py")
+    assert not rlbt._is_behavior_path("framework/assets/hooks/foo.md")
+    assert not rlbt._is_behavior_path("docs/README.md")
+    assert not rlbt._is_behavior_path("framework/assets/hooks/__init__.py")
+
+
+def test_is_test_path() -> None:
+    assert rlbt._is_test_path("framework/tests/test_foo.py")
+    assert rlbt._is_test_path("python/tests/test_cli.py")
+    assert rlbt._is_test_path("framework/tests/conftest.py")
+    assert rlbt._is_test_path("some/dir/foo_test.py")
+    assert not rlbt._is_test_path("framework/assets/hooks/foo.py")
+
+
+def test_added_substantive_lines() -> None:
+    assert rlbt._added_substantive_lines(_SUBSTANTIVE_PATCH) == [
+        "def new_behavior():",
+        "    return 42",
+    ]
+    assert rlbt._added_substantive_lines(_TRIVIAL_PATCH) == []
+    assert rlbt._added_substantive_lines(None) == []
+    assert rlbt._added_substantive_lines("") == []


### PR DESCRIPTION
## Summary
- New hard, fail-CLOSED PreToolUse hook `require_load_bearing_test` (S2, #167): blocks
  `gh pr create`/`gh pr ready` when the diff adds a substantive line to a "behavior" `.py`
  file with no accompanying test-file change in the same diff, or when the diff itself
  can't be verified (network/API failure, unresolvable `--repo`/`--head`).
- Bypass only via a validated `LOAD_BEARING_TEST_EXCEPTION=<class>:<rationale>` naming a
  class configured under `policy.load_bearing_test_exceptions` (empty by default — no
  bypass exists in this repo until a class is configured), mirroring the existing
  `ADMIN_MERGE_EXCEPTION` convention in `validate_pr_ci_status.py`.
- Wired into all four `hooks.pre_bash` sync points (`framework.config.schema.json`,
  `_framework_config._DEFAULTS`, `bootstrap._schema_defaults()`,
  `framework.config.example.json`) plus this repo's live `.claude/framework.config.json`.
- New charter section `charter/pull-requests.md § Pre-Review Self-Check`, plus a
  `charter/hooks.md` enforcement-map row — canonical (`framework/assets/team/charter/**`)
  and live (`.claude/team/charter/**`) copies both updated (#116).
- Load-bearing test: `framework/tests/test_require_load_bearing_test.py` (18 tests).
  Verified by manually neutering the gate's core conditional
  (`if not behavior_files or test_touched: return None` → `if True: return None`) and
  re-running the suite: 6 tests failed, including the flagship
  `test_blocks_new_behavior_without_test_file` — confirming the tests are load-bearing,
  not tautological. Reverted the neutering before committing.

## Related Issues
Closes #167

## Review Checklist
- [ ] Reviewed by another team member
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)
