### PR TITLE
fix(dispatcher): fail-closed top-level guard around hook check() (#175)

### DIFF
--- a/.claude/team/charter/hooks.md
+++ b/.claude/team/charter/hooks.md
@@ -9,7 +9,12 @@ reviewer count, identity roster, …) from that same config. All hooks are
 stdlib-only, and fail open by default — a broken hook never blocks unrelated
 work — with one deliberate exception: `require_load_bearing_test` (see below and
 [pull-requests.md § Pre-Review Self-Check](pull-requests.md)) fails **closed** on
-the review-request path, by owner-approved design (#167).
+the review-request path, by owner-approved design (#167). "Fail open" is now an
+explicit, per-hook opt-in (`FAIL_OPEN = True`) rather than the dispatcher's
+implicit default: if a hook's `check()` raises an uncaught exception, the
+dispatcher blocks unless that module declared itself fail-open, so a hook that
+forgets to declare (like `require_load_bearing_test`, deliberately) fails closed
+on its own crash too (#175).
 
 ## Rule → Enforcement Map
 

--- a/framework/assets/hooks/block_git_config.py
+++ b/framework/assets/hooks/block_git_config.py
@@ -50,6 +50,11 @@ from _shell_parse import (  # noqa: E402
     tokenize,
 )
 
+#: Declares this hook's fail-direction to the dispatcher (#175): an uncaught
+#: exception from `check()` allows the command, matching this module's
+#: documented "parse failure -> fail open" posture.
+FAIL_OPEN = True
+
 # Config keys the policy actually protects (commit identity). The whole `user.`
 # namespace is treated as identity (user.name / user.email / user.signingkey).
 # Non-identity / operational keys (core.hooksPath, commit.gpgsign, …) are NOT

--- a/framework/assets/hooks/block_no_verify.py
+++ b/framework/assets/hooks/block_no_verify.py
@@ -48,6 +48,11 @@ from _shell_parse import (  # noqa: E402
     tokenize,
 )
 
+#: Declares this hook's fail-direction to the dispatcher (#175): an uncaught
+#: exception from `check()` allows the command, matching this module's
+#: documented "parse failure -> fail open" posture.
+FAIL_OPEN = True
+
 
 def _segment_has_no_verify(segment: list[str]) -> bool:
     """True if a tokenized git commit/push segment carries --no-verify or -n.

--- a/framework/assets/hooks/block_squash_wave_merge.py
+++ b/framework/assets/hooks/block_squash_wave_merge.py
@@ -49,6 +49,11 @@ from _shell_parse import (  # noqa: E402
     walk_flag_values,
 )
 
+#: Declares this hook's fail-direction to the dispatcher (#175): an uncaught
+#: exception from `check()` allows the command, matching this module's
+#: documented "base unresolvable -> fail-open" posture.
+FAIL_OPEN = True
+
 
 def _integration_regex(template: str) -> re.Pattern[str]:
     """Build an anchored regex from a ``branch.integration`` template.

--- a/framework/assets/hooks/dispatcher.py
+++ b/framework/assets/hooks/dispatcher.py
@@ -22,8 +22,27 @@ Exit codes:
   0 — allow (all passed, or aggregated warnings)
   2 — block (first blocking hook wins)
 
-Fail-safe posture: a missing module is skipped; a hook that raises is skipped
-(never let one hook crash the whole gate).
+Fail-safe posture, per hook (#175)
+====================================
+
+A missing/uninstalled module is always skipped (`ImportError` — nothing to run).
+
+A hook whose `check()` raises an uncaught exception is a different story: most
+hooks in this repo are documented fail-open (a matcher that can't parse a
+command should not block the user over its own bug), but at least one —
+`require_load_bearing_test` (#167) — is *deliberately* fail-CLOSED: its entire
+purpose is to stop unverified new behavior from reaching review, so an
+unhandled crash inside it must BLOCK, not silently allow the exact thing it
+exists to catch.
+
+Each hook module declares its fail-direction via a module-level
+``FAIL_OPEN = True`` attribute. A module that sets it is skipped (allow) on a
+crash, exactly like before #175. A module that does NOT set it (the default —
+covers `require_load_bearing_test` and any future hook that forgets to
+declare) is treated as fail-CLOSED: the crash blocks the tool call. This makes
+"fail open on my own bug" an explicit, auditable opt-in per hook rather than
+the dispatcher's implicit default, and means a newly added hook is fail-closed
+until its author consciously decides otherwise.
 """
 
 from __future__ import annotations
@@ -31,6 +50,7 @@ from __future__ import annotations
 import importlib
 import json
 import sys
+import traceback
 from pathlib import Path
 
 _HOOKS_DIR = Path(__file__).resolve().parent
@@ -38,6 +58,7 @@ if str(_HOOKS_DIR) not in sys.path:
     sys.path.insert(0, str(_HOOKS_DIR))
 
 from _framework_config import config  # noqa: E402
+from _framework_log import log_pretooluse_block  # noqa: E402
 
 #: tool_name -> config key holding the ordered module list for that gate.
 #: "Task" is the legacy name of the Agent tool — same gate.
@@ -46,6 +67,17 @@ _TOOL_CONFIG_KEYS = {
     "Agent": "hooks.agent",
     "Task": "hooks.agent",
 }
+
+
+def _crash_reason(module_name: str, exc: Exception) -> str:
+    return (
+        f"BLOCKED (fail-closed): the `{module_name}` hook raised an uncaught "
+        f"{type(exc).__name__} instead of returning a decision. This module is "
+        "not declared fail-open (no `FAIL_OPEN = True`), so the dispatcher "
+        "treats the crash as a block rather than silently allowing the tool "
+        "call (#175). If this hook is meant to fail open on infrastructure "
+        "errors, fix the bug or add `FAIL_OPEN = True` to its module."
+    )
 
 
 def main() -> None:
@@ -71,8 +103,19 @@ def main() -> None:
             continue
         try:
             result = check_fn(input_data)
-        except Exception:
-            continue  # never let a hook crash the gate
+        except Exception as exc:
+            if getattr(mod, "FAIL_OPEN", False):
+                continue  # declared fail-open: never let this hook crash the gate
+            reason = _crash_reason(module_name, exc)
+            log_pretooluse_block(
+                "dispatcher",
+                json.dumps(input_data.get("tool_input", {}))[:200],
+                f"{reason}\n{traceback.format_exc()[-2000:]}",
+                tool_name=input_data.get("tool_name", "Bash"),
+                input_data=input_data,
+            )
+            print(json.dumps({"decision": "block", "reason": reason}))
+            sys.exit(2)
         if result is None:
             continue
         if result.get("decision") == "block":

--- a/framework/assets/hooks/no_worktree_self_delete.py
+++ b/framework/assets/hooks/no_worktree_self_delete.py
@@ -81,6 +81,11 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from _framework_log import log_pretooluse_block  # noqa: E402
 from _shell_parse import resolve_invocation_cwd  # noqa: E402
 
+#: Declares this hook's fail-direction to the dispatcher (#175): an uncaught
+#: exception from `check()` allows the command, matching this module's
+#: documented "any unexpected exception returns None (allow)" posture.
+FAIL_OPEN = True
+
 # Shell operators that separate command segments. We split on these to reach
 # each `git worktree remove` invocation individually.
 _SEGMENT_SPLIT_RE = re.compile(r"&&|\|\||;|\|")

--- a/framework/assets/hooks/require_load_bearing_test.py
+++ b/framework/assets/hooks/require_load_bearing_test.py
@@ -113,6 +113,11 @@ from validate_workflow_paths_coverage import (  # noqa: E402
     _resolve_repo,
 )
 
+# Deliberately NOT declared `FAIL_OPEN = True` (#175): this hook is the repo's
+# documented fail-CLOSED exception (see module docstring), so the dispatcher's
+# default posture for an undeclared/crashing hook — block, not allow — is
+# exactly what this gate needs. Do not add `FAIL_OPEN` here.
+
 # --- Path classification -----------------------------------------------------
 
 #: Repo-relative path prefixes treated as "behavior" surfaces for this gate's v1
@@ -161,10 +166,10 @@ def _is_behavior_path(path: str) -> bool:
 _TRIVIAL_ADDED_LINE_RE = re.compile(r"^\s*(#.*)?$")
 
 
-def _added_substantive_lines(patch: str | None) -> list[str]:
+def _added_substantive_lines(patch: object) -> list[str]:
     """Return the added (`+`-prefixed) lines of a unified diff `patch` that are
-    NOT blank/comment-only. Empty list for a missing/binary/trivial patch."""
-    if not patch:
+    NOT blank/comment-only. Empty list for a missing/binary/trivial/non-str patch."""
+    if not patch or not isinstance(patch, str):
         return []
     lines: list[str] = []
     for raw in patch.splitlines():

--- a/framework/assets/hooks/validate_labels.py
+++ b/framework/assets/hooks/validate_labels.py
@@ -46,6 +46,11 @@ from _shell_parse import (  # noqa: E402
     walk_flag_values,
 )
 
+#: Declares this hook's fail-direction to the dispatcher (#175): an uncaught
+#: exception from `check()` allows the command rather than blocking on the
+#: hook's own bug.
+FAIL_OPEN = True
+
 # Flags whose VALUE is a label (comma-separated allowed by gh).
 _LABEL_FLAGS = {"--label", "-l"}
 

--- a/framework/assets/hooks/validate_pr_ci_status.py
+++ b/framework/assets/hooks/validate_pr_ci_status.py
@@ -70,6 +70,11 @@ from _framework_config import config  # noqa: E402
 from _framework_log import log_pretooluse_block  # noqa: E402
 from _repo_flag_parse import extract_repo  # noqa: E402
 
+#: Declares this hook's fail-direction to the dispatcher (#175): an uncaught
+#: exception from `check()` allows the command rather than blocking on the
+#: hook's own bug.
+FAIL_OPEN = True
+
 # Conclusion values that unambiguously indicate a failed check.
 _FAILURE_CONCLUSIONS = {
     "FAILURE",

--- a/framework/assets/hooks/validate_review_comment_format.py
+++ b/framework/assets/hooks/validate_review_comment_format.py
@@ -113,6 +113,11 @@ from _shell_parse import (  # noqa: E402
     walk_flag_values,
 )
 
+#: Declares this hook's fail-direction to the dispatcher (#175): an uncaught
+#: exception from `check()` allows the command, matching this module's
+#: documented "fail-open posture (matches the dispatcher)".
+FAIL_OPEN = True
+
 # --------------------------------------------------------------------------- #
 # Canonical grammar — the vocabulary #98 aligns against.
 # --------------------------------------------------------------------------- #

--- a/framework/assets/hooks/validate_workflow_paths_coverage.py
+++ b/framework/assets/hooks/validate_workflow_paths_coverage.py
@@ -92,6 +92,11 @@ from _shell_parse import (  # noqa: E402
     tokenize,
 )
 
+#: Declares this hook's fail-direction to the dispatcher (#175): an uncaught
+#: exception from `check()` allows the command, matching this module's
+#: documented "cannot determine -> fail-open" posture.
+FAIL_OPEN = True
+
 # --- Command-shape matchers -------------------------------------------------
 
 _GH_PR_GATE_ACTIONS = {"create", "ready"}

--- a/framework/assets/hooks/warn_zsh_wordsplit.py
+++ b/framework/assets/hooks/warn_zsh_wordsplit.py
@@ -83,6 +83,11 @@ if str(_HOOKS_DIR) not in sys.path:
 from _framework_config import config  # noqa: E402
 from _shell_parse import strip_heredocs  # noqa: E402
 
+#: Declares this hook's fail-direction to the dispatcher (#175): an uncaught
+#: exception from `check()` allows the command (this is a warn-only hook —
+#: it never blocks, so it must never crash-block either).
+FAIL_OPEN = True
+
 # ---------------------------------------------------------------------------
 # Pattern 3: ${!var} / ${!arr[@]} / ${!arr[*]} — bash indirect/keys expansion
 # ---------------------------------------------------------------------------

--- a/framework/assets/team/charter/hooks.md
+++ b/framework/assets/team/charter/hooks.md
@@ -9,7 +9,12 @@ reviewer count, identity roster, …) from that same config. All hooks are
 stdlib-only, and fail open by default — a broken hook never blocks unrelated
 work — with one deliberate exception: `require_load_bearing_test` (see below and
 [pull-requests.md § Pre-Review Self-Check](pull-requests.md)) fails **closed** on
-the review-request path, by owner-approved design (#167).
+the review-request path, by owner-approved design (#167). "Fail open" is now an
+explicit, per-hook opt-in (`FAIL_OPEN = True`) rather than the dispatcher's
+implicit default: if a hook's `check()` raises an uncaught exception, the
+dispatcher blocks unless that module declared itself fail-open, so a hook that
+forgets to declare (like `require_load_bearing_test`, deliberately) fails closed
+on its own crash too (#175).
 
 ## Rule → Enforcement Map
 

--- a/framework/tests/test_agent_stop_dispatch.py
+++ b/framework/tests/test_agent_stop_dispatch.py
@@ -5,8 +5,11 @@ hook modules into the installed ``.claude/hooks/``, points the config's
 ``hooks.agent`` / ``hooks.stop`` lists at them, and fires JSON payloads through
 the INSTALLED dispatchers as subprocesses — asserting PreToolUse semantics for
 Agent (first block wins, exit 2), never-block semantics for Stop (always exit
-0, advisories aggregated, block decisions downgraded), and fail-open behaviour
-for missing/raising modules on both. Stdlib + pytest only.
+0, advisories aggregated, block decisions downgraded), a missing module always
+skipped on both, and (#175) per-hook fail-direction on a raising module: Agent
+gate hooks default to fail-CLOSED unless they declare `FAIL_OPEN = True`,
+while Stop hooks are unconditionally swallowed (Stop never blocks by design,
+so there is no fail-direction to declare). Stdlib + pytest only.
 """
 
 from __future__ import annotations
@@ -53,6 +56,9 @@ def _fire(target: Path, dispatcher: str, payload: dict) -> subprocess.CompletedP
 _BLOCKER = 'def check(input_data):\n    return {"decision": "block", "reason": "agent gate says no"}\n'
 _WARNER = 'def check(input_data):\n    return {"decision": "allow", "systemMessage": "heads up"}\n'
 _RAISER = 'def check(input_data):\n    raise RuntimeError("boom")\n'
+_FAIL_OPEN_RAISER = (
+    'FAIL_OPEN = True\n\ndef check(input_data):\n    raise RuntimeError("boom")\n'
+)
 _STOP_NOTE = 'def check(input_data):\n    return {"systemMessage": "stop note"}\n'
 _STOP_BLOCKER = 'def check(input_data):\n    return {"decision": "block", "reason": "do not stop"}\n'
 
@@ -109,12 +115,27 @@ def test_agent_default_is_empty_and_allows(tmp_path: Path) -> None:
     assert r.stdout.strip() == ""
 
 
-def test_agent_fail_open_on_import_error_and_raise(tmp_path: Path) -> None:
+def test_agent_missing_module_skipped_undeclared_raise_blocks(tmp_path: Path) -> None:
+    """#175: a missing module is still skipped (ImportError, nothing to run), but a
+    raising module with no `FAIL_OPEN = True` declaration now BLOCKS — the dispatcher's
+    default fail-direction for an undeclared/crashing hook flipped from allow to block."""
     _install(tmp_path)
     _write_hook(tmp_path, "agent_raiser", _RAISER)
     _set_hooks(tmp_path, "agent", ["not_installed_module", "agent_raiser"])
     r = _fire(tmp_path, "dispatcher.py", {"tool_name": "Agent", "tool_input": {"prompt": "x"}})
-    assert r.returncode == 0  # missing module skipped; raising module swallowed
+    assert r.returncode == 2
+    assert "agent_raiser" in r.stdout
+    assert "fail-closed" in r.stdout.lower()
+
+
+def test_agent_declared_fail_open_raise_still_allows(tmp_path: Path) -> None:
+    """#175: a hook that explicitly opts in with `FAIL_OPEN = True` keeps the
+    pre-#175 behaviour — a crash inside it is swallowed, not blocked."""
+    _install(tmp_path)
+    _write_hook(tmp_path, "agent_fail_open_raiser", _FAIL_OPEN_RAISER)
+    _set_hooks(tmp_path, "agent", ["not_installed_module", "agent_fail_open_raiser"])
+    r = _fire(tmp_path, "dispatcher.py", {"tool_name": "Agent", "tool_input": {"prompt": "x"}})
+    assert r.returncode == 0  # missing module skipped; declared-fail-open raise swallowed
 
 
 # ------------------------------------------------------------------- Stop event

--- a/framework/tests/test_dispatcher_fail_closed.py
+++ b/framework/tests/test_dispatcher_fail_closed.py
@@ -1,0 +1,146 @@
+"""Tests for the dispatcher's per-hook fail-direction guard (#175).
+
+Before this fix, `dispatcher.py` had no top-level try/except around a hook's
+`check()`: any uncaught exception was silently swallowed and treated as
+ALLOW — the opposite of a fail-closed hook's intent (e.g.
+`require_load_bearing_test`, #167). These tests exercise `dispatcher.main()`
+directly (stdin + config monkeypatched, no subprocess) and assert:
+
+  - A hook that does NOT declare `FAIL_OPEN = True` (the dispatcher's default,
+    and `require_load_bearing_test`'s deliberate posture) BLOCKS the tool call
+    when its `check()` raises. `test_undeclared_hook_crash_blocks` is the
+    load-bearing case: it fails if the fix is reverted back to a bare
+    `except Exception: continue` (verified manually — see PR description).
+  - A hook that DOES declare `FAIL_OPEN = True` still allows the tool call
+    through when its `check()` raises, preserving the pre-#175 behavior for
+    every hook that documents itself as fail-open.
+
+A third test covers the sibling bug in the same issue: `_added_substantive_lines`
+in `require_load_bearing_test.py` crashing on a non-str `patch` value.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_FRAMEWORK_ROOT / "assets" / "hooks"))
+
+import dispatcher  # noqa: E402
+import require_load_bearing_test as rlbt  # noqa: E402
+import validate_labels as vl  # noqa: E402
+
+
+class _FakeCfg:
+    """Minimal stand-in for `_framework_config._Config` — just `.get(key, default)`."""
+
+    def __init__(self, mapping: dict) -> None:
+        self._mapping = mapping
+
+    def get(self, dotted: str, default=None):
+        return self._mapping.get(dotted, default)
+
+
+def _run_dispatcher(monkeypatch, capsys, *, pre_bash: list[str], tool_input: dict):
+    """Drive `dispatcher.main()` for a synthetic Bash call, returning (exit_code, stdout)."""
+    monkeypatch.setattr(
+        dispatcher, "config", lambda input_data=None: _FakeCfg({"hooks.pre_bash": pre_bash})
+    )
+    payload = json.dumps({"tool_name": "Bash", "tool_input": tool_input})
+    monkeypatch.setattr(dispatcher.sys, "stdin", io.StringIO(payload))
+    with pytest.raises(SystemExit) as exc_info:
+        dispatcher.main()
+    out = capsys.readouterr().out
+    return exc_info.value.code, out
+
+
+def test_undeclared_hook_crash_blocks(monkeypatch, capsys) -> None:
+    """Load-bearing: a hook with no FAIL_OPEN declaration that raises must BLOCK.
+
+    require_load_bearing_test is the repo's documented fail-closed hook (#167)
+    and intentionally does not set FAIL_OPEN — this is exactly the gap #175
+    reported: previously this crash would have been swallowed as allow (exit 0).
+    """
+
+    def _boom(_input_data):
+        raise RuntimeError("simulated crash inside a fail-closed hook")
+
+    monkeypatch.setattr(rlbt, "check", _boom)
+    assert getattr(rlbt, "FAIL_OPEN", False) is False  # sanity: not declared fail-open
+
+    code, out = _run_dispatcher(
+        monkeypatch,
+        capsys,
+        pre_bash=["require_load_bearing_test"],
+        tool_input={"command": "gh pr create --repo acme/demo --head feat"},
+    )
+
+    assert code == 2
+    result = json.loads(out)
+    assert result["decision"] == "block"
+    assert "require_load_bearing_test" in result["reason"]
+    assert "fail-closed" in result["reason"].lower()
+
+
+def test_declared_fail_open_hook_crash_still_allows(monkeypatch, capsys) -> None:
+    """A hook that declares FAIL_OPEN = True keeps the pre-#175 behavior: a crash
+    inside it is skipped rather than blocking the tool call."""
+
+    def _boom(_input_data):
+        raise RuntimeError("simulated crash inside a fail-open hook")
+
+    monkeypatch.setattr(vl, "check", _boom)
+    assert getattr(vl, "FAIL_OPEN", False) is True  # sanity: declared fail-open
+
+    code, out = _run_dispatcher(
+        monkeypatch,
+        capsys,
+        pre_bash=["validate_labels"],
+        tool_input={"command": "gh issue create -t x -b y --label bug"},
+    )
+
+    assert code == 0
+    assert out == ""  # no warnings, no block — the crash was swallowed as allow
+
+
+def test_mixed_order_fail_closed_hook_still_blocks_after_fail_open_hook(monkeypatch, capsys) -> None:
+    """A crashing fail-open hook earlier in the list must not short-circuit a
+    later fail-closed hook's normal (non-crash) block decision."""
+    monkeypatch.setattr(vl, "check", lambda _d: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    code, out = _run_dispatcher(
+        monkeypatch,
+        capsys,
+        pre_bash=["validate_labels", "require_load_bearing_test"],
+        # Not a gh pr create/ready command -> require_load_bearing_test.check() returns
+        # None (allow) rather than needing network access; this just proves the loop
+        # continues past the crashed fail-open hook to evaluate the next one at all.
+        tool_input={"command": "echo hi"},
+    )
+
+    assert code == 0
+    assert out == ""
+
+
+# --------------------------------------------------------- non-str patch guard
+
+
+def test_added_substantive_lines_rejects_non_str_patch() -> None:
+    """Load-bearing: a non-str `patch` (e.g. an unexpected JSON shape from the
+    compare API) must not crash `_added_substantive_lines` — it should be
+    treated as "no substantive lines" instead of raising AttributeError on
+    `.splitlines()`. Fails if the `isinstance(patch, str)` guard is reverted."""
+    assert rlbt._added_substantive_lines(None) == []
+    assert rlbt._added_substantive_lines(123) == []
+    assert rlbt._added_substantive_lines(["+not", "+a-string"]) == []
+    assert rlbt._added_substantive_lines({"unexpected": "shape"}) == []
+
+
+def test_added_substantive_lines_still_parses_real_patch() -> None:
+    patch = "@@ -1,2 +1,3 @@\n+import os\n+\n+# just a comment\n"
+    assert rlbt._added_substantive_lines(patch) == ["import os"]


### PR DESCRIPTION
## What

Closes #175. Two related crash-safety gaps in the shared hook plumbing, both flagged in the #172 review:

1. **`dispatcher.py` swallowed any uncaught `check()` exception as ALLOW.** For most hooks (documented fail-open matchers) that's the intended posture — a parse bug shouldn't block the user's unrelated command. But `require_load_bearing_test` (#167) is deliberately **fail-closed**: its whole job is to stop unverified new behavior from reaching review, so a crash inside it must BLOCK, not silently pass the exact thing it exists to catch. Before this PR, a bug in that hook (or any future fail-closed hook) would have been indistinguishable from "everything's fine."
2. **`_added_substantive_lines(patch)`** in `require_load_bearing_test.py` assumed `patch` was a string once truthy, with no `isinstance` guard — an unexpected JSON shape from the compare API (e.g. a non-string `patch` field) would raise `AttributeError` on `.splitlines()`, which (per gap 1) used to be swallowed as allow.

## Design: per-hook fail-direction declaration

There was no existing mechanism for a hook to declare its fail-direction, so this PR adds a minimal one: a module-level **`FAIL_OPEN = True`** attribute.

- **Declared fail-open** (`FAIL_OPEN = True`): a crash in `check()` is skipped exactly as before — the dispatcher moves on to the next hook. Added to the 9 hooks in the default `hooks.pre_bash` list whose docstrings already document a fail-open posture (`block_no_verify`, `block_git_config`, `no_worktree_self_delete`, `warn_zsh_wordsplit`, `validate_labels`, `validate_review_comment_format`, `validate_workflow_paths_coverage`, `validate_pr_ci_status`, `block_squash_wave_merge`) — their existing behavior is unchanged, just now explicit and auditable.
- **Undeclared** (no `FAIL_OPEN` attribute — the default): a crash now **blocks**, with a reason naming the hook and pointing at the fix (either the underlying bug, or add `FAIL_OPEN = True` if the hook really is meant to fail open). `require_load_bearing_test` deliberately does **not** set `FAIL_OPEN` — it's the repo's one fail-closed hook by design (#167), so "default to block" is exactly the behavior it needs, and any *future* hook that forgets to declare a fail-direction is safe-by-default rather than silently fail-open.

This flips the dispatcher's implicit default from "swallow every crash" to "block unless a hook opts into fail-open" — the least invasive change that closes the actual gap (an undeclared/forgotten-to-declare hook is now the safe case, not the dangerous one) while leaving every currently-fail-open hook's behavior bit-for-bit identical (via explicit opt-in).

The crash-block path also logs via `_framework_log.log_pretooluse_block` (audit trail, same as other block decisions) and is suppressed under `ENVIRONMENT=test`/pytest like all other event-log writes.

Scope note: this only touches `dispatcher.py` (the PreToolUse Bash/Agent gate), matching the issue. `start_dispatcher.py` / `post_dispatcher.py` / `stop_dispatcher.py` have their own "always allow, never block" contracts (Stop in particular must never block by design) and are out of scope.

## Testing

- `framework/tests/test_dispatcher_fail_closed.py` (new, 5 tests) drives `dispatcher.main()` in-process:
  - **Load-bearing** `test_undeclared_hook_crash_blocks`: a hook without `FAIL_OPEN` that raises → dispatcher exits 2 with a fail-closed reason naming the hook. Verified this fails (asserts `0 == 2`) when the `except Exception: continue` guard is reverted.
  - `test_declared_fail_open_hook_crash_still_allows`: a `FAIL_OPEN = True` hook that raises → exit 0, nothing printed (pre-#175 behavior preserved).
  - `test_mixed_order_fail_closed_hook_still_blocks_after_fail_open_hook`: a crashing fail-open hook earlier in the list doesn't short-circuit the loop for a later hook.
  - **Load-bearing** `test_added_substantive_lines_rejects_non_str_patch`: `None`/`int`/`list`/`dict` patch values all return `[]` instead of raising. Verified this fails with `AttributeError: 'int' object has no attribute 'splitlines'` when the `isinstance` guard is reverted.
  - `test_added_substantive_lines_still_parses_real_patch`: sanity check the real parsing path is untouched.
- Updated `framework/tests/test_agent_stop_dispatch.py`: the old `test_agent_fail_open_on_import_error_and_raise` asserted the *previous* (now-intentionally-changed) behavior — a raising Agent-gate hook used to be swallowed. Split into `test_agent_missing_module_skipped_undeclared_raise_blocks` (new default: blocks) and `test_agent_declared_fail_open_raise_still_allows` (opt-out preserved), both exercised through the real bootstrap-installed dispatcher via subprocess.
- Also refreshed `charter/hooks.md` (canonical + this repo's rendered copy) to describe the new per-hook `FAIL_OPEN` opt-in instead of "fail open by default" without qualification.

**Test count:** 507 (v0.7.0 baseline) → 513 (+6: 5 new in `test_dispatcher_fail_closed.py`, +1 net in `test_agent_stop_dispatch.py` after the 1-test split into 2).

## Verification

- `ENVIRONMENT=test python -m pytest framework/tests/` → 513 passed
- `ruff check framework/` → all checks passed
- `python3 framework/install/reinstall.py --check` → in sync (hooks/lib run canonical-by-reference in this repo — `.claude/settings.json` points straight at `framework/assets/hooks/*`, so there's no copied `.claude/hooks/` twin to drift for this change)
- `python3 framework/install/manifest.py --check` → in sync (no new installed files)

This satisfies W2-retro proposal #1 (prerequisite to trusting the #167 gate) — `require_load_bearing_test` can now actually be trusted to fail closed end-to-end, including on its own bugs.
