### PR TITLE
feat(promotion): dogfood promotion-audit + settle ledger policy + per-wave audit log (#187)

### DIFF
--- a/.claude/skills/promotion-audit/helpers.py
+++ b/.claude/skills/promotion-audit/helpers.py
@@ -82,6 +82,21 @@ TIER_DECIDE = "DECIDE"
 _MARKER_COMMENT_RE = re.compile(r"<!--\s*Promoted from memory\b.*?-->", re.IGNORECASE | re.DOTALL)
 _PROVENANCE_LABEL_RE = re.compile(r"\*\*Promotion provenance:\*\*")
 
+# Dogfood finding (#187): the charter module that DOCUMENTS this convention
+# (``team/charter/skills.md``) quotes the marker shape verbatim inside fenced
+# ``` examples`` — a bare substring search over its own content therefore
+# false-positives as an AUTO-tier "already promoted" artifact the moment that
+# doc is edited (it is a `team/charter/**` candidate root, so the silent
+# feeder hook records it like any other touched charter module). Fenced code
+# blocks are stripped before matching so an illustrative example never counts
+# as a live marker — only markers in the artifact's real prose do.
+_FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL)
+
+
+def _strip_fenced_code(content: str) -> str:
+    """Drop fenced ``` code blocks so quoted examples never match as markers."""
+    return _FENCED_CODE_RE.sub("", content)
+
 
 # ---------------------------------------------------------------------------
 # Pure classification / rendering core (no I/O)
@@ -89,8 +104,14 @@ _PROVENANCE_LABEL_RE = re.compile(r"\*\*Promotion provenance:\*\*")
 
 
 def has_promotion_markers(content: str) -> bool:
-    """True when *content* carries BOTH halves of the marker convention."""
-    return bool(_MARKER_COMMENT_RE.search(content) and _PROVENANCE_LABEL_RE.search(content))
+    """True when *content* carries BOTH halves of the marker convention.
+
+    Matches are searched OUTSIDE fenced ``` code blocks only (see
+    ``_FENCED_CODE_RE``) — an illustrative example of the marker shape quoted
+    in documentation must never itself read as a completed promotion.
+    """
+    prose = _strip_fenced_code(content)
+    return bool(_MARKER_COMMENT_RE.search(prose) and _PROVENANCE_LABEL_RE.search(prose))
 
 
 def classify_tier(entry: dict, content: str | None) -> str:

--- a/.claude/team/promotion_audit_log/wave_wave-9.md
+++ b/.claude/team/promotion_audit_log/wave_wave-9.md
@@ -1,0 +1,14 @@
+# Promotion Audit — wave wave-9
+
+Generated: 2026-07-06T23:34:34Z
+
+## Auto-promoted (0)
+- (none)
+
+## Filed for decision (3)
+- .claude/memory/MEMORY.md
+- .claude/memory/handoff.md
+- .claude/memory/project_framework_extraction_state.md
+
+## Already decided (0)
+- (none)

--- a/framework/assets/skills/promotion-audit/helpers.py
+++ b/framework/assets/skills/promotion-audit/helpers.py
@@ -82,6 +82,21 @@ TIER_DECIDE = "DECIDE"
 _MARKER_COMMENT_RE = re.compile(r"<!--\s*Promoted from memory\b.*?-->", re.IGNORECASE | re.DOTALL)
 _PROVENANCE_LABEL_RE = re.compile(r"\*\*Promotion provenance:\*\*")
 
+# Dogfood finding (#187): the charter module that DOCUMENTS this convention
+# (``team/charter/skills.md``) quotes the marker shape verbatim inside fenced
+# ``` examples`` — a bare substring search over its own content therefore
+# false-positives as an AUTO-tier "already promoted" artifact the moment that
+# doc is edited (it is a `team/charter/**` candidate root, so the silent
+# feeder hook records it like any other touched charter module). Fenced code
+# blocks are stripped before matching so an illustrative example never counts
+# as a live marker — only markers in the artifact's real prose do.
+_FENCED_CODE_RE = re.compile(r"```.*?```", re.DOTALL)
+
+
+def _strip_fenced_code(content: str) -> str:
+    """Drop fenced ``` code blocks so quoted examples never match as markers."""
+    return _FENCED_CODE_RE.sub("", content)
+
 
 # ---------------------------------------------------------------------------
 # Pure classification / rendering core (no I/O)
@@ -89,8 +104,14 @@ _PROVENANCE_LABEL_RE = re.compile(r"\*\*Promotion provenance:\*\*")
 
 
 def has_promotion_markers(content: str) -> bool:
-    """True when *content* carries BOTH halves of the marker convention."""
-    return bool(_MARKER_COMMENT_RE.search(content) and _PROVENANCE_LABEL_RE.search(content))
+    """True when *content* carries BOTH halves of the marker convention.
+
+    Matches are searched OUTSIDE fenced ``` code blocks only (see
+    ``_FENCED_CODE_RE``) — an illustrative example of the marker shape quoted
+    in documentation must never itself read as a completed promotion.
+    """
+    prose = _strip_fenced_code(content)
+    return bool(_MARKER_COMMENT_RE.search(prose) and _PROVENANCE_LABEL_RE.search(prose))
 
 
 def classify_tier(entry: dict, content: str | None) -> str:

--- a/framework/harness/snapshot.py
+++ b/framework/harness/snapshot.py
@@ -87,6 +87,8 @@ def is_owned(relpath: str) -> bool:
         return True
     if parts[-1].startswith("CLAUDE.md"):
         return True
+    if parts[-1] == ".gitignore":  # #187: installer ensures the ledger-ignore default
+        return True
     if ".git" in parts:  # an installed .git/hooks/pre-push at any depth (meta children)
         i = parts.index(".git")
         return i + 1 < len(parts) and parts[i + 1] == "hooks"

--- a/framework/install/bootstrap.py
+++ b/framework/install/bootstrap.py
@@ -921,6 +921,15 @@ def install_children(
         statuses = {"settings": settings_status, "config": cfg_status, "CLAUDE.md": md_status}
         if pre_push_mode != "none":  # pushes happen FROM the children — same mode as the meta
             statuses["pre-push"] = install_pre_push(child_root, pre_push_mode, ccfg, dry_run=dry_run)
+        # Each selected child is its own git repo (discover_repos scans for a
+        # nested .git) and inherits the parent's hooks.post_file list verbatim,
+        # so it can accumulate its own ledger too — same #187 gitignore default.
+        child_ledger_rel = ccfg.get("paths", {}).get(
+            "generic_prompt_ledger", ".claude/generic_prompt_ledger.json"
+        )
+        statuses["gitignore"] = ensure_gitignore_entries(
+            child_root, (child_ledger_rel,), dry_run=dry_run
+        )
         reports.append((c["path"], c["flavor"], statuses))
     return reports
 
@@ -1009,6 +1018,13 @@ def install_child_mode(args: argparse.Namespace, inst: dict, user_keys: set[str]
     pre_push_mode = install_config.get_key(inst, "pre_push.mode", "noop")
     pre_push_status = install_pre_push(target, pre_push_mode, cfg, dry_run=args.dry_run)
 
+    # A child is its own git repo (see the pre-push comment above) and inherits
+    # the parent's `hooks.post_file` list verbatim — including
+    # `suggest_generic_prompt` — so it can accumulate its OWN ledger. Same #187
+    # gitignore-default dual-deploy as the standalone/meta path.
+    ledger_rel = cfg.get("paths", {}).get("generic_prompt_ledger", ".claude/generic_prompt_ledger.json")
+    gitignore_status = ensure_gitignore_entries(target, (ledger_rel,), dry_run=args.dry_run)
+
     roster_status = "skipped (team disabled)"
     if roster_plan is not None:
         rep = roster_gen.write_roster(target_claude / "team", roster_plan, force=args.force, dry_run=args.dry_run)
@@ -1029,6 +1045,7 @@ def install_child_mode(args: argparse.Namespace, inst: dict, user_keys: set[str]
     print(f"framework.config:  {cfg_status} (project.model=child, parent={rel}, flavor={flavor})")
     print(f"install snapshot:  {snapshot_status}")
     print(f"pre-push hook:     {pre_push_status}")
+    print(f".gitignore:        {gitignore_status}")
     print(f"team roster:       {roster_status}")
     print(f"CLAUDE.md:         {md_status}")
     if roster_plan is not None and not args.no_enforce_identity:
@@ -1161,6 +1178,48 @@ def _git_hooks_dir(target: Path) -> tuple[Path | None, str | None]:
     except OSError:
         pass
     return None, "unrecognised .git layout"
+
+
+#: Header comment stamped once above the installer-managed block, so a re-run
+#: (or a hand-edited .gitignore that already has it) never duplicates it.
+_GITIGNORE_HEADER = "# 2real framework: transient runtime output (installer-managed, #187)"
+
+
+def ensure_gitignore_entries(target: Path, entries: tuple[str, ...], *, dry_run: bool) -> str:
+    """Idempotently append *entries* to the target repo's ``.gitignore``.
+
+    Settles the #187 ledger-policy follow-up: the ``generic_prompt_ledger`` path
+    (a transient per-repo working queue the ``suggest_generic_prompt`` feeder
+    hook writes) is gitignored as a matter of policy — see the ledger's own
+    docstring and ``framework/assets/skills/promotion-audit/SKILL.md``. THIS
+    repo's own ``.gitignore`` carries that entry by hand (precedent:
+    ``.claude-backups/``, ``.claude/framework/`` — also framework-owned runtime
+    output that must never be committed); every OTHER installed repo hit the
+    same untracked-noise surprise with no installer help. This closes that gap.
+
+    Creates ``.gitignore`` if missing. Only entries not ALREADY present as an
+    exact line anywhere in the file are appended (under a stable header,
+    written once) — a hand-authored ``.gitignore`` is never rewritten or
+    reordered, and a re-run adds nothing new. ``dry_run`` reports what would be
+    added without touching the file.
+    """
+    gi_path = target / ".gitignore"
+    existing_lines = gi_path.read_text(encoding="utf-8").splitlines() if gi_path.is_file() else []
+    existing_set = set(existing_lines)
+    missing = [e for e in entries if e not in existing_set]
+    if not missing:
+        return "up to date (0 added)"
+    plural = "y" if len(missing) == 1 else "ies"
+    if dry_run:
+        return f"would add {len(missing)} entr{plural}: {', '.join(missing)}"
+    block: list[str] = []
+    if existing_lines and existing_lines[-1] != "":
+        block.append("")
+    if _GITIGNORE_HEADER not in existing_set:
+        block.append(_GITIGNORE_HEADER)
+    block.extend(missing)
+    gi_path.write_text("\n".join(existing_lines + block) + "\n", encoding="utf-8")
+    return f"added {len(missing)} entr{plural}: {', '.join(missing)}"
 
 
 def install_pre_push(target: Path, mode: str, cfg: dict | None = None, *, dry_run: bool) -> str:
@@ -1443,6 +1502,12 @@ def main() -> int:
     pre_push_mode = install_config.get_key(inst, "pre_push.mode", "noop")
     pre_push_status = install_pre_push(target, pre_push_mode, cfg, dry_run=args.dry_run)
 
+    # Dual-deploy the ledger's gitignore policy (#187): the target's own
+    # .gitignore gets the transient generic-prompt-ledger path so downstream
+    # adopters don't hit the same untracked-noise surprise this repo hit first.
+    ledger_rel = cfg.get("paths", {}).get("generic_prompt_ledger", ".claude/generic_prompt_ledger.json")
+    gitignore_status = ensure_gitignore_entries(target, (ledger_rel,), dry_run=args.dry_run)
+
     # Ontology (seed overlay + generated structural index) is config-driven:
     # the RESOLVED ontology.enabled (flags > user YAML > shipped default ON).
     overlay = None
@@ -1508,6 +1573,7 @@ def main() -> int:
             f"{', '.join(charter['preserved'])}. Use --force to overwrite."
         )
     print(f"pre-push hook:     {pre_push_status}")
+    print(f".gitignore:        {gitignore_status}")
     children = inst.get("children") or []
     if children:
         print(f"children:          {len(children)} recorded ({', '.join(c.get('path', '?') for c in children[:4])}{' …' if len(children) > 4 else ''})")

--- a/framework/tests/test_gitignore_ledger_default.py
+++ b/framework/tests/test_gitignore_ledger_default.py
@@ -1,0 +1,92 @@
+"""Unit tests for ``bootstrap.ensure_gitignore_entries`` (#187).
+
+Settles the generic-prompt-ledger git-tracking policy: the live ledger
+(``.claude/generic_prompt_ledger.json``) is a transient per-repo working queue
+and is gitignored by policy (see ``generic_prompt_tracker.py``'s module
+docstring). This repo's own ``.gitignore`` carried that entry by hand as a
+stopgap (commit ``0873fea``); this dual-deploys the same default into every
+OTHER repo the installer touches, so downstream adopters don't hit the same
+untracked-noise surprise. End-to-end coverage (the entry actually lands in a
+real bootstrap install, standalone/meta/child) lives in
+``test_bootstrap_smoke.py`` / ``test_meta_child_install.py``; this file
+isolates the pure file-mutation logic.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_FRAMEWORK_ROOT / "install"))
+
+import bootstrap  # noqa: E402
+
+LEDGER = ".claude/generic_prompt_ledger.json"
+
+
+def test_creates_gitignore_when_absent(tmp_path: Path) -> None:
+    status = bootstrap.ensure_gitignore_entries(tmp_path, (LEDGER,), dry_run=False)
+    assert "added 1" in status
+    text = (tmp_path / ".gitignore").read_text(encoding="utf-8")
+    assert LEDGER in text.splitlines()
+    assert text.endswith("\n")
+
+
+def test_appends_to_existing_gitignore_without_disturbing_it(tmp_path: Path) -> None:
+    gi = tmp_path / ".gitignore"
+    gi.write_text("node_modules/\n*.pyc\n", encoding="utf-8")
+    bootstrap.ensure_gitignore_entries(tmp_path, (LEDGER,), dry_run=False)
+    lines = gi.read_text(encoding="utf-8").splitlines()
+    assert lines[0] == "node_modules/"
+    assert lines[1] == "*.pyc"
+    assert LEDGER in lines
+
+
+def test_second_call_is_a_no_op_never_duplicates(tmp_path: Path) -> None:
+    bootstrap.ensure_gitignore_entries(tmp_path, (LEDGER,), dry_run=False)
+    first = (tmp_path / ".gitignore").read_text(encoding="utf-8")
+    status = bootstrap.ensure_gitignore_entries(tmp_path, (LEDGER,), dry_run=False)
+    second = (tmp_path / ".gitignore").read_text(encoding="utf-8")
+    assert status == "up to date (0 added)"
+    assert first == second
+    assert first.count(LEDGER) == 1
+    # The header is stamped once even across repeated calls.
+    assert first.count(bootstrap._GITIGNORE_HEADER) == 1
+
+
+def test_entry_already_hand_authored_is_left_alone(tmp_path: Path) -> None:
+    """A repo that already gitignores the ledger by hand (this repo's own
+    stopgap, commit 0873fea) gets no duplicate — the installer defers to
+    whatever is already present."""
+    gi = tmp_path / ".gitignore"
+    gi.write_text(f"# my own notes\n{LEDGER}\n", encoding="utf-8")
+    status = bootstrap.ensure_gitignore_entries(tmp_path, (LEDGER,), dry_run=False)
+    assert status == "up to date (0 added)"
+    assert gi.read_text(encoding="utf-8") == f"# my own notes\n{LEDGER}\n"
+
+
+def test_dry_run_reports_without_writing(tmp_path: Path) -> None:
+    status = bootstrap.ensure_gitignore_entries(tmp_path, (LEDGER,), dry_run=True)
+    assert "would add 1" in status
+    assert LEDGER in status
+    assert not (tmp_path / ".gitignore").exists()
+
+
+def test_dry_run_up_to_date_when_already_present(tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text(f"{LEDGER}\n", encoding="utf-8")
+    status = bootstrap.ensure_gitignore_entries(tmp_path, (LEDGER,), dry_run=True)
+    assert status == "up to date (0 added)"
+
+
+def test_multiple_entries_only_missing_ones_added(tmp_path: Path) -> None:
+    gi = tmp_path / ".gitignore"
+    gi.write_text(f"{LEDGER}\n", encoding="utf-8")
+    status = bootstrap.ensure_gitignore_entries(
+        tmp_path, (LEDGER, ".claude-backups/"), dry_run=False
+    )
+    assert "added 1" in status
+    assert ".claude-backups/" in status
+    lines = gi.read_text(encoding="utf-8").splitlines()
+    assert lines.count(LEDGER) == 1
+    assert ".claude-backups/" in lines

--- a/framework/tests/test_meta_child_install.py
+++ b/framework/tests/test_meta_child_install.py
@@ -143,10 +143,21 @@ class TestMetaInstall:
         assert not (meta / "api" / ".claude" / "hooks").exists()
         assert (meta / ".claude" / "hooks" / "dispatcher.py").is_file()
 
+        # #187: each child is its own git repo and inherits the parent's
+        # hooks.post_file (incl. suggest_generic_prompt) verbatim, so each gets
+        # its OWN gitignore entry for the transient ledger — same as the meta.
+        meta_gitignore = (meta / ".gitignore").read_text(encoding="utf-8")
+        assert ".claude/generic_prompt_ledger.json" in meta_gitignore.splitlines()
+        api_gitignore = (meta / "api" / ".gitignore").read_text(encoding="utf-8")
+        assert ".claude/generic_prompt_ledger.json" in api_gitignore.splitlines()
+        tf_gitignore = (meta / "infra" / "tf" / ".gitignore").read_text(encoding="utf-8")
+        assert ".claude/generic_prompt_ledger.json" in tf_gitignore.splitlines()
+
     def test_e2e_meta_rerun_is_idempotent(self, tmp_path: Path) -> None:
         meta, r1 = self._install_meta(tmp_path)
         assert r1.returncode == 0, r1.stderr or r1.stdout
         before = (meta / "api" / ".claude" / "settings.json").read_text(encoding="utf-8")
+        gitignore_before = (meta / "api" / ".gitignore").read_text(encoding="utf-8")
 
         yaml = tmp_path / "install.yaml"
         r2 = _run(str(meta), "--install-config", str(yaml), "--non-interactive")
@@ -156,6 +167,8 @@ class TestMetaInstall:
         assert "CLAUDE.md up to date" in r2.stdout
         assert (meta / "api" / ".claude" / "settings.json").read_text(encoding="utf-8") == before
         assert not list((meta / "api").glob("CLAUDE.md.bak*"))  # no backup churn
+        # #187: re-run never duplicates the gitignore entry.
+        assert (meta / "api" / ".gitignore").read_text(encoding="utf-8") == gitignore_before
 
     def test_missing_configured_child_is_fatal(self, tmp_path: Path) -> None:
         meta = tmp_path / "meta"
@@ -216,12 +229,16 @@ class TestChildInstall:
         snapshot = json.loads((child / ".claude" / "install.config.json").read_text())
         assert snapshot["project"]["model"] == "child"
         assert snapshot["parent"]["path"] == ".."
+        # #187: a standalone child is its own git repo — gets its own gitignore entry.
+        child_gitignore = (child / ".gitignore").read_text(encoding="utf-8")
+        assert ".claude/generic_prompt_ledger.json" in child_gitignore.splitlines()
 
         # Idempotent re-run.
         r2 = _run(str(child), "--install-config", str(yaml), "--non-interactive")
         assert r2.returncode == 0, r2.stderr or r2.stdout
         assert "already wired" in r2.stdout
         assert "up to date" in r2.stdout
+        assert (child / ".gitignore").read_text(encoding="utf-8") == child_gitignore
 
     def test_child_mode_without_installed_parent_is_fatal(self, tmp_path: Path) -> None:
         parent = tmp_path / "bare-parent"

--- a/framework/tests/test_promotion_audit_helpers.py
+++ b/framework/tests/test_promotion_audit_helpers.py
@@ -42,6 +42,35 @@ def test_has_promotion_markers_requires_both_halves() -> None:
     assert pa.has_promotion_markers("plain content, no markers") is False
 
 
+def test_has_promotion_markers_ignores_fenced_code_examples() -> None:
+    """#187 dogfood finding: a doc ILLUSTRATING the marker convention inside a
+    fenced ``` code block must not itself read as a completed promotion — only
+    a live (unfenced) marker in the artifact's real prose counts."""
+    doc_with_fenced_example = (
+        "# Some charter module\n\n"
+        "Here is what a promoted module looks like:\n\n"
+        "```markdown\n"
+        "<!-- Promoted from memory: reference_widget (#1) -->\n"
+        "**Promotion provenance:** because reasons — promoted 2026-01-01.\n"
+        "```\n\n"
+        "The rest of this doc's own prose has no live marker.\n"
+    )
+    assert pa.has_promotion_markers(doc_with_fenced_example) is False
+    # A live (unfenced) marker elsewhere in the SAME doc still counts.
+    assert pa.has_promotion_markers(doc_with_fenced_example + "\n" + MARKED) is True
+
+
+def test_has_promotion_markers_false_on_real_skills_md_convention_doc() -> None:
+    """Regression pin for the #187 dogfood finding: the actual charter doc that
+    defines the marker convention (`team/charter/skills.md`) quotes the marker
+    shape verbatim in its own "Example" section. Before the fenced-code strip,
+    this doc false-positived as AUTO-tier the moment it was itself edited (it is
+    a `team/charter/**` candidate root the silent feeder hook records)."""
+    skills_md = _FRAMEWORK_ROOT / "assets" / "team" / "charter" / "skills.md"
+    content = skills_md.read_text(encoding="utf-8")
+    assert pa.has_promotion_markers(content) is False
+
+
 # --------------------------------------------------------------- classify_tier
 
 


### PR DESCRIPTION
## Summary

Follow-up to #102-P0 (PR #185, shipped v0.8.0). Two parts, per #187:

**A — Dogfood the `promotion-audit` skill for real** (this is its first live fire; it
had only been unit-tested against hand-built ledgers before).

**B — Settle the `generic_prompt_ledger.json` git-tracking policy** and dual-deploy the
gitignore default into the installer.

## Part A — Dogfood findings

Ran `helpers.py plan` / `run` against this repo's real accumulated ledger (3 pending
memory-file candidates from a prior session's edits: `MEMORY.md`, `handoff.md`,
`project_framework_extraction_state.md`).

- **Classification was correct, not mis-promoted:** all 3 landed in the `decide` tier
  (none auto-flipped to `genericized`) — exactly right, since these are project-local
  memory/state files, not completed promotions. Confirms the feeder hook's indiscriminate
  recording of every touched `.claude/memory/**` file does NOT translate into indiscriminate
  auto-promotion; the marker-convention gate does its job.
- **Bug found and fixed:** `has_promotion_markers()` did a bare substring search over the
  WHOLE file. `team/charter/skills.md` — the doc that *defines* the marker convention —
  quotes the marker shape verbatim inside a fenced ` ``` ` example in its own "Example"
  section. Since `skills.md` is itself a `team/charter/**` candidate root the silent feeder
  hook records like any other touched charter module, editing it would have false-positived
  it as AUTO-tier "already promoted" the moment it's touched — a real mis-promotion risk.
  Fixed by stripping fenced code blocks before matching
  (`framework/assets/skills/promotion-audit/helpers.py`). Added a regression test pinned
  against the ACTUAL `skills.md` content plus a synthetic fenced-example case
  (`test_has_promotion_markers_false_on_real_skills_md_convention_doc`,
  `test_has_promotion_markers_ignores_fenced_code_examples`); confirmed load-bearing
  (revert the fix → both fail).
- **Human call recorded:** all 3 memory candidates decided `skip` (project-local
  state/handoff tracking, not a generic pattern for `framework/assets/**`) — no draft
  issues filed (they'd have been noise). Ledger lifecycle `pending -> decide -> skip
  (done)` re-verified on replan.
- **Determinism re-verified:** `plan_audit` / `render_audit_log` / `render_draft_issue_body`
  produce byte-identical output across repeated calls on the same input (both via the CLI
  and directly against the pure functions).

## Part B — Ledger policy decision

**Decision:** keep the live `.claude/generic_prompt_ledger.json` gitignored (transient
per-repo working queue — already the case here, commit `0873fea`) and rely on the
**committed per-wave audit log** the skill already writes
(`paths.promotion_audit_log/wave_<id>.md`, default `.claude/team/promotion_audit_log/`)
as the durable trail — this wave's log (`wave_wave-9.md`) is included in this PR.

**Dual-deploy:** added `bootstrap.ensure_gitignore_entries()` — idempotent, creates
`.gitignore` if absent, only appends missing entries under a stable header, never
reorders or duplicates. Wired into every install path that can accumulate its own ledger:
the standalone/meta parent, each selected meta child (its own git repo, inherits
`hooks.post_file` verbatim), and the standalone child mode (also its own git repo).
Confirmed this repo's own `.gitignore` entry is already consistent with the new default
(`bootstrap.py . --dry-run` reports `up to date (0 added)`).

Also taught the install-quality harness's `no_unexpected_files` ownership model
(`framework/harness/snapshot.py::is_owned`) about the new `.gitignore` side effect —
a fresh install now legitimately creates one, which the harness's B10/B11/dogfood-parity
cells correctly flagged as "unexpected" until this was added.

## Test plan

- [x] `ENVIRONMENT=test python -m pytest framework/tests/` — 638 passed
- [x] `ruff check framework/` — clean
- [x] `python3 framework/install/reinstall.py --check` — exit 0 (ran a real reinstall
      first to sync the live `.claude/skills/promotion-audit/helpers.py` copy)
- [x] `python3 framework/install/manifest.py --check` — exit 0 (no manifest update
      needed: `.gitignore` is outside `.claude/**`, out of the manifest's contract by design)
- [x] Load-bearing: revert the fenced-code-strip fix → 2 new tests fail;
      revert `ensure_gitignore_entries` → 7 new tests fail with `AttributeError`
- [x] New/updated coverage: `test_promotion_audit_helpers.py` (+2),
      `test_gitignore_ledger_default.py` (new, 7 unit tests),
      `test_meta_child_install.py` (+3 assertions across meta/child/rerun paths)

Closes #187. Applies W3-retro proposal #2 (dogfood `promotion-audit` before trusting its
auto-promotions).
