### PR TITLE
feat(lib): pr_review_state oracle — N-reviewer approval state over parsed verdicts (#194)

### DIFF
--- a/framework/assets/lib/pr_review_state.py
+++ b/framework/assets/lib/pr_review_state.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Config-driven, fail-open N-reviewer approval-state oracle for a PR (#194).
+
+The team's merge gate and trust scorer already agree on ONE review-verdict
+grammar — the charter's ``Requestor:`` / ``Requestee:`` / ``RequestOrReplied:``
+header plus a body ``Must-fix:`` / ``Tech-debt:`` severity split
+(``.claude/team/charter/issues.md``). ``trust_signals.parse_verdicts`` is the
+single parser for that grammar. This oracle does **not** re-implement any of it:
+it consumes already-parsed :class:`trust_signals.Verdict` objects and computes a
+pure state machine over them — the N-of-M approval state of a PR.
+
+Reconcile, don't duplicate
+==========================
+This is deliberately NOT a blind port of another project's ``pr_review_state``
+(which forked its own comment parsing). 2real evolved its own verdict grammar
+and already parses it in one place; re-parsing here would fork that vocabulary
+and let the oracle drift from the gate/scorer. So:
+
+* **Parsing** is ``trust_signals``' job — the thin :func:`review_state` wrapper
+  fetches a PR's comment bodies via ``trust_signals._pr_comment_bodies`` and
+  parses them via ``trust_signals.parse_verdicts``.
+* **The state machine** is this module's job — pure, no I/O, unit-testable on a
+  hand-built ``list[Verdict]`` (:func:`compute_state`).
+
+The amend-in-place convention (a reviewer edits their blocking
+``Request`` / ``Must-fix:`` comment *in place* to ``Replied`` / ``Must-fix:
+None`` once the fix lands — charter Reply Protocol) is handled for free: the
+oracle reads the PR's **current** comment bodies, so an amended-clean verdict
+parses with ``changes_requested=False`` and stops counting as an open must-fix
+(and its author now counts toward approvals).
+
+Reviewer identity
+=================
+Per the charter and ``trust_signals.extract_signals``, the **reviewer** is the
+verdict comment's ``Requestor:`` field (``Requestee:`` is the addressed PR
+author). Approvals are therefore counted over distinct **Requestors** whose
+current verdict is clean (a ``Replied`` / non-``Must-fix`` review), NOT over
+requestees. [PINNED-CONTRACT NOTE #194/#193: the frozen ``ReviewState`` *shape*
+is honored exactly — ``state`` / ``approvals`` (int) / ``reviewers_required``
+(int) / ``unresolved_must_fix`` (list). The contract's descriptive comment said
+"distinct requestees"; the charter grammar makes the reviewer the ``Requestor``
+(a requestee is the single PR author, so counting requestees could never reach a
+2-reviewer bar), so this implementation counts distinct Requestors. Flagged to
+Hiro on #193; the dict shape S2/S3 build against is unchanged.]
+
+Fail-open posture (FAIL_OPEN = True)
+====================================
+This is a lib, not a hook, but it declares the same fail-open intent as the
+Wave-3 dispatcher: an error must NEVER manufacture a false ``"approved"`` and
+never hard-fail the caller.
+
+* ``reviewers_required`` is read from ``policy.reviewers_required`` via the
+  shared config, which fail-opens to its schema default (1) when the config is
+  missing/unreadable; a non-integer/negative value or a config-load exception
+  degrades to :data:`_FAIL_OPEN_REVIEWERS_REQUIRED`.
+* :func:`review_state` catches comment-fetch / parse errors and returns a
+  ``pending`` state (approvals=0, no must-fix) rather than raising or inventing
+  an approval — the safe, non-blocking degradation.
+
+State machine (PINNED CONTRACT — frozen for S2/S3)
+==================================================
+``ReviewState`` is a plain dict::
+
+    {
+      "state": "pending" | "changes_requested" | "approved",
+      "approvals": int,            # distinct reviewers (Requestors) with a
+                                   # current clean/approved verdict
+      "reviewers_required": int,   # policy.reviewers_required (fail-open default)
+      "unresolved_must_fix": list, # one entry per current changes-requested verdict
+    }
+
+    state == "approved"          iff approvals >= reviewers_required
+                                     AND unresolved_must_fix == []
+    state == "changes_requested" iff any current verdict carries an unresolved
+                                     Must-fix (takes precedence over approvals)
+    else                             "pending"
+
+CLI::
+
+    python3 lib/pr_review_state.py <pr_number> --repo <owner/repo> [--json]
+
+Exit codes: 0 approved, 1 not-approved (pending / changes_requested). The I/O
+wrapper itself fail-opens to pending, so a fetch error prints pending / exit 1.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, TypedDict
+
+# trust_signals.py is a same-dir sibling (the canonical lib tree). It carries the
+# single verdict parser (parse_verdicts) and the comment-fetch helper this oracle
+# reuses; it also bridges to _framework_config in the sibling hooks dir. Mirror
+# its own lib->hooks path bridge so this module is importable wherever the
+# framework is deployed (in-place canonical, or a target's .claude/lib).
+_LIB_DIR = Path(__file__).resolve().parent
+_HOOKS_DIR = _LIB_DIR.parent / "hooks"
+sys.path.insert(0, str(_HOOKS_DIR))
+sys.path.insert(0, str(_LIB_DIR))
+
+import trust_signals as ts  # noqa: E402  (single verdict parser — no re-parse here)
+from _framework_config import config  # noqa: E402
+
+#: Fail-open declaration, consistent with the Wave-3 dispatcher convention. An
+#: error must never manufacture a false "approved" nor hard-fail the caller.
+FAIL_OPEN = True
+
+#: Last-resort reviewers-required floor when the config cannot be read at all
+#: (config() itself fail-opens to the schema default of 1, so this only bites on
+#: a raised exception or a malformed value). One reviewer is the least-surprising
+#: non-zero bar; a value of 0 would make an unreviewed PR read "approved".
+_FAIL_OPEN_REVIEWERS_REQUIRED = 1
+
+# The three legal states, exported for callers/tests that assert the vocabulary.
+PENDING = "pending"
+CHANGES_REQUESTED = "changes_requested"
+APPROVED = "approved"
+
+
+class MustFixEntry(TypedDict):
+    """One open (unresolved) blocking verdict, at the granularity of a Verdict."""
+
+    requestor: str | None
+    requestee: str | None
+    verdict: str | None
+
+
+class ReviewState(TypedDict):
+    """The pinned N-reviewer approval state of a PR (frozen shape — S2/S3)."""
+
+    state: str
+    approvals: int
+    reviewers_required: int
+    unresolved_must_fix: list[MustFixEntry]
+
+
+def compute_state(
+    verdicts: list[ts.Verdict], reviewers_required: int
+) -> ReviewState:
+    """Pure N-of-M approval state over already-parsed *verdicts*. No I/O.
+
+    Consumes :class:`trust_signals.Verdict` objects (from
+    ``trust_signals.parse_verdicts``) and applies the pinned state machine:
+
+    * an **unresolved must-fix** is any current verdict with
+      ``changes_requested=True`` (``trust_signals`` resolved the charter's
+      body-severity rule at parse time). One entry per such verdict lands in
+      ``unresolved_must_fix``. If any exist, the state is ``changes_requested``
+      regardless of approval count.
+    * **approvals** = the number of distinct reviewers (the ``Requestor:``
+      identity) who have a current *clean* verdict and who do NOT currently
+      carry an unresolved must-fix. Identities are folded with
+      ``trust_signals._name_key`` so ``Tariq.Morales`` / ``Tariq Morales`` /
+      ``Tariq Morales (QA)`` count once. A reviewer whose blocking comment was
+      amended in place to ``Replied`` now parses clean and counts here.
+    * ``approved`` requires ``approvals >= reviewers_required`` AND no unresolved
+      must-fix; otherwise ``pending``.
+
+    Pure and total: never raises on the parsed input, never does I/O.
+    """
+    unresolved: list[MustFixEntry] = [
+        {
+            "requestor": v.requestor,
+            "requestee": v.requestee,
+            "verdict": v.verdict,
+        }
+        for v in verdicts
+        if v.changes_requested
+    ]
+
+    # A reviewer with any current blocking verdict is not counted as an approver,
+    # even if they also left a separate clean comment — their standing review is
+    # still "changes requested" until they amend it.
+    blocking_reviewers = {
+        ts._name_key(v.requestor)
+        for v in verdicts
+        if v.changes_requested and v.requestor
+    }
+    approvers: set[str] = set()
+    for v in verdicts:
+        if v.changes_requested or not v.requestor:
+            continue
+        key = ts._name_key(v.requestor)
+        if key in blocking_reviewers:
+            continue
+        approvers.add(key)
+    approvals = len(approvers)
+
+    if unresolved:
+        state = CHANGES_REQUESTED
+    elif approvals >= reviewers_required:
+        state = APPROVED
+    else:
+        state = PENDING
+
+    return {
+        "state": state,
+        "approvals": approvals,
+        "reviewers_required": reviewers_required,
+        "unresolved_must_fix": unresolved,
+    }
+
+
+def _reviewers_required(cfg: Any = None) -> int:
+    """``policy.reviewers_required`` from shared config; fail-open.
+
+    ``config()`` already fail-opens to the schema default (1) on a
+    missing/unreadable config. This adds a second guard: a config-load exception
+    or a non-integer/negative value degrades to
+    :data:`_FAIL_OPEN_REVIEWERS_REQUIRED` rather than raising or admitting a
+    bar of 0 (which would read an unreviewed PR as "approved").
+    """
+    try:
+        cfg = cfg if cfg is not None else config()
+        val = cfg.get("policy.reviewers_required", _FAIL_OPEN_REVIEWERS_REQUIRED)
+        n = int(val)
+    except (ValueError, TypeError, OSError, AttributeError):
+        return _FAIL_OPEN_REVIEWERS_REQUIRED
+    return n if n >= 1 else _FAIL_OPEN_REVIEWERS_REQUIRED
+
+
+def review_state(repo: str, pr: int, *, cfg: Any = None) -> ReviewState:
+    """Thin I/O wrapper: fetch a PR's comments, parse them, compute the state.
+
+    Delegates parsing to ``trust_signals.parse_verdicts`` (single verdict
+    grammar) over the comment bodies from ``trust_signals._pr_comment_bodies``,
+    reads ``reviewers_required`` from shared config, and returns the pinned
+    :class:`ReviewState`.
+
+    Fail-open: any comment-fetch / parse error returns a ``pending`` state
+    (approvals=0, no must-fix) rather than raising or inventing an approval — an
+    error must never manufacture a false "approved".
+    """
+    required = _reviewers_required(cfg)
+    try:
+        bodies = ts._pr_comment_bodies(repo, int(pr))
+        verdicts = ts.parse_verdicts(bodies)
+    except Exception:  # noqa: BLE001 — fail-open: degrade to pending, never raise
+        return {
+            "state": PENDING,
+            "approvals": 0,
+            "reviewers_required": required,
+            "unresolved_must_fix": [],
+        }
+    return compute_state(verdicts, required)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _render_text(repo: str, pr: int, state: ReviewState) -> str:
+    lines = [
+        f"PR #{pr} ({repo}) — review state: {state['state'].upper()}",
+        f"  approvals: {state['approvals']}/{state['reviewers_required']} required",
+    ]
+    if state["unresolved_must_fix"]:
+        lines.append(f"  unresolved must-fix verdicts: {len(state['unresolved_must_fix'])}")
+        for mf in state["unresolved_must_fix"]:
+            who = mf.get("requestor") or "(unknown reviewer)"
+            lines.append(f"    - from {who}")
+    else:
+        lines.append("  unresolved must-fix verdicts: none")
+    return "\n".join(lines)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="pr_review_state",
+        description=(
+            "Compute a PR's N-reviewer approval state from the charter verdict "
+            "grammar (parsed by trust_signals). Exit 0 if approved, 1 if not "
+            "(pending / changes_requested)."
+        ),
+    )
+    p.add_argument("pr_number", type=int, help="PR number to query")
+    p.add_argument(
+        "--repo",
+        required=True,
+        help="target repo as OWNER/NAME (e.g. acme/widget)",
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        help="emit machine-readable JSON instead of the text report",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    state = review_state(args.repo, args.pr_number)
+    if args.json:
+        print(json.dumps(state, indent=2, sort_keys=True))
+    else:
+        print(_render_text(args.repo, args.pr_number, state))
+    return 0 if state["state"] == APPROVED else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/framework/install/golden-manifest.json
+++ b/framework/install/golden-manifest.json
@@ -49,6 +49,7 @@
     ".claude/lib/ontology_gen/refresh.py",
     ".claude/lib/ontology_gen/typescript_ext.py",
     ".claude/lib/pr_ci_state.py",
+    ".claude/lib/pr_review_state.py",
     ".claude/lib/roster_consistency_check.py",
     ".claude/lib/roster_union_sync.py",
     ".claude/lib/trust_signals.py",

--- a/framework/tests/test_pr_review_state.py
+++ b/framework/tests/test_pr_review_state.py
@@ -1,0 +1,292 @@
+"""Load-bearing tests for pr_review_state.py — the N-reviewer approval oracle (#194).
+
+The oracle is a PURE state machine (:func:`compute_state`) over already-parsed
+``trust_signals.Verdict`` objects, plus a thin fail-open I/O wrapper
+(:func:`review_state`) that reuses ``trust_signals`` for comment fetch + verdict
+parsing (it does NOT re-implement charter-comment parsing).
+
+These tests are the mutation bar for the transition truth table:
+
+  pending -> changes_requested -> approved,
+  the amend-in-place Request->Replied convention,
+  N-of-M distinct-reviewer approvals,
+  and an unresolved Must-fix blocking "approved" even at N approvals.
+
+Reverting any of the transition logic in ``compute_state`` (drop the
+must-fix-precedence branch, flip ``>=`` to ``>``, stop excluding a
+currently-blocking reviewer, or stop folding distinct reviewer names) makes at
+least one test here fail. Every case builds ``Verdict`` lists directly — no live
+``gh``, no I/O. The two wrapper tests monkeypatch the comment-fetch helper to
+prove the wrapper reuses ``parse_verdicts`` and fail-opens.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Mirror test_trust_signals.py's path bridge: the canonical lib tree plus its
+# sibling hooks dir (the modules bridge to _framework_config at import time).
+_LIB = Path(__file__).resolve().parent.parent / "assets" / "lib"
+_HOOKS = Path(__file__).resolve().parent.parent / "assets" / "hooks"
+sys.path.insert(0, str(_HOOKS))
+sys.path.insert(0, str(_LIB))
+
+import pr_review_state as prs  # noqa: E402
+import trust_signals as ts  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Verdict builders (pure — the state machine's real input shape).
+# ---------------------------------------------------------------------------
+
+
+def _approval(requestor: str, requestee: str = "Paloma.Gupta") -> ts.Verdict:
+    """A clean/approving verdict (``Replied``, no must-fix) by *requestor*."""
+    return ts.Verdict(
+        requestor=requestor,
+        requestee=requestee,
+        verdict="Replied",
+        false_positive=False,
+        changes_requested=False,
+    )
+
+
+def _changes_requested(requestor: str, requestee: str = "Paloma.Gupta") -> ts.Verdict:
+    """A blocking verdict (``Request`` + enumerated must-fix) by *requestor*."""
+    return ts.Verdict(
+        requestor=requestor,
+        requestee=requestee,
+        verdict="Request",
+        false_positive=False,
+        changes_requested=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Transition truth table (pure compute_state).
+# ---------------------------------------------------------------------------
+
+
+def test_pending_when_no_approvals_and_no_must_fix():
+    """No verdicts at all, one reviewer required -> pending (never approved)."""
+    state = prs.compute_state([], reviewers_required=1)
+    assert state["state"] == "pending"
+    assert state["approvals"] == 0
+    assert state["unresolved_must_fix"] == []
+
+
+def test_pending_when_approvals_below_required():
+    """1 distinct approval but 2 required -> pending (the N-of-M lower edge)."""
+    state = prs.compute_state([_approval("Nia.Rossi")], reviewers_required=2)
+    assert state["state"] == "pending"
+    assert state["approvals"] == 1
+
+
+def test_approved_at_exactly_required():
+    """approvals == reviewers_required with no must-fix -> approved (the >= edge).
+
+    Mutation bar: flipping ``approvals >= reviewers_required`` to ``>`` makes
+    this exact-threshold case read pending -> this test fails.
+    """
+    state = prs.compute_state([_approval("Nia.Rossi")], reviewers_required=1)
+    assert state["state"] == "approved"
+    assert state["approvals"] == 1
+
+
+def test_changes_requested_when_any_unresolved_must_fix():
+    """Any current blocking verdict -> changes_requested, and it is enumerated."""
+    verdicts = [_changes_requested("Tariq.Morales")]
+    state = prs.compute_state(verdicts, reviewers_required=1)
+    assert state["state"] == "changes_requested"
+    assert len(state["unresolved_must_fix"]) == 1
+    assert state["unresolved_must_fix"][0]["requestor"] == "Tariq.Morales"
+
+
+def test_unresolved_must_fix_blocks_approved_even_at_n_approvals():
+    """N distinct approvals but one open must-fix -> changes_requested, NOT approved.
+
+    Mutation bar: dropping the ``if unresolved: changes_requested`` precedence
+    branch (letting the approval count win) flips this to approved -> fails.
+    """
+    verdicts = [
+        _approval("Nia.Rossi"),
+        _approval("Ibrahim.El-Amin"),
+        _changes_requested("Tariq.Morales"),
+    ]
+    state = prs.compute_state(verdicts, reviewers_required=2)
+    assert state["approvals"] == 2  # the two clean reviewers still counted
+    assert state["state"] == "changes_requested"
+
+
+# ---------------------------------------------------------------------------
+# N-of-M distinct-reviewer approvals.
+# ---------------------------------------------------------------------------
+
+
+def test_n_of_m_needs_two_distinct_reviewers():
+    """reviewers_required=2 needs 2 DISTINCT reviewers; two comments from one
+    reviewer do not reach the bar.
+
+    Mutation bar: counting raw clean-verdict comments instead of DISTINCT
+    reviewer identities would read this (2 comments, 1 person) as approved ->
+    fails.
+    """
+    one_person_twice = [_approval("Nia.Rossi"), _approval("Nia.Rossi")]
+    state = prs.compute_state(one_person_twice, reviewers_required=2)
+    assert state["approvals"] == 1
+    assert state["state"] == "pending"
+
+    two_people = [_approval("Nia.Rossi"), _approval("Ibrahim.El-Amin")]
+    state = prs.compute_state(two_people, reviewers_required=2)
+    assert state["approvals"] == 2
+    assert state["state"] == "approved"
+
+
+def test_distinct_reviewers_fold_name_variants():
+    """``Tariq.Morales`` / ``Tariq Morales`` / ``Tariq Morales (QA)`` are ONE
+    reviewer, not three.
+
+    Mutation bar: dropping the ``_name_key`` folding counts the variants as 3
+    distinct approvers and wrongly reaches a 2-reviewer bar -> fails.
+    """
+    variants = [
+        _approval("Tariq.Morales"),
+        _approval("Tariq Morales"),
+        _approval("Tariq Morales (QA)"),
+    ]
+    state = prs.compute_state(variants, reviewers_required=2)
+    assert state["approvals"] == 1
+    assert state["state"] == "pending"
+
+
+# ---------------------------------------------------------------------------
+# Amend-in-place Request -> Replied convention.
+# ---------------------------------------------------------------------------
+
+
+def test_amend_in_place_request_to_replied_clears_and_counts_as_approval():
+    """A reviewer's blocking Request, once amended in place to a clean Replied,
+    stops blocking AND now counts toward approvals.
+
+    The amendment edits the SAME comment, so re-parsing the PR's current bodies
+    yields a clean verdict for that reviewer. Modelled as before/after Verdict
+    lists (compute_state is pure over the CURRENT parse).
+    """
+    # BEFORE the fix lands: Tariq blocks, Nia approves. required=2.
+    before = [_changes_requested("Tariq.Morales"), _approval("Nia.Rossi")]
+    s_before = prs.compute_state(before, reviewers_required=2)
+    assert s_before["state"] == "changes_requested"
+    assert s_before["approvals"] == 1  # only Nia; Tariq is currently blocking
+
+    # AFTER Tariq amends his Request -> Replied in place (now clean).
+    after = [_approval("Tariq.Morales"), _approval("Nia.Rossi")]
+    s_after = prs.compute_state(after, reviewers_required=2)
+    assert s_after["unresolved_must_fix"] == []
+    assert s_after["approvals"] == 2
+    assert s_after["state"] == "approved"
+
+
+def test_blocking_reviewer_not_double_counted_as_approver():
+    """A reviewer who left BOTH a clean note and a still-open must-fix is not an
+    approver — their standing review is changes-requested until amended.
+
+    Mutation bar: dropping the ``blocking_reviewers`` exclusion counts that
+    reviewer as an approver -> this test's approvals assertion fails.
+    """
+    verdicts = [
+        _approval("Tariq.Morales"),  # an earlier clean note
+        _changes_requested("Tariq.Morales"),  # a later, still-open block
+    ]
+    state = prs.compute_state(verdicts, reviewers_required=1)
+    assert state["state"] == "changes_requested"
+    assert state["approvals"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Fail-open posture.
+# ---------------------------------------------------------------------------
+
+
+def test_reviewers_required_fail_open_defaults():
+    """A None/garbage/zero policy value degrades to the fail-open floor, never 0
+    (a 0 bar would read an unreviewed PR as approved)."""
+
+    class _Cfg:
+        def __init__(self, val):
+            self._val = val
+
+        def get(self, _dotted, default=None):
+            return self._val if self._val is not None else default
+
+    assert prs._reviewers_required(_Cfg(None)) == prs._FAIL_OPEN_REVIEWERS_REQUIRED
+    assert prs._reviewers_required(_Cfg("nonsense")) == prs._FAIL_OPEN_REVIEWERS_REQUIRED
+    assert prs._reviewers_required(_Cfg(0)) == prs._FAIL_OPEN_REVIEWERS_REQUIRED
+    assert prs._reviewers_required(_Cfg(3)) == 3
+
+
+def test_review_state_wrapper_fail_opens_to_pending_on_fetch_error(monkeypatch):
+    """A comment-fetch error returns pending — never a raised exception and
+    never a manufactured 'approved'."""
+
+    def _boom(_repo, _num):
+        raise RuntimeError("gh exploded")
+
+    monkeypatch.setattr(ts, "_pr_comment_bodies", _boom)
+
+    class _Cfg:
+        def get(self, _dotted, default=None):
+            return 1
+
+    state = prs.review_state("acme/widget", 7, cfg=_Cfg())
+    assert state["state"] == "pending"
+    assert state["approvals"] == 0
+    assert state["unresolved_must_fix"] == []
+
+
+def test_review_state_wrapper_reuses_parse_verdicts(monkeypatch):
+    """End-to-end through the wrapper on REAL charter-format comment bodies:
+    proves the oracle reuses ``trust_signals.parse_verdicts`` (no re-parse) and
+    produces the same verdict semantics — two clean approvals reach approved."""
+
+    nia = (
+        "Requestor: Nia.Rossi\nRequestee: Paloma.Gupta\nRequestOrReplied: Replied\n\n"
+        "**Review: LGTM — ships as-is**\nMust-fix: None\nTech-debt: None\n"
+    )
+    ibrahim = (
+        "Requestor: Ibrahim.El-Amin\nRequestee: Paloma.Gupta\nRequestOrReplied: Replied\n\n"
+        "**Review: looks good**\nMust-fix: None\nTech-debt: None\n"
+    )
+
+    monkeypatch.setattr(ts, "_pr_comment_bodies", lambda _repo, _num: [nia, ibrahim])
+
+    class _Cfg:
+        def get(self, _dotted, default=None):
+            return 2
+
+    state = prs.review_state("acme/widget", 42, cfg=_Cfg())
+    assert state["approvals"] == 2
+    assert state["reviewers_required"] == 2
+    assert state["state"] == "approved"
+
+
+def test_review_state_wrapper_surfaces_must_fix_from_real_body(monkeypatch):
+    """A real charter ``Request`` + enumerated ``Must-fix:`` body flows through
+    parse_verdicts to a changes_requested state (severity read from the body,
+    not the token — the charter's rule, applied by trust_signals)."""
+
+    blocking = (
+        "Requestor: Tariq.Morales\nRequestee: Paloma.Gupta\nRequestOrReplied: Request\n\n"
+        "**Review: one must-fix**\nMust-fix:\n1. Rebase — the branch is CONFLICTING.\n"
+        "Tech-debt: None\n"
+    )
+
+    monkeypatch.setattr(ts, "_pr_comment_bodies", lambda _repo, _num: [blocking])
+
+    class _Cfg:
+        def get(self, _dotted, default=None):
+            return 1
+
+    state = prs.review_state("acme/widget", 99, cfg=_Cfg())
+    assert state["state"] == "changes_requested"
+    assert len(state["unresolved_must_fix"]) == 1


### PR DESCRIPTION
## S1 (flagship) — `pr_review_state` oracle (#194, #102 P2 review-gate tranche)

A config-driven, **fail-open** N-reviewer approval-state oracle: a pure state
machine that computes the N-of-M approval state of a PR **from 2real's existing
verdict parsing**.

### Reconcile, don't duplicate
This is NOT a blind port of noorinalabs' `pr_review_state` (which forked its own
comment parsing), and NOT a new parsing vocabulary. 2real already evolved its
own charter verdict grammar and parses it in one place —
`trust_signals.parse_verdicts()` / `_is_changes_requested()` /
`_pr_comment_bodies()`. This oracle **consumes** those parsed
`trust_signals.Verdict` objects and adds only the state machine. Re-parsing here
would fork the vocabulary and let the oracle drift from the merge gate / trust
scorer — exactly the failure the reuse exists to prevent.

- **Parsing** stays `trust_signals`' job — the thin `review_state()` wrapper
  fetches bodies via `trust_signals._pr_comment_bodies` and parses via
  `trust_signals.parse_verdicts`.
- **The state machine** is this module's job — pure, no I/O
  (`compute_state(verdicts, reviewers_required)`).
- **amend-in-place** (charter Reply Protocol: a reviewer edits their blocking
  `Request`/`Must-fix:` comment *in place* to `Replied`/`Must-fix: None` once
  fixed) is handled for free: the oracle reads the PR's **current** bodies, so
  an amended-clean verdict parses `changes_requested=False`, drops out of
  `unresolved_must_fix`, and its author now counts toward approvals.

### Pinned API (confirmed — shape matches the frozen contract)
```
review_state(repo: str, pr: int) -> ReviewState
compute_state(verdicts: list[Verdict], reviewers_required: int) -> ReviewState  # pure inner
ReviewState = {
  "state": "pending" | "changes_requested" | "approved",
  "approvals": int,
  "reviewers_required": int,          # policy.reviewers_required, fail-open default
  "unresolved_must_fix": list,
}
# approved          iff approvals >= reviewers_required AND unresolved_must_fix == []
# changes_requested iff any current verdict carries an unresolved Must-fix (precedence)
# else pending
```

### ⚠️ One flag for the Manager (Hiro) — coordinate on #193 (shape UNCHANGED)
The frozen `ReviewState` **shape** is honored exactly. The contract's
*descriptive comment* said `approvals` counts "distinct **requestees**". But the
charter grammar and `trust_signals.extract_signals` make the **reviewer** the
`Requestor:` (the `Requestee:` is the single PR author — counting requestees
could never reach a 2-reviewer bar). So `approvals` counts **distinct
Requestors** of clean verdicts. This is an internal-semantics correction only;
`approvals` is still an `int` and the dict keys S2/S3 build against are
identical, so nothing downstream breaks. Please confirm the wording on #193.

### FAIL_OPEN posture (Wave-3 dispatcher convention)
Declared `FAIL_OPEN = True`. `reviewers_required` reads `policy.reviewers_required`
via shared config (fail-opens to the schema default `1`); a garbage/zero/raising
value degrades to `_FAIL_OPEN_REVIEWERS_REQUIRED = 1` (never `0`, which would
read an unreviewed PR as approved). A comment-fetch error in the wrapper returns
`pending` — **an error never manufactures a false "approved" nor hard-fails**.
No blocking behavior is wired (that is S2; this is the oracle only).

### Acceptance-criteria results
- [x] Pure `compute_state()` + thin `review_state()` reusing `parse_verdicts()` (no re-parse).
- [x] `reviewers_required` from `policy.reviewers_required` via shared config; explicit fail-open default + `FAIL_OPEN` posture documented.
- [x] Load-bearing unit tests (13) covering the transition truth table, amend-in-place, N-of-M distinct reviewers, and must-fix-blocks-approved. Pure (hand-built Verdict lists, no live `gh`).
- [x] Dual-deploy #116: canonical `framework/assets/lib/pr_review_state.py` added; libs are wired canonical-by-reference (`reinstall.py` manages only skills), golden manifest regenerated to add `.claude/lib/pr_review_state.py`.
- [x] `ruff check framework/` clean; `ENVIRONMENT=test python -m pytest framework/tests/` → **658 passed**.
- [x] No blocking behavior wired.

### Gate results
| Gate | Result |
|------|--------|
| `ruff check framework/` | ✅ All checks passed |
| `pytest framework/tests/` | ✅ 658 passed |
| `pytest framework/tests/test_pr_review_state.py` | ✅ 13 passed |
| `reinstall.py --check` | ✅ exit 0 (in sync) |
| `manifest.py --check` | ✅ exit 0 (regenerated, in sync) |
| `charter_drift.py --check` | ✅ exit 0 |

### Mutation-bar reproduction (revert → fail)
Reverting the transition logic in `compute_state` (flip `approvals >= reviewers_required`
to `>`, and drop the `if unresolved: changes_requested` precedence branch), then
`pytest framework/tests/test_pr_review_state.py`:

```
8 failed, 5 passed
FAILED test_approved_at_exactly_required
FAILED test_changes_requested_when_any_unresolved_must_fix
FAILED test_unresolved_must_fix_blocks_approved_even_at_n_approvals
FAILED test_n_of_m_needs_two_distinct_reviewers
FAILED test_amend_in_place_request_to_replied_clears_and_counts_as_approval
FAILED test_blocking_reviewer_not_double_counted_as_approver
FAILED test_review_state_wrapper_reuses_parse_verdicts
FAILED test_review_state_wrapper_surfaces_must_fix_from_real_body
```
Restoring the file → **13 passed**.

Refs #194. Base: `deployments/phase6/wave-5` (do not merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UJ8cYWv2cBj2yG24E5NcTo
