### PR TITLE
feat(policy): activate PR-review gate — reviewers_required=2 + pr_review_gate_enabled=true (#202)

### DIFF
--- a/.claude/framework.config.json
+++ b/.claude/framework.config.json
@@ -18,8 +18,8 @@
     "allow_emails": ["parametrization@gmail.com"]
   },
   "policy": {
-    "reviewers_required": 1,
-    "pr_review_gate_enabled": false,
+    "reviewers_required": 2,
+    "pr_review_gate_enabled": true,
     "merge_model": "wave-branch"
   },
   "ci": {

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -21,6 +21,13 @@ blocked.
   in `.claude/framework.config.json` is the N-reviewer gate. Read it — a PR needs
   that many DISTINCT approving reviewers before it can merge, so your approval may
   be only one of several required.
+- **When `policy.pr_review_gate_enabled` is true, that bar is mechanically enforced:**
+  the `validate_pr_review` hook BLOCKS `gh pr ready` / `gh pr merge` until the oracle
+  reports the PR `approved` (`reviewers_required` distinct clean approvals AND no
+  unresolved `Must-fix:`). Your clean verdict is then load-bearing — the merge cannot
+  land without it. (Escape hatch if the team ever wedges: an owner reverts the flag with
+  a direct config-only commit to the default branch; the gate is also fail-open on an
+  oracle error.) When the flag is false the same bar is advisory, not blocked.
 
 ## Instructions
 1. Fetch PR diff: `gh pr diff {number}`

--- a/.claude/team/.charter-manifest.json
+++ b/.claude/team/.charter-manifest.json
@@ -3,11 +3,11 @@
   "files": {
     "agents.md": "8a53b9a7bf6b97e473bc5387b84609a83fe8c0524374d66dc2330e5d7ed450ce",
     "branching.md": "3e51782810787065403bbd7203610e7be247788cb60278960859e1ffb922b5af",
-    "charter.md": "bc0f7655f97c2d6e872e8c2f74ef2ab9a3e1a8919bc526c30bcc6df6defe98c5",
+    "charter.md": "b2d200f1de236bc1ba6d997917be5e186504a05c12015e392b1ecf7291564dfb",
     "commits.md": "c9d5e7349f0ead70cb37dd8cf20a7753fe3bea5c943ad56fe3f661dc4daaab67",
-    "hooks.md": "4b2ce25d2365800ec6d940cd091be12c7a230092b91dc673fac78a4bd823068e",
+    "hooks.md": "77d72942082cf0dd1fb45da686376d8813d3e2b30ebe1ec4f99e432ef0fdb1d5",
     "issues.md": "6f57a50dd85c4dd516c5dfd5a6772f65b881f5089929504166c267148544e62b",
-    "pull-requests.md": "7dd6f9aa05edf6fb4949de64f084d50c075cfefacb3bec7838e1cc05fde92e24",
+    "pull-requests.md": "54cfb55729ac26a5a4b066c48f19639912656cc1b4e659d56d29da3bd3af0a99",
     "skills.md": "dcc93b623b5f62cbac412634d4d3b04c3731c5a4a0892dd3227c70241703e81e"
   }
 }

--- a/.claude/team/charter/charter.md
+++ b/.claude/team/charter/charter.md
@@ -30,7 +30,7 @@ documents (CLAUDE.md, roster cards, skills) should link here rather than restate
 - **Owner:** `parametrization` · **Default branch:** `main` ·
   **Merge model:** `wave-branch` (configured default; the effective model per
   wave is declared at kickoff via `lifecycle.py wave kickoff --merge-model …` and
-  recorded in the state file) · **Reviews required per PR:** 1
+  recorded in the state file) · **Reviews required per PR:** 2
 - **User approval gates.** Merging to `main`, creating releases, and
   kicking off a new wave all require explicit approval from the project owner. No
   team member may bypass these gates.

--- a/.claude/team/charter/pull-requests.md
+++ b/.claude/team/charter/pull-requests.md
@@ -92,8 +92,30 @@ Closes #<issue-number>
 
 ## Review Workflow
 
-Every PR requires **1 review(s)** from team members who are not
+Every PR requires **2 review(s)** from team members who are not
 the branch author.
+
+### The N-reviewer merge gate (mechanically enforced when armed)
+
+The reviewer bar is not advisory when `policy.pr_review_gate_enabled` is **true**: the
+`validate_pr_review` PreToolUse hook (thin over the `lib/pr_review_state` oracle — see
+[hooks.md](hooks.md)) **blocks `gh pr ready` / `gh pr merge` until the PR is
+`approved`** — meaning **2 distinct clean reviewer approvals AND no
+unresolved `Must-fix:` verdict**. Approvals are counted over distinct `Requestor:`
+identities whose current verdict is clean (a `Replied` review with `Must-fix: None`, per
+[issues.md](issues.md)); a standing `Must-fix:` blocks regardless of the approval count.
+
+- **On THIS repo the gate is LIVE as of Phase 6 Wave 6** (`pr_review_gate_enabled=true`,
+  `reviewers_required=2`): a merge cannot land without 2 distinct clean approvals.
+- **The framework ships the gate DORMANT** (`pr_review_gate_enabled=false`): a downstream
+  install keeps this bar advisory until its owner flips the flag, so nothing here blocks a
+  fresh adopter's merges.
+- **Escape hatch (if the team wedges):** the gate must never trap the team. It can be
+  disarmed by a **direct config-only commit to `main`** setting
+  `policy.pr_review_gate_enabled` back to `false` (no PR merge required — the config edit
+  itself is not a gated verb). The gate is additionally **fail-open on oracle error**: an
+  inability to *evaluate* approval state ALLOWS the merge rather than hard-blocking it, so a
+  broken oracle can never wedge the workflow either.
 
 1. **Create the PR** and notify the assigned reviewer(s).
 2. **Reviewer reviews** and posts findings on the PR, classified as:

--- a/framework/assets/skills/review-pr/SKILL.md
+++ b/framework/assets/skills/review-pr/SKILL.md
@@ -21,6 +21,13 @@ blocked.
   in `.claude/framework.config.json` is the N-reviewer gate. Read it — a PR needs
   that many DISTINCT approving reviewers before it can merge, so your approval may
   be only one of several required.
+- **When `policy.pr_review_gate_enabled` is true, that bar is mechanically enforced:**
+  the `validate_pr_review` hook BLOCKS `gh pr ready` / `gh pr merge` until the oracle
+  reports the PR `approved` (`reviewers_required` distinct clean approvals AND no
+  unresolved `Must-fix:`). Your clean verdict is then load-bearing — the merge cannot
+  land without it. (Escape hatch if the team ever wedges: an owner reverts the flag with
+  a direct config-only commit to the default branch; the gate is also fail-open on an
+  oracle error.) When the flag is false the same bar is advisory, not blocked.
 
 ## Instructions
 1. Fetch PR diff: `gh pr diff {number}`

--- a/framework/assets/team/charter/pull-requests.md
+++ b/framework/assets/team/charter/pull-requests.md
@@ -95,6 +95,28 @@ Closes #<issue-number>
 Every PR requires **{{reviewers_required}} review(s)** from team members who are not
 the branch author.
 
+### The N-reviewer merge gate (mechanically enforced when armed)
+
+The reviewer bar is not advisory when `policy.pr_review_gate_enabled` is **true**: the
+`validate_pr_review` PreToolUse hook (thin over the `lib/pr_review_state` oracle — see
+[hooks.md](hooks.md)) **blocks `gh pr ready` / `gh pr merge` until the PR is
+`approved`** — meaning **{{reviewers_required}} distinct clean reviewer approvals AND no
+unresolved `Must-fix:` verdict**. Approvals are counted over distinct `Requestor:`
+identities whose current verdict is clean (a `Replied` review with `Must-fix: None`, per
+[issues.md](issues.md)); a standing `Must-fix:` blocks regardless of the approval count.
+
+- **On THIS repo the gate is LIVE as of Phase 6 Wave 6** (`pr_review_gate_enabled=true`,
+  `reviewers_required=2`): a merge cannot land without 2 distinct clean approvals.
+- **The framework ships the gate DORMANT** (`pr_review_gate_enabled=false`): a downstream
+  install keeps this bar advisory until its owner flips the flag, so nothing here blocks a
+  fresh adopter's merges.
+- **Escape hatch (if the team wedges):** the gate must never trap the team. It can be
+  disarmed by a **direct config-only commit to `{{default_branch}}`** setting
+  `policy.pr_review_gate_enabled` back to `false` (no PR merge required — the config edit
+  itself is not a gated verb). The gate is additionally **fail-open on oracle error**: an
+  inability to *evaluate* approval state ALLOWS the merge rather than hard-blocking it, so a
+  broken oracle can never wedge the workflow either.
+
 1. **Create the PR** and notify the assigned reviewer(s).
 2. **Reviewer reviews** and posts findings on the PR, classified as:
    - **Must-fix** — blocks merge; the submitter resolves before proceeding.

--- a/framework/tests/test_activate_pr_review_gate.py
+++ b/framework/tests/test_activate_pr_review_gate.py
@@ -1,0 +1,264 @@
+"""Load-bearing integration test for the ACTIVATED PR-review gate (#202, W6/S1).
+
+Unlike ``test_validate_pr_review.py`` (which hand-builds fixture policy values),
+this test wires the gate against **this repo's ACTUAL runtime config**
+(``.claude/framework.config.json``): it reads the shipped ``policy`` block and
+drives ``validate_pr_review.check`` + the ``pr_review_state`` oracle with those
+exact values. That makes it break if the activation is reverted — it is the
+mutation bar for the config edit this story ships.
+
+What it pins (all against the real config, no hand-built policy fixture):
+
+* ``test_repo_config_is_activated`` — the shipped values ARE the activation
+  (``pr_review_gate_enabled=true``, ``reviewers_required=2``). A revert of either
+  fails here directly.
+* ``test_enabled_not_approved_blocks_gh_pr_merge`` — armed by the REAL flag, a
+  not-approved oracle state ⇒ the gate returns a ``block`` decision on
+  ``gh pr merge``, and the reason names ``approvals X/N`` with N = the real
+  ``reviewers_required`` (``0/2``).
+* ``test_two_distinct_clean_requestor_verdicts_approve`` — the oracle's real
+  ``compute_state`` over TWO distinct clean ``Requestor:`` verdicts, at the real
+  ``reviewers_required``, reports ``approved`` — and the gate then ALLOWS the
+  merge. ONE clean verdict does not (``pending``); a standing ``Must-fix:`` does
+  not (``changes_requested``).
+* ``test_mutation_bar_reverting_config_flips_the_block`` — the SAME not-approved
+  oracle state that BLOCKS under the real (activated) config ALLOWS once the two
+  config values are reverted in a copy (``enabled=false``, ``reviewers_required=1``).
+  This is the explicit revert→fail simulation for the two-line config change.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+_REPO_ROOT = _FRAMEWORK_ROOT.parent
+sys.path.insert(0, str(_FRAMEWORK_ROOT / "assets" / "hooks"))
+sys.path.insert(0, str(_FRAMEWORK_ROOT / "assets" / "lib"))
+
+import pr_review_state as oracle  # noqa: E402
+import trust_signals as ts  # noqa: E402
+import validate_pr_review as hook  # noqa: E402
+
+#: This repo's live runtime config — the file the gate actually loads in anger.
+_CONFIG_PATH = _REPO_ROOT / ".claude" / "framework.config.json"
+
+
+def _real_policy() -> dict:
+    """The ACTUAL shipped ``policy`` block (not a hand-built fixture)."""
+    return json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))["policy"]
+
+
+class _RealCfg:
+    """Dotted-get config shim over a real ``policy`` dict.
+
+    Matches the surface both consumers use: the hook reads
+    ``config(...).get("policy.pr_review_gate_enabled")`` and the oracle reads
+    ``cfg.get("policy.reviewers_required")``. Fed the SHIPPED policy so the gate
+    is exercised with this repo's real activation values.
+    """
+
+    def __init__(self, policy: dict) -> None:
+        self._policy = policy
+
+    def get(self, key: str, default=None):
+        if key.startswith("policy."):
+            return self._policy.get(key[len("policy.") :], default)
+        return default
+
+
+def _bash(command: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+def _arm_with(monkeypatch, policy: dict) -> None:
+    """Point the hook's config at a ``_RealCfg`` over *policy*."""
+    monkeypatch.setattr(
+        hook, "config", lambda input_data=None, **kw: _RealCfg(policy)
+    )
+
+
+def _stub_oracle(monkeypatch, state: dict) -> None:
+    """Replace the oracle's I/O so no real ``gh``/network is touched."""
+    monkeypatch.setattr(hook, "review_state", lambda repo, pr, **kw: state)
+
+
+def _clean_verdict_body(requestor: str, requestee: str = "Paloma.Gupta") -> str:
+    """A charter-grammar clean approval (``Replied`` / ``Must-fix: None``)."""
+    return (
+        f"Requestor: {requestor}\n"
+        f"Requestee: {requestee}\n"
+        "RequestOrReplied: Replied\n\n"
+        "**Review: LGTM**\n"
+        "Must-fix: None\n"
+        "Tech-debt: None\n"
+    )
+
+
+def _must_fix_body(requestor: str, requestee: str = "Paloma.Gupta") -> str:
+    """A charter-grammar changes-requested verdict (one blocking Must-fix)."""
+    return (
+        f"Requestor: {requestor}\n"
+        f"Requestee: {requestee}\n"
+        "RequestOrReplied: Request\n\n"
+        "**Review: one blocker**\n"
+        "Must-fix:\n"
+        "1. Config value must be reverted before merge.\n"
+        "Tech-debt: None\n"
+    )
+
+
+# An explicit --repo + literal PR so resolve_repo/resolve_pr never shell out.
+_MERGE = "gh pr merge 202 --repo parametrization/2real-team-framework --squash"
+
+
+# --------------------------------------------------------------- activation is live
+
+
+def test_repo_config_is_activated() -> None:
+    """The shipped runtime config carries the activation this story delivers."""
+    policy = _real_policy()
+    assert policy["pr_review_gate_enabled"] is True, (
+        "gate must be ARMED on this repo (pr_review_gate_enabled=true)"
+    )
+    assert policy["reviewers_required"] == 2, (
+        "this repo requires 2 distinct clean approvals to merge"
+    )
+
+
+# --------------------------------------------------------------- gate BLOCKS (real config)
+
+
+def test_enabled_not_approved_blocks_gh_pr_merge(monkeypatch) -> None:
+    """Real flag=true + not-approved oracle ⇒ block, reason names approvals 0/N."""
+    policy = _real_policy()
+    required = policy["reviewers_required"]
+    _arm_with(monkeypatch, policy)
+    _stub_oracle(
+        monkeypatch,
+        {
+            "state": oracle.PENDING,
+            "approvals": 0,
+            "reviewers_required": required,
+            "unresolved_must_fix": [],
+        },
+    )
+    result = hook.check(_bash(_MERGE))
+    assert result is not None, "an activated gate must block a not-approved merge"
+    assert result["decision"] == "block"
+    assert f"0/{required}" in result["reason"]
+    assert "#202" in result["reason"]
+
+
+def test_standing_must_fix_blocks(monkeypatch) -> None:
+    """A standing Must-fix blocks even at/above the approval count; reason names it."""
+    policy = _real_policy()
+    _arm_with(monkeypatch, policy)
+    verdicts = ts.parse_verdicts(
+        [
+            _clean_verdict_body("Nia.Rossi"),
+            _clean_verdict_body("Tariq.Morales"),
+            _must_fix_body("Ibrahim.El-Amin"),
+        ]
+    )
+    state = oracle.compute_state(verdicts, policy["reviewers_required"])
+    assert state["state"] == oracle.CHANGES_REQUESTED
+    _stub_oracle(monkeypatch, state)
+    result = hook.check(_bash(_MERGE))
+    assert result is not None
+    assert result["decision"] == "block"
+    assert "Must-fix" in result["reason"]
+    assert "Ibrahim.El-Amin" in result["reason"]
+
+
+# --------------------------------------------------------------- oracle: 2-of-2 approves
+
+
+def test_two_distinct_clean_requestor_verdicts_approve(monkeypatch) -> None:
+    """The real oracle at reviewers_required=2 approves on 2 distinct clean verdicts."""
+    required = _real_policy()["reviewers_required"]
+    assert required == 2  # the invariant the rest of this test is meaningful under
+
+    # Two distinct clean Requestors -> approved.
+    two = oracle.compute_state(
+        ts.parse_verdicts(
+            [_clean_verdict_body("Nia.Rossi"), _clean_verdict_body("Tariq.Morales")]
+        ),
+        required,
+    )
+    assert two["state"] == oracle.APPROVED
+    assert two["approvals"] == 2
+
+    # One distinct clean Requestor -> NOT enough (pending).
+    one = oracle.compute_state(
+        ts.parse_verdicts([_clean_verdict_body("Nia.Rossi")]), required
+    )
+    assert one["state"] == oracle.PENDING
+    assert one["approvals"] == 1
+
+    # Two comments from the SAME reviewer collapse to one approval (distinct-Requestor).
+    dup = oracle.compute_state(
+        ts.parse_verdicts(
+            [_clean_verdict_body("Nia.Rossi"), _clean_verdict_body("Nia.Rossi")]
+        ),
+        required,
+    )
+    assert dup["state"] == oracle.PENDING
+    assert dup["approvals"] == 1
+
+
+def test_enabled_approved_allows_merge(monkeypatch) -> None:
+    """Real flag=true + an oracle-approved state ⇒ the gate ALLOWS the merge."""
+    policy = _real_policy()
+    approved = oracle.compute_state(
+        ts.parse_verdicts(
+            [_clean_verdict_body("Nia.Rossi"), _clean_verdict_body("Tariq.Morales")]
+        ),
+        policy["reviewers_required"],
+    )
+    assert approved["state"] == oracle.APPROVED
+    _arm_with(monkeypatch, policy)
+    _stub_oracle(monkeypatch, approved)
+    assert hook.check(_bash(_MERGE)) is None
+
+
+# --------------------------------------------------------------- mutation bar
+
+
+def test_mutation_bar_reverting_config_flips_the_block(monkeypatch) -> None:
+    """Reverting the two config values flips the BLOCK to an ALLOW (revert→fail sim).
+
+    The SAME not-approved oracle state is evaluated twice: under the real
+    (activated) policy it BLOCKS; under a copy with the two values reverted
+    (``pr_review_gate_enabled=false``, ``reviewers_required=1``) it ALLOWS. If the
+    shipped config ever regresses to the reverted values, the block above stops
+    happening — which is exactly what this asserts must NOT be the live state.
+    """
+    real = _real_policy()
+    pending = {
+        "state": oracle.PENDING,
+        "approvals": 0,
+        "reviewers_required": real["reviewers_required"],
+        "unresolved_must_fix": [],
+    }
+    _stub_oracle(monkeypatch, pending)
+
+    # Activated (real) config: BLOCKS.
+    _arm_with(monkeypatch, real)
+    assert hook.check(_bash(_MERGE)) is not None
+
+    # Reverted copy: same not-approved PR now ALLOWS (dormant no-op).
+    reverted = copy.deepcopy(real)
+    reverted["pr_review_gate_enabled"] = False
+    reverted["reviewers_required"] = 1
+    _arm_with(monkeypatch, reverted)
+    assert hook.check(_bash(_MERGE)) is None
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary
Activate this repo's dormant N-reviewer PR-review merge gate and prove the enabled path live for the first time (the oracle's gate running outside a fixture).

- **Activation (this repo only):** `.claude/framework.config.json` — `policy.reviewers_required` 1→2, `policy.pr_review_gate_enabled` false→true. The gate goes live only when this PR rolls up to `main`; the wave's own PRs still merge under the dormant regime.
- **Load-bearing integration test** wiring the gate against the ACTUAL runtime config.
- **Controlled live demonstration** on a self-contained throwaway PR (now torn down).
- **Charter + review-pr skill** state the now-live rule + escape hatch (canonical first, reinstalled byte-identical to runtime).

## Related Issues
Closes #202

## Defaults stay DORMANT for downstream adopters (verified)
This is a **this-repo activation, not a default flip**. Framework defaults shipped to other repos remain dormant — a fresh install stays advisory:

| Sync point | `pr_review_gate_enabled` | `reviewers_required` |
|---|---|---|
| `framework/config/framework.config.schema.json` (default) | `false` | `1` |
| `framework/assets/hooks/_framework_config.py` `_DEFAULTS` | `False` | `1` |
| `framework/config/framework.config.example.json` | `false` | `2` (recommendation; harmless while gate off) |
| `framework/install/bootstrap.py` `_schema_defaults` | (unset → loader fills schema `false`) | (unset → loader fills schema `1`) |

The load-bearing dormancy invariant — `pr_review_gate_enabled=false` in every framework default — holds across all four. Only the runtime `.claude/framework.config.json` for THIS repo is armed.

## Load-bearing integration test (mutation bar)
`framework/tests/test_activate_pr_review_gate.py` reads the ACTUAL `.claude/framework.config.json` (not a hand-built fixture) and drives `validate_pr_review.check` + the real `pr_review_state` oracle with those values:

- not-approved oracle state ⇒ gate returns a `block` decision on `gh pr merge`, reason names `0/2`;
- 2 distinct clean `Requestor:` verdicts through the real `compute_state` at `reviewers_required=2` ⇒ `approved` (approvals 2/2) ⇒ gate ALLOWS; 1 clean ⇒ `pending`; duplicate reviewer ⇒ 1; a standing `Must-fix:` ⇒ `changes_requested` (blocks);
- **mutation bar:** the same not-approved state that BLOCKS under the real config ALLOWS once the two values are reverted in a copy (`false`/`1`).

**Revert→fail→restore reproduced physically:** with the two values reverted in `.claude/framework.config.json`, the suite goes **5 failed / 1 passed** (the block, activation, standing-must-fix, oracle-approves, and mutation tests all fail; only `test_enabled_approved_allows_merge` stays green — an approved PR passes regardless of the flag). Restored → **6 passed**. Full suite: **700 passed** (694 W5 baseline + 6 new).

## Controlled live demonstration (throwaway PR #205 — created + torn down)
Drove the LIVE gate (this branch's armed config) against a real throwaway PR's real comments via the oracle's real gh I/O — the first enabled-path run outside a fixture.

**Not approved (before):**
```
$ python3 framework/assets/lib/pr_review_state.py 205 --repo parametrization/2real-team-framework
PR #205 — review state: PENDING
  approvals: 0/2 required
  unresolved must-fix verdicts: none        (oracle exit 1)

$ echo '{... "command":"gh pr merge 205 ..."}' | python3 framework/assets/hooks/validate_pr_review.py
{"decision":"block","reason":"BLOCKED: PR #205 is not approved (review state: PENDING);
`gh pr merge` is gated by policy.pr_review_gate_enabled=true.
Approvals: 0/2 required — needs 2 more distinct approving reviewer(s) ..."}   (gate exit 2)
```

**Added 2 distinct clean charter verdicts** (`Requestor: Nia.Rossi`, `Requestor: Tariq.Morales`; both `RequestOrReplied: Replied` / `Must-fix: None`).

**Approved (after):**
```
$ python3 framework/assets/lib/pr_review_state.py 205 --repo parametrization/2real-team-framework
PR #205 — review state: APPROVED
  approvals: 2/2 required
  unresolved must-fix verdicts: none        (oracle exit 0)

$ echo '{... "command":"gh pr merge 205 ..."}' | python3 framework/assets/hooks/validate_pr_review.py
(no output — allow, gate exit 0)
```

Throwaway PR #205 CLOSED and its branch `scratch/gate-demo-202` deleted.

## Charter + skill (canonical first, reinstalled byte-identical)
- `framework/assets/team/charter/pull-requests.md` — new "N-reviewer merge gate" section: **2 distinct clean reviewer approvals + no unresolved Must-fix required to merge** when armed; states THIS repo is live as of Phase 6 Wave 6 and the framework ships dormant.
- **Escape hatch** documented (charter + skill): if the team wedges, disarm the flag via a **direct config-only commit to `main`** (no PR merge required — a config edit is not a gated verb); the gate is additionally **fail-open on oracle error**.
- `framework/assets/skills/review-pr/SKILL.md` — config-aware note that a clean verdict is load-bearing when the gate is armed, plus the escape hatch. Kept generic (byte-mirrored asset, correct for both live and dormant installs).
- Runtime re-rendered/reinstalled: `.claude/team/charter/pull-requests.md`, `.claude/team/charter/charter.md` (Reviews-required 1→2), `.claude/skills/review-pr/SKILL.md`.

## Dual-deploy #116 gates
- `python3 framework/install/reinstall.py --check` → **0**
- `python3 framework/install/manifest.py --check` → **0** (asset file set unchanged — content-only edits)
- `python3 framework/install/charter_drift.py --check` → **0**
- `ruff check framework/` → clean · `ENVIRONMENT=test pytest framework/tests/` → **700 passed**

## Do NOT merge
Reviewers: **Nia.Rossi + Tariq.Morales** (2 distinct required). The gate goes live at rollup→main.
