### PR TITLE
docs(charter): formalize integration-owner + pin-contracts-to-code proposals; N=2 assignment rule (#204)

### DIFF
--- a/.claude/team/.charter-manifest.json
+++ b/.claude/team/.charter-manifest.json
@@ -6,8 +6,8 @@
     "charter.md": "b2d200f1de236bc1ba6d997917be5e186504a05c12015e392b1ecf7291564dfb",
     "commits.md": "c9d5e7349f0ead70cb37dd8cf20a7753fe3bea5c943ad56fe3f661dc4daaab67",
     "hooks.md": "77d72942082cf0dd1fb45da686376d8813d3e2b30ebe1ec4f99e432ef0fdb1d5",
-    "issues.md": "6f57a50dd85c4dd516c5dfd5a6772f65b881f5089929504166c267148544e62b",
-    "pull-requests.md": "54cfb55729ac26a5a4b066c48f19639912656cc1b4e659d56d29da3bd3af0a99",
+    "issues.md": "18d7a6a6e31112abad5ae6f92635c268168cce750b3372aacfa9d875f3dfbc9d",
+    "pull-requests.md": "b22eb3ea593b0dde9d37d1387f04ab07c18f5eeffa8f9a54b20070c7178710ff",
     "skills.md": "dcc93b623b5f62cbac412634d4d3b04c3731c5a4a0892dd3227c70241703e81e"
   }
 }

--- a/.claude/team/charter/issues.md
+++ b/.claude/team/charter/issues.md
@@ -9,6 +9,50 @@
 3. Disputes about ownership are negotiated with the relevant lead and the Manager;
    the Manager makes the final call.
 
+## Wave Planning: Shared Artifacts & Frozen Contracts
+
+Two planning rules the Manager/lead apply when decomposing a wave into parallel
+stories. Both pre-empt a *predictable*, foreseeable-at-planning failure rather than
+resolving it after the fact.
+
+### Single Integration-Owner for Shared Registries
+
+When two or more stories in the same wave will touch the **same shared config list,
+registry, or module** — e.g. `hooks.pre_bash`, a `_DEFAULTS` / `_MANAGED_TREES` list,
+the golden install manifest, or a single charter module (`pull-requests.md`) — the
+Manager **designates exactly ONE story as the integration-owner** for that artifact at
+wave kickoff (or explicitly **serializes** those specific edits so they never land in
+parallel). Every other story routes the change it needs into that artifact **through the
+owner** (via the lead's relay) instead of editing the shared artifact itself.
+
+Rationale: two stories editing one append-only list — or one prose module — produce a
+**predictable** merge conflict that is foreseeable at planning, not an accident to
+resolve after the fact (Phase 6 Wave 5, #201: the S2↔S3 `hooks.pre_bash` conflict
+surfaced as a CONFLICTING PR and cost a resolution round-trip that kickoff could have
+pre-empted). Designating one owner removes the round-trip; serializing the edits is the
+fallback when no single owner is natural. The designation is recorded in the wave
+kickoff brief alongside reviewer assignment.
+
+If this rule ever becomes worth mechanically enforcing (e.g. a gate that flags two
+in-flight branches touching the same registry), file it as a follow-up issue — do not
+build the gate inline.
+
+### Pin Frozen Contracts Against Code, Not Prose
+
+When a wave **freezes an inter-story contract** — a data shape, API signature, hook
+grammar, or parsing vocabulary that a later story will build against — the frozen
+contract must be **validated against the actual code layer at authoring time**: check
+the real signature / grammar / parser it binds to, not only a narrative description of
+it. The kickoff brief that pins the contract carries the concrete check (the exact
+field name, token, or signature it must agree with), not prose alone.
+
+Rationale: a contract authored in prose alone can read as internally consistent and
+still be wrong against the code it names (Phase 6 Wave 5, #201: the frozen `ReviewState`
+contract said "distinct requestees" where the charter's verdict grammar makes the
+reviewer the `Requestor:` — so a 2-reviewer bar could never clear; caught downstream by
+the implementer, far later than authoring). A one-line grammar/signature check against
+the real code at freeze time moves that whole class of defect left of implementation.
+
 ## Issue Review Process
 
 Every newly created issue gets a review pass from each lead and senior contributor.

--- a/.claude/team/charter/pull-requests.md
+++ b/.claude/team/charter/pull-requests.md
@@ -128,9 +128,23 @@ identities whose current verdict is clean (a `Replied` review with `Must-fix: No
 4. **Merge into the integration branch** — the team merges these PRs itself; no
    owner approval is needed below `main`.
 
-Reviewers are assigned by the lead at wave kickoff (no self-review; spread the load).
-The reviewer runs the tests on the branch — a review is an act of verification, not
-a reading exercise.
+### Reviewer Assignment (distinct, author-exclusive)
+
+Reviewers are assigned by the lead at wave kickoff (spread the load). The reviewer runs
+the tests on the branch — a review is an act of verification, not a reading exercise.
+
+Every PR is assigned **2 distinct reviewers**, and the assignment
+is **author-exclusive**: a reviewer can never be the PR's own author — the `Requestee:`
+of that PR's verdicts, per the verdict grammar in [issues.md](issues.md). The
+2 reviewers must be 2 *different* people; the
+same reviewer counted twice does not satisfy the bar, and no self-review is permitted.
+
+This assignment convention is what the armed merge gate mechanically enforces (§ The
+N-reviewer merge gate): the oracle counts clean approvals over **distinct `Requestor:`
+identities other than the author**, so assigning fewer than 2
+distinct non-author reviewers leaves the PR unable to reach `approved` — it cannot
+merge. Assign the full slate at kickoff so the process the gate checks and the process
+the team runs are the same one.
 
 ## CI Gates
 

--- a/.claude/team/feedback_log.md
+++ b/.claude/team/feedback_log.md
@@ -577,14 +577,22 @@ review-gate flagship — `pr_review_state` oracle (S1), `block_gh_pr_review` sub
    prose without checking it against the actual verdict grammar/`trust_signals` — the requestee/Requestor
    error got through planning and was caught downstream by the implementer, later than it should've been.
 
-### New proposals (need owner approval before a future wave adopts them)
+### New proposals (owner-approved at Phase 6 Wave 6 kickoff — both folded into the charter this wave)
 1. **Single integration-owner for shared registries.** When 2+ stories in a wave touch the same shared
    config list / registry (`pre_bash`, `_DEFAULTS`, golden manifest), designate one story as the
    integration owner for that list (or serialize those specific edits) so the predictable merge conflict
    is pre-empted rather than resolved after the fact. Low effort, removes a recurring round-trip.
+   **Status: APPLIED via #204 (Phase 6 Wave 6, S3)** — written into the charter as
+   `framework/assets/team/charter/issues.md` § Wave Planning → "Single Integration-Owner for Shared
+   Registries" (canonical + dual-deployed to runtime, byte-identical via `charter_drift.py --check`).
+   Dogfooded live this wave: S3 (Nia) was the sole charter integration-owner; S2 (Ibrahim) was barred
+   from editing `charter/**` and routed wording through the lead's relay.
 2. **Pin contracts against code, not just prose.** When a wave freezes an inter-story contract, validate
    it against the actual grammar/parsing layer at authoring time (a quick grammar check), not only in
    narrative. Would have caught the requestee/Requestor bug before it reached an implementer.
+   **Status: APPLIED via #204 (Phase 6 Wave 6, S3)** — written into the charter as
+   `framework/assets/team/charter/issues.md` § Wave Planning → "Pin Frozen Contracts Against Code, Not
+   Prose" (canonical + dual-deployed to runtime).
 
 ### Carry-over (still unapplied, from Wave 9 retro — no early slot claimed this flagship wave)
 - **Charter-manifest checksum cross-check** in `charter_drift.py plan()` (Nia's #190 tech-debt).

--- a/framework/assets/team/charter/issues.md
+++ b/framework/assets/team/charter/issues.md
@@ -9,6 +9,50 @@
 3. Disputes about ownership are negotiated with the relevant lead and the Manager;
    the Manager makes the final call.
 
+## Wave Planning: Shared Artifacts & Frozen Contracts
+
+Two planning rules the Manager/lead apply when decomposing a wave into parallel
+stories. Both pre-empt a *predictable*, foreseeable-at-planning failure rather than
+resolving it after the fact.
+
+### Single Integration-Owner for Shared Registries
+
+When two or more stories in the same wave will touch the **same shared config list,
+registry, or module** — e.g. `hooks.pre_bash`, a `_DEFAULTS` / `_MANAGED_TREES` list,
+the golden install manifest, or a single charter module (`pull-requests.md`) — the
+Manager **designates exactly ONE story as the integration-owner** for that artifact at
+wave kickoff (or explicitly **serializes** those specific edits so they never land in
+parallel). Every other story routes the change it needs into that artifact **through the
+owner** (via the lead's relay) instead of editing the shared artifact itself.
+
+Rationale: two stories editing one append-only list — or one prose module — produce a
+**predictable** merge conflict that is foreseeable at planning, not an accident to
+resolve after the fact (Phase 6 Wave 5, #201: the S2↔S3 `hooks.pre_bash` conflict
+surfaced as a CONFLICTING PR and cost a resolution round-trip that kickoff could have
+pre-empted). Designating one owner removes the round-trip; serializing the edits is the
+fallback when no single owner is natural. The designation is recorded in the wave
+kickoff brief alongside reviewer assignment.
+
+If this rule ever becomes worth mechanically enforcing (e.g. a gate that flags two
+in-flight branches touching the same registry), file it as a follow-up issue — do not
+build the gate inline.
+
+### Pin Frozen Contracts Against Code, Not Prose
+
+When a wave **freezes an inter-story contract** — a data shape, API signature, hook
+grammar, or parsing vocabulary that a later story will build against — the frozen
+contract must be **validated against the actual code layer at authoring time**: check
+the real signature / grammar / parser it binds to, not only a narrative description of
+it. The kickoff brief that pins the contract carries the concrete check (the exact
+field name, token, or signature it must agree with), not prose alone.
+
+Rationale: a contract authored in prose alone can read as internally consistent and
+still be wrong against the code it names (Phase 6 Wave 5, #201: the frozen `ReviewState`
+contract said "distinct requestees" where the charter's verdict grammar makes the
+reviewer the `Requestor:` — so a 2-reviewer bar could never clear; caught downstream by
+the implementer, far later than authoring). A one-line grammar/signature check against
+the real code at freeze time moves that whole class of defect left of implementation.
+
 ## Issue Review Process
 
 Every newly created issue gets a review pass from each lead and senior contributor.

--- a/framework/assets/team/charter/pull-requests.md
+++ b/framework/assets/team/charter/pull-requests.md
@@ -128,9 +128,23 @@ identities whose current verdict is clean (a `Replied` review with `Must-fix: No
 4. **Merge into the integration branch** — the team merges these PRs itself; no
    owner approval is needed below `{{default_branch}}`.
 
-Reviewers are assigned by the lead at wave kickoff (no self-review; spread the load).
-The reviewer runs the tests on the branch — a review is an act of verification, not
-a reading exercise.
+### Reviewer Assignment (distinct, author-exclusive)
+
+Reviewers are assigned by the lead at wave kickoff (spread the load). The reviewer runs
+the tests on the branch — a review is an act of verification, not a reading exercise.
+
+Every PR is assigned **{{reviewers_required}} distinct reviewers**, and the assignment
+is **author-exclusive**: a reviewer can never be the PR's own author — the `Requestee:`
+of that PR's verdicts, per the verdict grammar in [issues.md](issues.md). The
+{{reviewers_required}} reviewers must be {{reviewers_required}} *different* people; the
+same reviewer counted twice does not satisfy the bar, and no self-review is permitted.
+
+This assignment convention is what the armed merge gate mechanically enforces (§ The
+N-reviewer merge gate): the oracle counts clean approvals over **distinct `Requestor:`
+identities other than the author**, so assigning fewer than {{reviewers_required}}
+distinct non-author reviewers leaves the PR unable to reach `approved` — it cannot
+merge. Assign the full slate at kickoff so the process the gate checks and the process
+the team runs are the same one.
 
 ## CI Gates
 


### PR DESCRIPTION
## Summary
- Folds the two owner-approved **Phase 6 Wave 5** retro process proposals into the charter.
- **Single Integration-Owner for Shared Registries** and **Pin Frozen Contracts Against Code, Not Prose** → new `issues.md` § *Wave Planning: Shared Artifacts & Frozen Contracts* (issues.md is the delegation / wave-planning + issue-AC-authoring module — the natural home for both).
- Adds the **N=2 reviewer-assignment convention** to `pull-requests.md` (§ *Reviewer Assignment — distinct, author-exclusive*), building on S1's merged armed-gate wording: every PR gets `{{reviewers_required}}` **distinct** reviewers, author-exclusive (a reviewer is never the `Requestee:`/author).
- Canonical `framework/assets/team/charter/**` edited first, then dual-deployed to runtime `.claude/team/charter/**` via `install_charter(force=True)` — byte-identical.
- `feedback_log.md`: both W5 proposals marked **APPLIED via #204**. The two W9 carry-over tech-debt items left untouched (explicitly deferred).

## Dogfood
This story dogfoods proposal #1 live: Nia (S3) is the sole charter integration-owner this wave; Ibrahim (S2) is barred from editing `charter/**` and routes wording through the lead's relay.

## Follow-ups (not built this story, per AC)
- The integration-owner rule is machine-checkable in principle (flag two in-flight branches touching the same registry) — noted in-prose as a follow-up, no gate built.

## Gates
- `charter_drift.py --check` exit 0 · `reinstall.py --check` exit 0 · `manifest.py --check` exit 0
- `ruff check framework/` clean · `ENVIRONMENT=test pytest framework/tests/` → 700 passed

## Related Issues
Closes #204

## Review Checklist
- [ ] Reviewed by another team member
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)
