### PR TITLE
test(policy): prove + harden N=2 review process end-to-end (#203)

### DIFF
--- a/framework/tests/test_pr_review_state.py
+++ b/framework/tests/test_pr_review_state.py
@@ -290,3 +290,65 @@ def test_review_state_wrapper_surfaces_must_fix_from_real_body(monkeypatch):
     state = prs.review_state("acme/widget", 99, cfg=_Cfg())
     assert state["state"] == "changes_requested"
     assert len(state["unresolved_must_fix"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# N=2 end-to-end matrix (#203): the three review outcomes at reviewers_required=2,
+# driven through the full fetch→parse→compute chain on charter-format bodies whose
+# shape is taken from the real wave-6 multi-reviewer PR (#206: two distinct clean
+# Requestors — Nia.Rossi + Tariq.Morales) and a real blocking verdict (#93 shape).
+# This is the regression anchor for the live proof captured in the #203 PR body:
+# the oracle's N-of-M path, exercised end-to-end rather than only on hand-built
+# Verdict objects.
+# ---------------------------------------------------------------------------
+
+# Two distinct clean Requestors — the exact shape PR #206 carries.
+_N2_CLEAN_TARIQ = (
+    "Requestor: Tariq.Morales\nRequestee: Paloma.Gupta\nRequestOrReplied: Replied\n\n"
+    "**Review: verified — ships as-is**\nMust-fix: None\nTech-debt: None\n"
+)
+_N2_CLEAN_NIA = (
+    "Requestor: Nia.Rossi\nRequestee: Paloma.Gupta\nRequestOrReplied: Replied\n\n"
+    "**Review: LGTM — ships as-is**\nMust-fix: None\nTech-debt: None\n"
+)
+# A real blocking verdict (bold Must-fix label, one enumerated item — the #93 shape).
+_N2_MUSTFIX_NIA = (
+    "Requestor: Nia.Rossi\nRequestee: Paloma.Gupta\nRequestOrReplied: Request\n\n"
+    "**Review: one must-fix**\n**Must-fix:**\n1. Correct the recorded numbers.\n"
+    "**Tech-debt:** None\n"
+)
+
+
+def _n2_state(bodies, monkeypatch):
+    monkeypatch.setattr(ts, "_pr_comment_bodies", lambda _repo, _num: bodies)
+
+    class _Cfg:  # reviewers_required = 2 (the standing N=2 bar)
+        def get(self, _dotted, default=None):
+            return 2
+
+    return prs.review_state("acme/widget", 206, cfg=_Cfg())
+
+
+def test_n2_two_distinct_clean_requestors_approved(monkeypatch):
+    """2 distinct clean Requestors ⇒ approved, approvals=2 (the PR #206 case)."""
+    state = _n2_state([_N2_CLEAN_TARIQ, _N2_CLEAN_NIA], monkeypatch)
+    assert state["state"] == "approved"
+    assert state["approvals"] == 2
+    assert state["reviewers_required"] == 2
+    assert state["unresolved_must_fix"] == []
+
+
+def test_n2_one_clean_one_unresolved_mustfix_changes_requested(monkeypatch):
+    """1 clean + 1 unresolved Must-fix ⇒ changes_requested (must-fix precedence)."""
+    state = _n2_state([_N2_CLEAN_TARIQ, _N2_MUSTFIX_NIA], monkeypatch)
+    assert state["state"] == "changes_requested"
+    assert state["approvals"] == 1  # the clean reviewer still counts
+    assert len(state["unresolved_must_fix"]) == 1
+
+
+def test_n2_one_clean_only_pending(monkeypatch):
+    """1 clean approval only ⇒ pending (approvals below the required 2)."""
+    state = _n2_state([_N2_CLEAN_TARIQ], monkeypatch)
+    assert state["state"] == "pending"
+    assert state["approvals"] == 1
+    assert state["reviewers_required"] == 2

--- a/framework/tests/test_trust_signals.py
+++ b/framework/tests/test_trust_signals.py
@@ -530,6 +530,137 @@ def test_absent_reviewer_still_buckets_without_roster(tmp_path) -> None:
 
 
 # ===========================================================================
+# N=2 review process (#203): a single PR reviewed by TWO distinct reviewers.
+# These drive the REAL ``ts._account_pr`` (not a test mirror), so they are the
+# mutation bar for the attribution invariants that a 1-reviewer-era
+# implementation silently gets wrong: a catch must be credited to the RIGHT
+# Requestor (never dropped, never double-counted onto one reviewer), the author
+# must take one ``must_fix_received`` per blocking reviewer, and ``rework_cycles``
+# must count the PR ONCE regardless of how many reviewers blocked it.
+# ===========================================================================
+
+
+def _verdict_body(requestor: str, verdict: str, must_fix: str | None) -> str:
+    """A charter-format verdict comment; *must_fix* None → clean, str → blocking."""
+    mf = "Must-fix: None" if must_fix is None else f"Must-fix:\n1. {must_fix}"
+    return (
+        f"Requestor: {requestor}\n"
+        "Requestee: Paloma.Gupta\n"
+        f"RequestOrReplied: {verdict}\n\n"
+        "**Review**\n"
+        f"{mf}\n"
+        "Tech-debt: None\n"
+    )
+
+
+def test_two_distinct_reviewers_each_mustfix_credited_once(tmp_path) -> None:
+    """One PR, two DISTINCT reviewers each raise a must-fix (the N=2 case).
+
+    Every catch is credited to its own Requestor — exactly once each, never
+    dropped, never both folded onto one reviewer. The author takes one
+    ``must_fix_received`` per blocking reviewer (2), but the PR is a SINGLE
+    ``rework_cycles`` round.
+
+    Mutation bar (all in ``_account_pr``):
+      * moving ``rework_cycles += 1`` inside the per-verdict loop (the naive
+        1-reviewer shortcut) makes ``rework_cycles == 2`` → this test fails;
+      * crediting the catch to a single fixed reviewer instead of ``v.requestor``
+        drops one of the two ``must_fix_caught == 1`` assertions → fails;
+      * counting only the first blocking verdict makes ``must_fix_received == 1``
+        → fails.
+    """
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Paloma Gupta",
+        repo="o/r",
+        number=500,
+        comment_bodies=[
+            _verdict_body("Tariq.Morales", "Request", "Fix the thing."),
+            _verdict_body("Nia.Rossi", "Request", "Fix the other thing."),
+        ],
+        ci_red=False,
+    )
+    assert sigs["Paloma Gupta"].must_fix_received == 2  # one per blocking reviewer
+    assert sigs["Paloma Gupta"].rework_cycles == 1  # ONE PR, not one-per-verdict
+    assert sigs["Tariq Morales"].must_fix_caught == 1  # credited to the right reviewer
+    assert sigs["Nia Rossi"].must_fix_caught == 1  # the second catch is not dropped
+
+
+def test_two_reviewers_one_clean_one_mustfix_credits_only_blocker(tmp_path) -> None:
+    """One PR, two distinct reviewers: one clean approval, one must-fix.
+
+    Only the blocking reviewer earns the catch; the clean reviewer earns none.
+    The author takes exactly one ``must_fix_received`` and one ``rework_cycles``.
+
+    Mutation bar: crediting ``must_fix_caught`` off the clean verdict too (an
+    attribution that ignores ``v.changes_requested``) gives Tariq a phantom
+    bucket with a catch → the "Tariq absent" assertion fails. (A clean reviewer
+    produces no trust signal here — approvals are the oracle's concern, not this
+    scorer's — so a clean-only reviewer is legitimately not in the map.)
+    """
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Paloma Gupta",
+        repo="o/r",
+        number=501,
+        comment_bodies=[
+            _verdict_body("Tariq.Morales", "Replied", None),  # clean
+            _verdict_body("Nia.Rossi", "Request", "Fix this."),  # blocking
+        ],
+        ci_red=False,
+    )
+    assert sigs["Paloma Gupta"].must_fix_received == 1
+    assert sigs["Paloma Gupta"].rework_cycles == 1
+    assert sigs["Nia Rossi"].must_fix_caught == 1
+    assert "Tariq Morales" not in sigs  # clean reviewer earns no catch / no bucket
+
+
+def test_durable_ledger_attributes_two_distinct_reviewers(tmp_path) -> None:
+    """The #164 durable review-catch ledger, at N=2: two distinct reviewers each
+    recorded a catch on one PR, and both live comments were later amended clean.
+
+    The ledger stays authoritative for the whole PR — both catches survive the
+    amendment and land on the right (distinct) reviewers; the author still takes
+    two ``must_fix_received`` and one ``rework_cycles``.
+
+    Mutation bar: a 1-reviewer ledger read (e.g. only the first entry, or folding
+    every entry onto one reviewer) drops Nia's catch → the two
+    ``must_fix_caught == 1`` assertions fail. Reading the amended-clean live
+    comments instead of the ledger makes ``must_fix_received == 0`` → fails.
+    """
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ledger = [
+        {"repo": "o/r", "pr": 502, "requestor": "Tariq.Morales", "requestee": "Paloma.Gupta"},
+        {"repo": "o/r", "pr": 502, "requestor": "Nia.Rossi", "requestee": "Paloma.Gupta"},
+    ]
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Paloma Gupta",
+        repo="o/r",
+        number=502,
+        # Both blocking comments were amended in place to clean after the fix.
+        comment_bodies=[
+            _verdict_body("Tariq.Morales", "Replied", None),
+            _verdict_body("Nia.Rossi", "Replied", None),
+        ],
+        ci_red=False,
+        review_catches=ledger,
+    )
+    assert sigs["Paloma Gupta"].must_fix_received == 2  # ledger, not amended comments
+    assert sigs["Paloma Gupta"].rework_cycles == 1
+    assert sigs["Tariq Morales"].must_fix_caught == 1
+    assert sigs["Nia Rossi"].must_fix_caught == 1
+
+
+# ===========================================================================
 # Integration-branch resolution (#100): phase-aware branch.integration template.
 # ===========================================================================
 


### PR DESCRIPTION
Story **S2 (#203)** — harden the N=2 team process end-to-end. Base `deployments/phase6/wave-6` (S1 `8fcecf9` merged). Reviewers (×2): **Paloma Gupta + Tariq Morales**. Meta #201.

## Summary
The oracle's N-of-M path had only ever run in unit tests. This PR (a) proves it live on the real 2-reviewer PR #206, and (b) audits the surrounding trust/lifecycle tooling for 1-reviewer assumptions and locks the result with mutation-style tests. **No production asset changed — tests only** (+6 tests, 706 pass).

## AC1 — End-to-end proof on real multi-reviewer data
PR #206 carries **2 distinct real clean Requestors** (`Nia.Rossi` + `Tariq.Morales`, both `RequestOrReplied: Replied` / `Must-fix: None`). Live oracle run:

```
$ python3 framework/assets/lib/pr_review_state.py 206 --repo parametrization/2real-team-framework
PR #206 (parametrization/2real-team-framework) — review state: APPROVED
  approvals: 2/2 required
  unresolved must-fix verdicts: none
```

All three transitions, driven through the real `parse_verdicts` → `compute_state` chain on **real comment bodies** (clean bodies from #206; a genuine blocking verdict pulled from #93, `Nia.Rossi` must-fix):

| Scenario (real bodies) | state | approvals | must-fix |
|---|---|---|---|
| 2 distinct clean (Tariq+Nia, #206) | `approved` | 2/2 | 0 |
| 1 clean (Tariq #206) + 1 unresolved Must-fix (Nia #93) | `changes_requested` | 1/2 | 1 |
| 1 clean only (Tariq #206) | `pending` | 1/2 | 0 |

Regression anchor: `test_pr_review_state.py::test_n2_*` runs this exact matrix at `reviewers_required=2` through the fail-open wrapper.

## AC2 — 1-reviewer-assumption audit + load-bearing coverage
**Finding: no 1-reviewer assumption exists** in `trust_signals` or `lifecycle wrapup`. Both were already N-of-M correct; proven with mutation-style tests (revert ⇒ fail) driving the **real** `ts._account_pr` (not a test mirror):

- **`trust_signals._account_pr`** — verdict attribution is per-`Requestor`:
  - 2 distinct reviewers each catching a must-fix on ONE PR ⇒ each `must_fix_caught == 1` (right reviewer, never dropped, never folded onto one), author `must_fix_received == 2`, **`rework_cycles == 1`** (per-PR, not per-verdict).
  - 1 clean + 1 must-fix ⇒ only the blocker is credited; the clean reviewer earns no bucket (approvals are the oracle's job, not this scorer's).
  - Durable ledger (#164) attributes **2 distinct** catches even after both live comments are amended clean.
- **`lifecycle.wrapup_wave`** — a pure passthrough that stores whatever `cr_cycles`/`concentration` ints it's handed; no reviewer logic, so no 1-reviewer assumption. The real cr-cycle N=2 correctness lives upstream in `rework_cycles` (per-PR), which the new tests lock down.

**Mutation proof** (each naive 1-reviewer rewrite fails exactly its guard, source restored clean):

| Mutation | Result |
|---|---|
| `rework_cycles` incremented per-verdict (1-reviewer shortcut) | 2 failed / 1 passed |
| catch credited to author instead of `v.requestor` (drop attribution) | 2 failed / 1 passed |
| ledger reads only first catch (`catches[:1]`) | 1 failed / 2 passed |

New tests: `test_trust_signals.py::{test_two_distinct_reviewers_each_mustfix_credited_once, test_two_reviewers_one_clean_one_mustfix_credits_only_blocker, test_durable_ledger_attributes_two_distinct_reviewers}` + the 3 `test_pr_review_state.py::test_n2_*`.

## AC3 — Dual-deploy #116
Only test files under `framework/tests/` changed — not part of the golden manifest / not deployed to `.claude/`, so no reinstall step applies. Gates still verified:
- `reinstall.py --check` → exit 0 (`.claude/` in sync)
- `manifest.py --check` → exit 0 (golden-manifest in sync)
- `charter_drift.py --check` → exit 0 (charter matches canonical)

## AC4 — lint + tests
- `ruff check framework/` → clean
- `ENVIRONMENT=test pytest framework/tests/` → **706 passed**

## Note routed to S3 (charter/skill wording — NOT edited here per scope discipline)
`framework/assets/skills/wave-end/SKILL.md:49` defines `--cr-cycles` = "**ChangesRequested verdicts** across them". At N=2 that phrasing counts two blocking verdicts on one PR as **2** cycles, but the code's `rework_cycles` (the intended semantics of the `changes_requested_cycles` counter) counts the PR **once**. Recommend the wording bind to "**PRs that took ≥1 changes-requested round**" (= sum of per-PR `rework_cycles`) so the manual wrapup count matches the mechanical scorer at N≥2. Flagging for the integration-owner rather than editing (process-doc / shared-registry territory).

Depends on S1's activation (`reviewers_required=2`) already merged at `8fcecf9`. **Do not merge** — awaiting the two reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
