### PR TITLE
Phase 6 Wave 6 — Activate the review gate (arms reviewers_required=2 + gate on this repo)

### DIFF
--- a/.claude/framework.config.json
+++ b/.claude/framework.config.json
@@ -18,8 +18,8 @@
     "allow_emails": ["parametrization@gmail.com"]
   },
   "policy": {
-    "reviewers_required": 1,
-    "pr_review_gate_enabled": false,
+    "reviewers_required": 2,
+    "pr_review_gate_enabled": true,
     "merge_model": "wave-branch"
   },
   "ci": {

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -21,6 +21,13 @@ blocked.
   in `.claude/framework.config.json` is the N-reviewer gate. Read it — a PR needs
   that many DISTINCT approving reviewers before it can merge, so your approval may
   be only one of several required.
+- **When `policy.pr_review_gate_enabled` is true, that bar is mechanically enforced:**
+  the `validate_pr_review` hook BLOCKS `gh pr ready` / `gh pr merge` until the oracle
+  reports the PR `approved` (`reviewers_required` distinct clean approvals AND no
+  unresolved `Must-fix:`). Your clean verdict is then load-bearing — the merge cannot
+  land without it. (Escape hatch if the team ever wedges: an owner reverts the flag with
+  a direct config-only commit to the default branch; the gate is also fail-open on an
+  oracle error.) When the flag is false the same bar is advisory, not blocked.
 
 ## Instructions
 1. Fetch PR diff: `gh pr diff {number}`

--- a/.claude/team/.charter-manifest.json
+++ b/.claude/team/.charter-manifest.json
@@ -6,8 +6,8 @@
     "charter.md": "b2d200f1de236bc1ba6d997917be5e186504a05c12015e392b1ecf7291564dfb",
     "commits.md": "c9d5e7349f0ead70cb37dd8cf20a7753fe3bea5c943ad56fe3f661dc4daaab67",
     "hooks.md": "77d72942082cf0dd1fb45da686376d8813d3e2b30ebe1ec4f99e432ef0fdb1d5",
-    "issues.md": "6f57a50dd85c4dd516c5dfd5a6772f65b881f5089929504166c267148544e62b",
-    "pull-requests.md": "54cfb55729ac26a5a4b066c48f19639912656cc1b4e659d56d29da3bd3af0a99",
+    "issues.md": "18d7a6a6e31112abad5ae6f92635c268168cce750b3372aacfa9d875f3dfbc9d",
+    "pull-requests.md": "b22eb3ea593b0dde9d37d1387f04ab07c18f5eeffa8f9a54b20070c7178710ff",
     "skills.md": "dcc93b623b5f62cbac412634d4d3b04c3731c5a4a0892dd3227c70241703e81e"
   }
 }

--- a/.claude/team/.charter-manifest.json
+++ b/.claude/team/.charter-manifest.json
@@ -3,11 +3,11 @@
   "files": {
     "agents.md": "8a53b9a7bf6b97e473bc5387b84609a83fe8c0524374d66dc2330e5d7ed450ce",
     "branching.md": "3e51782810787065403bbd7203610e7be247788cb60278960859e1ffb922b5af",
-    "charter.md": "bc0f7655f97c2d6e872e8c2f74ef2ab9a3e1a8919bc526c30bcc6df6defe98c5",
+    "charter.md": "b2d200f1de236bc1ba6d997917be5e186504a05c12015e392b1ecf7291564dfb",
     "commits.md": "c9d5e7349f0ead70cb37dd8cf20a7753fe3bea5c943ad56fe3f661dc4daaab67",
-    "hooks.md": "4b2ce25d2365800ec6d940cd091be12c7a230092b91dc673fac78a4bd823068e",
+    "hooks.md": "77d72942082cf0dd1fb45da686376d8813d3e2b30ebe1ec4f99e432ef0fdb1d5",
     "issues.md": "6f57a50dd85c4dd516c5dfd5a6772f65b881f5089929504166c267148544e62b",
-    "pull-requests.md": "7dd6f9aa05edf6fb4949de64f084d50c075cfefacb3bec7838e1cc05fde92e24",
+    "pull-requests.md": "54cfb55729ac26a5a4b066c48f19639912656cc1b4e659d56d29da3bd3af0a99",
     "skills.md": "dcc93b623b5f62cbac412634d4d3b04c3731c5a4a0892dd3227c70241703e81e"
   }
 }

--- a/.claude/team/charter/charter.md
+++ b/.claude/team/charter/charter.md
@@ -30,7 +30,7 @@ documents (CLAUDE.md, roster cards, skills) should link here rather than restate
 - **Owner:** `parametrization` · **Default branch:** `main` ·
   **Merge model:** `wave-branch` (configured default; the effective model per
   wave is declared at kickoff via `lifecycle.py wave kickoff --merge-model …` and
-  recorded in the state file) · **Reviews required per PR:** 1
+  recorded in the state file) · **Reviews required per PR:** 2
 - **User approval gates.** Merging to `main`, creating releases, and
   kicking off a new wave all require explicit approval from the project owner. No
   team member may bypass these gates.

--- a/.claude/team/charter/issues.md
+++ b/.claude/team/charter/issues.md
@@ -9,6 +9,50 @@
 3. Disputes about ownership are negotiated with the relevant lead and the Manager;
    the Manager makes the final call.
 
+## Wave Planning: Shared Artifacts & Frozen Contracts
+
+Two planning rules the Manager/lead apply when decomposing a wave into parallel
+stories. Both pre-empt a *predictable*, foreseeable-at-planning failure rather than
+resolving it after the fact.
+
+### Single Integration-Owner for Shared Registries
+
+When two or more stories in the same wave will touch the **same shared config list,
+registry, or module** — e.g. `hooks.pre_bash`, a `_DEFAULTS` / `_MANAGED_TREES` list,
+the golden install manifest, or a single charter module (`pull-requests.md`) — the
+Manager **designates exactly ONE story as the integration-owner** for that artifact at
+wave kickoff (or explicitly **serializes** those specific edits so they never land in
+parallel). Every other story routes the change it needs into that artifact **through the
+owner** (via the lead's relay) instead of editing the shared artifact itself.
+
+Rationale: two stories editing one append-only list — or one prose module — produce a
+**predictable** merge conflict that is foreseeable at planning, not an accident to
+resolve after the fact (Phase 6 Wave 5, #201: the S2↔S3 `hooks.pre_bash` conflict
+surfaced as a CONFLICTING PR and cost a resolution round-trip that kickoff could have
+pre-empted). Designating one owner removes the round-trip; serializing the edits is the
+fallback when no single owner is natural. The designation is recorded in the wave
+kickoff brief alongside reviewer assignment.
+
+If this rule ever becomes worth mechanically enforcing (e.g. a gate that flags two
+in-flight branches touching the same registry), file it as a follow-up issue — do not
+build the gate inline.
+
+### Pin Frozen Contracts Against Code, Not Prose
+
+When a wave **freezes an inter-story contract** — a data shape, API signature, hook
+grammar, or parsing vocabulary that a later story will build against — the frozen
+contract must be **validated against the actual code layer at authoring time**: check
+the real signature / grammar / parser it binds to, not only a narrative description of
+it. The kickoff brief that pins the contract carries the concrete check (the exact
+field name, token, or signature it must agree with), not prose alone.
+
+Rationale: a contract authored in prose alone can read as internally consistent and
+still be wrong against the code it names (Phase 6 Wave 5, #201: the frozen `ReviewState`
+contract said "distinct requestees" where the charter's verdict grammar makes the
+reviewer the `Requestor:` — so a 2-reviewer bar could never clear; caught downstream by
+the implementer, far later than authoring). A one-line grammar/signature check against
+the real code at freeze time moves that whole class of defect left of implementation.
+
 ## Issue Review Process
 
 Every newly created issue gets a review pass from each lead and senior contributor.

--- a/.claude/team/charter/pull-requests.md
+++ b/.claude/team/charter/pull-requests.md
@@ -92,8 +92,30 @@ Closes #<issue-number>
 
 ## Review Workflow
 
-Every PR requires **1 review(s)** from team members who are not
+Every PR requires **2 review(s)** from team members who are not
 the branch author.
+
+### The N-reviewer merge gate (mechanically enforced when armed)
+
+The reviewer bar is not advisory when `policy.pr_review_gate_enabled` is **true**: the
+`validate_pr_review` PreToolUse hook (thin over the `lib/pr_review_state` oracle — see
+[hooks.md](hooks.md)) **blocks `gh pr ready` / `gh pr merge` until the PR is
+`approved`** — meaning **2 distinct clean reviewer approvals AND no
+unresolved `Must-fix:` verdict**. Approvals are counted over distinct `Requestor:`
+identities whose current verdict is clean (a `Replied` review with `Must-fix: None`, per
+[issues.md](issues.md)); a standing `Must-fix:` blocks regardless of the approval count.
+
+- **On THIS repo the gate is LIVE as of Phase 6 Wave 6** (`pr_review_gate_enabled=true`,
+  `reviewers_required=2`): a merge cannot land without 2 distinct clean approvals.
+- **The framework ships the gate DORMANT** (`pr_review_gate_enabled=false`): a downstream
+  install keeps this bar advisory until its owner flips the flag, so nothing here blocks a
+  fresh adopter's merges.
+- **Escape hatch (if the team wedges):** the gate must never trap the team. It can be
+  disarmed by a **direct config-only commit to `main`** setting
+  `policy.pr_review_gate_enabled` back to `false` (no PR merge required — the config edit
+  itself is not a gated verb). The gate is additionally **fail-open on oracle error**: an
+  inability to *evaluate* approval state ALLOWS the merge rather than hard-blocking it, so a
+  broken oracle can never wedge the workflow either.
 
 1. **Create the PR** and notify the assigned reviewer(s).
 2. **Reviewer reviews** and posts findings on the PR, classified as:

--- a/.claude/team/charter/pull-requests.md
+++ b/.claude/team/charter/pull-requests.md
@@ -128,9 +128,23 @@ identities whose current verdict is clean (a `Replied` review with `Must-fix: No
 4. **Merge into the integration branch** — the team merges these PRs itself; no
    owner approval is needed below `main`.
 
-Reviewers are assigned by the lead at wave kickoff (no self-review; spread the load).
-The reviewer runs the tests on the branch — a review is an act of verification, not
-a reading exercise.
+### Reviewer Assignment (distinct, author-exclusive)
+
+Reviewers are assigned by the lead at wave kickoff (spread the load). The reviewer runs
+the tests on the branch — a review is an act of verification, not a reading exercise.
+
+Every PR is assigned **2 distinct reviewers**, and the assignment
+is **author-exclusive**: a reviewer can never be the PR's own author — the `Requestee:`
+of that PR's verdicts, per the verdict grammar in [issues.md](issues.md). The
+2 reviewers must be 2 *different* people; the
+same reviewer counted twice does not satisfy the bar, and no self-review is permitted.
+
+This assignment convention is what the armed merge gate mechanically enforces (§ The
+N-reviewer merge gate): the oracle counts clean approvals over **distinct `Requestor:`
+identities other than the author**, so assigning fewer than 2
+distinct non-author reviewers leaves the PR unable to reach `approved` — it cannot
+merge. Assign the full slate at kickoff so the process the gate checks and the process
+the team runs are the same one.
 
 ## CI Gates
 

--- a/.claude/team/feedback_log.md
+++ b/.claude/team/feedback_log.md
@@ -577,14 +577,22 @@ review-gate flagship — `pr_review_state` oracle (S1), `block_gh_pr_review` sub
    prose without checking it against the actual verdict grammar/`trust_signals` — the requestee/Requestor
    error got through planning and was caught downstream by the implementer, later than it should've been.
 
-### New proposals (need owner approval before a future wave adopts them)
+### New proposals (owner-approved at Phase 6 Wave 6 kickoff — both folded into the charter this wave)
 1. **Single integration-owner for shared registries.** When 2+ stories in a wave touch the same shared
    config list / registry (`pre_bash`, `_DEFAULTS`, golden manifest), designate one story as the
    integration owner for that list (or serialize those specific edits) so the predictable merge conflict
    is pre-empted rather than resolved after the fact. Low effort, removes a recurring round-trip.
+   **Status: APPLIED via #204 (Phase 6 Wave 6, S3)** — written into the charter as
+   `framework/assets/team/charter/issues.md` § Wave Planning → "Single Integration-Owner for Shared
+   Registries" (canonical + dual-deployed to runtime, byte-identical via `charter_drift.py --check`).
+   Dogfooded live this wave: S3 (Nia) was the sole charter integration-owner; S2 (Ibrahim) was barred
+   from editing `charter/**` and routed wording through the lead's relay.
 2. **Pin contracts against code, not just prose.** When a wave freezes an inter-story contract, validate
    it against the actual grammar/parsing layer at authoring time (a quick grammar check), not only in
    narrative. Would have caught the requestee/Requestor bug before it reached an implementer.
+   **Status: APPLIED via #204 (Phase 6 Wave 6, S3)** — written into the charter as
+   `framework/assets/team/charter/issues.md` § Wave Planning → "Pin Frozen Contracts Against Code, Not
+   Prose" (canonical + dual-deployed to runtime).
 
 ### Carry-over (still unapplied, from Wave 9 retro — no early slot claimed this flagship wave)
 - **Charter-manifest checksum cross-check** in `charter_drift.py plan()` (Nia's #190 tech-debt).

--- a/framework/assets/skills/review-pr/SKILL.md
+++ b/framework/assets/skills/review-pr/SKILL.md
@@ -21,6 +21,13 @@ blocked.
   in `.claude/framework.config.json` is the N-reviewer gate. Read it — a PR needs
   that many DISTINCT approving reviewers before it can merge, so your approval may
   be only one of several required.
+- **When `policy.pr_review_gate_enabled` is true, that bar is mechanically enforced:**
+  the `validate_pr_review` hook BLOCKS `gh pr ready` / `gh pr merge` until the oracle
+  reports the PR `approved` (`reviewers_required` distinct clean approvals AND no
+  unresolved `Must-fix:`). Your clean verdict is then load-bearing — the merge cannot
+  land without it. (Escape hatch if the team ever wedges: an owner reverts the flag with
+  a direct config-only commit to the default branch; the gate is also fail-open on an
+  oracle error.) When the flag is false the same bar is advisory, not blocked.
 
 ## Instructions
 1. Fetch PR diff: `gh pr diff {number}`

--- a/framework/assets/team/charter/issues.md
+++ b/framework/assets/team/charter/issues.md
@@ -9,6 +9,50 @@
 3. Disputes about ownership are negotiated with the relevant lead and the Manager;
    the Manager makes the final call.
 
+## Wave Planning: Shared Artifacts & Frozen Contracts
+
+Two planning rules the Manager/lead apply when decomposing a wave into parallel
+stories. Both pre-empt a *predictable*, foreseeable-at-planning failure rather than
+resolving it after the fact.
+
+### Single Integration-Owner for Shared Registries
+
+When two or more stories in the same wave will touch the **same shared config list,
+registry, or module** — e.g. `hooks.pre_bash`, a `_DEFAULTS` / `_MANAGED_TREES` list,
+the golden install manifest, or a single charter module (`pull-requests.md`) — the
+Manager **designates exactly ONE story as the integration-owner** for that artifact at
+wave kickoff (or explicitly **serializes** those specific edits so they never land in
+parallel). Every other story routes the change it needs into that artifact **through the
+owner** (via the lead's relay) instead of editing the shared artifact itself.
+
+Rationale: two stories editing one append-only list — or one prose module — produce a
+**predictable** merge conflict that is foreseeable at planning, not an accident to
+resolve after the fact (Phase 6 Wave 5, #201: the S2↔S3 `hooks.pre_bash` conflict
+surfaced as a CONFLICTING PR and cost a resolution round-trip that kickoff could have
+pre-empted). Designating one owner removes the round-trip; serializing the edits is the
+fallback when no single owner is natural. The designation is recorded in the wave
+kickoff brief alongside reviewer assignment.
+
+If this rule ever becomes worth mechanically enforcing (e.g. a gate that flags two
+in-flight branches touching the same registry), file it as a follow-up issue — do not
+build the gate inline.
+
+### Pin Frozen Contracts Against Code, Not Prose
+
+When a wave **freezes an inter-story contract** — a data shape, API signature, hook
+grammar, or parsing vocabulary that a later story will build against — the frozen
+contract must be **validated against the actual code layer at authoring time**: check
+the real signature / grammar / parser it binds to, not only a narrative description of
+it. The kickoff brief that pins the contract carries the concrete check (the exact
+field name, token, or signature it must agree with), not prose alone.
+
+Rationale: a contract authored in prose alone can read as internally consistent and
+still be wrong against the code it names (Phase 6 Wave 5, #201: the frozen `ReviewState`
+contract said "distinct requestees" where the charter's verdict grammar makes the
+reviewer the `Requestor:` — so a 2-reviewer bar could never clear; caught downstream by
+the implementer, far later than authoring). A one-line grammar/signature check against
+the real code at freeze time moves that whole class of defect left of implementation.
+
 ## Issue Review Process
 
 Every newly created issue gets a review pass from each lead and senior contributor.

--- a/framework/assets/team/charter/pull-requests.md
+++ b/framework/assets/team/charter/pull-requests.md
@@ -95,6 +95,28 @@ Closes #<issue-number>
 Every PR requires **{{reviewers_required}} review(s)** from team members who are not
 the branch author.
 
+### The N-reviewer merge gate (mechanically enforced when armed)
+
+The reviewer bar is not advisory when `policy.pr_review_gate_enabled` is **true**: the
+`validate_pr_review` PreToolUse hook (thin over the `lib/pr_review_state` oracle — see
+[hooks.md](hooks.md)) **blocks `gh pr ready` / `gh pr merge` until the PR is
+`approved`** — meaning **{{reviewers_required}} distinct clean reviewer approvals AND no
+unresolved `Must-fix:` verdict**. Approvals are counted over distinct `Requestor:`
+identities whose current verdict is clean (a `Replied` review with `Must-fix: None`, per
+[issues.md](issues.md)); a standing `Must-fix:` blocks regardless of the approval count.
+
+- **On THIS repo the gate is LIVE as of Phase 6 Wave 6** (`pr_review_gate_enabled=true`,
+  `reviewers_required=2`): a merge cannot land without 2 distinct clean approvals.
+- **The framework ships the gate DORMANT** (`pr_review_gate_enabled=false`): a downstream
+  install keeps this bar advisory until its owner flips the flag, so nothing here blocks a
+  fresh adopter's merges.
+- **Escape hatch (if the team wedges):** the gate must never trap the team. It can be
+  disarmed by a **direct config-only commit to `{{default_branch}}`** setting
+  `policy.pr_review_gate_enabled` back to `false` (no PR merge required — the config edit
+  itself is not a gated verb). The gate is additionally **fail-open on oracle error**: an
+  inability to *evaluate* approval state ALLOWS the merge rather than hard-blocking it, so a
+  broken oracle can never wedge the workflow either.
+
 1. **Create the PR** and notify the assigned reviewer(s).
 2. **Reviewer reviews** and posts findings on the PR, classified as:
    - **Must-fix** — blocks merge; the submitter resolves before proceeding.

--- a/framework/assets/team/charter/pull-requests.md
+++ b/framework/assets/team/charter/pull-requests.md
@@ -128,9 +128,23 @@ identities whose current verdict is clean (a `Replied` review with `Must-fix: No
 4. **Merge into the integration branch** — the team merges these PRs itself; no
    owner approval is needed below `{{default_branch}}`.
 
-Reviewers are assigned by the lead at wave kickoff (no self-review; spread the load).
-The reviewer runs the tests on the branch — a review is an act of verification, not
-a reading exercise.
+### Reviewer Assignment (distinct, author-exclusive)
+
+Reviewers are assigned by the lead at wave kickoff (spread the load). The reviewer runs
+the tests on the branch — a review is an act of verification, not a reading exercise.
+
+Every PR is assigned **{{reviewers_required}} distinct reviewers**, and the assignment
+is **author-exclusive**: a reviewer can never be the PR's own author — the `Requestee:`
+of that PR's verdicts, per the verdict grammar in [issues.md](issues.md). The
+{{reviewers_required}} reviewers must be {{reviewers_required}} *different* people; the
+same reviewer counted twice does not satisfy the bar, and no self-review is permitted.
+
+This assignment convention is what the armed merge gate mechanically enforces (§ The
+N-reviewer merge gate): the oracle counts clean approvals over **distinct `Requestor:`
+identities other than the author**, so assigning fewer than {{reviewers_required}}
+distinct non-author reviewers leaves the PR unable to reach `approved` — it cannot
+merge. Assign the full slate at kickoff so the process the gate checks and the process
+the team runs are the same one.
 
 ## CI Gates
 

--- a/framework/tests/test_activate_pr_review_gate.py
+++ b/framework/tests/test_activate_pr_review_gate.py
@@ -1,0 +1,264 @@
+"""Load-bearing integration test for the ACTIVATED PR-review gate (#202, W6/S1).
+
+Unlike ``test_validate_pr_review.py`` (which hand-builds fixture policy values),
+this test wires the gate against **this repo's ACTUAL runtime config**
+(``.claude/framework.config.json``): it reads the shipped ``policy`` block and
+drives ``validate_pr_review.check`` + the ``pr_review_state`` oracle with those
+exact values. That makes it break if the activation is reverted — it is the
+mutation bar for the config edit this story ships.
+
+What it pins (all against the real config, no hand-built policy fixture):
+
+* ``test_repo_config_is_activated`` — the shipped values ARE the activation
+  (``pr_review_gate_enabled=true``, ``reviewers_required=2``). A revert of either
+  fails here directly.
+* ``test_enabled_not_approved_blocks_gh_pr_merge`` — armed by the REAL flag, a
+  not-approved oracle state ⇒ the gate returns a ``block`` decision on
+  ``gh pr merge``, and the reason names ``approvals X/N`` with N = the real
+  ``reviewers_required`` (``0/2``).
+* ``test_two_distinct_clean_requestor_verdicts_approve`` — the oracle's real
+  ``compute_state`` over TWO distinct clean ``Requestor:`` verdicts, at the real
+  ``reviewers_required``, reports ``approved`` — and the gate then ALLOWS the
+  merge. ONE clean verdict does not (``pending``); a standing ``Must-fix:`` does
+  not (``changes_requested``).
+* ``test_mutation_bar_reverting_config_flips_the_block`` — the SAME not-approved
+  oracle state that BLOCKS under the real (activated) config ALLOWS once the two
+  config values are reverted in a copy (``enabled=false``, ``reviewers_required=1``).
+  This is the explicit revert→fail simulation for the two-line config change.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+_REPO_ROOT = _FRAMEWORK_ROOT.parent
+sys.path.insert(0, str(_FRAMEWORK_ROOT / "assets" / "hooks"))
+sys.path.insert(0, str(_FRAMEWORK_ROOT / "assets" / "lib"))
+
+import pr_review_state as oracle  # noqa: E402
+import trust_signals as ts  # noqa: E402
+import validate_pr_review as hook  # noqa: E402
+
+#: This repo's live runtime config — the file the gate actually loads in anger.
+_CONFIG_PATH = _REPO_ROOT / ".claude" / "framework.config.json"
+
+
+def _real_policy() -> dict:
+    """The ACTUAL shipped ``policy`` block (not a hand-built fixture)."""
+    return json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))["policy"]
+
+
+class _RealCfg:
+    """Dotted-get config shim over a real ``policy`` dict.
+
+    Matches the surface both consumers use: the hook reads
+    ``config(...).get("policy.pr_review_gate_enabled")`` and the oracle reads
+    ``cfg.get("policy.reviewers_required")``. Fed the SHIPPED policy so the gate
+    is exercised with this repo's real activation values.
+    """
+
+    def __init__(self, policy: dict) -> None:
+        self._policy = policy
+
+    def get(self, key: str, default=None):
+        if key.startswith("policy."):
+            return self._policy.get(key[len("policy.") :], default)
+        return default
+
+
+def _bash(command: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+def _arm_with(monkeypatch, policy: dict) -> None:
+    """Point the hook's config at a ``_RealCfg`` over *policy*."""
+    monkeypatch.setattr(
+        hook, "config", lambda input_data=None, **kw: _RealCfg(policy)
+    )
+
+
+def _stub_oracle(monkeypatch, state: dict) -> None:
+    """Replace the oracle's I/O so no real ``gh``/network is touched."""
+    monkeypatch.setattr(hook, "review_state", lambda repo, pr, **kw: state)
+
+
+def _clean_verdict_body(requestor: str, requestee: str = "Paloma.Gupta") -> str:
+    """A charter-grammar clean approval (``Replied`` / ``Must-fix: None``)."""
+    return (
+        f"Requestor: {requestor}\n"
+        f"Requestee: {requestee}\n"
+        "RequestOrReplied: Replied\n\n"
+        "**Review: LGTM**\n"
+        "Must-fix: None\n"
+        "Tech-debt: None\n"
+    )
+
+
+def _must_fix_body(requestor: str, requestee: str = "Paloma.Gupta") -> str:
+    """A charter-grammar changes-requested verdict (one blocking Must-fix)."""
+    return (
+        f"Requestor: {requestor}\n"
+        f"Requestee: {requestee}\n"
+        "RequestOrReplied: Request\n\n"
+        "**Review: one blocker**\n"
+        "Must-fix:\n"
+        "1. Config value must be reverted before merge.\n"
+        "Tech-debt: None\n"
+    )
+
+
+# An explicit --repo + literal PR so resolve_repo/resolve_pr never shell out.
+_MERGE = "gh pr merge 202 --repo parametrization/2real-team-framework --squash"
+
+
+# --------------------------------------------------------------- activation is live
+
+
+def test_repo_config_is_activated() -> None:
+    """The shipped runtime config carries the activation this story delivers."""
+    policy = _real_policy()
+    assert policy["pr_review_gate_enabled"] is True, (
+        "gate must be ARMED on this repo (pr_review_gate_enabled=true)"
+    )
+    assert policy["reviewers_required"] == 2, (
+        "this repo requires 2 distinct clean approvals to merge"
+    )
+
+
+# --------------------------------------------------------------- gate BLOCKS (real config)
+
+
+def test_enabled_not_approved_blocks_gh_pr_merge(monkeypatch) -> None:
+    """Real flag=true + not-approved oracle ⇒ block, reason names approvals 0/N."""
+    policy = _real_policy()
+    required = policy["reviewers_required"]
+    _arm_with(monkeypatch, policy)
+    _stub_oracle(
+        monkeypatch,
+        {
+            "state": oracle.PENDING,
+            "approvals": 0,
+            "reviewers_required": required,
+            "unresolved_must_fix": [],
+        },
+    )
+    result = hook.check(_bash(_MERGE))
+    assert result is not None, "an activated gate must block a not-approved merge"
+    assert result["decision"] == "block"
+    assert f"0/{required}" in result["reason"]
+    assert "#202" in result["reason"]
+
+
+def test_standing_must_fix_blocks(monkeypatch) -> None:
+    """A standing Must-fix blocks even at/above the approval count; reason names it."""
+    policy = _real_policy()
+    _arm_with(monkeypatch, policy)
+    verdicts = ts.parse_verdicts(
+        [
+            _clean_verdict_body("Nia.Rossi"),
+            _clean_verdict_body("Tariq.Morales"),
+            _must_fix_body("Ibrahim.El-Amin"),
+        ]
+    )
+    state = oracle.compute_state(verdicts, policy["reviewers_required"])
+    assert state["state"] == oracle.CHANGES_REQUESTED
+    _stub_oracle(monkeypatch, state)
+    result = hook.check(_bash(_MERGE))
+    assert result is not None
+    assert result["decision"] == "block"
+    assert "Must-fix" in result["reason"]
+    assert "Ibrahim.El-Amin" in result["reason"]
+
+
+# --------------------------------------------------------------- oracle: 2-of-2 approves
+
+
+def test_two_distinct_clean_requestor_verdicts_approve(monkeypatch) -> None:
+    """The real oracle at reviewers_required=2 approves on 2 distinct clean verdicts."""
+    required = _real_policy()["reviewers_required"]
+    assert required == 2  # the invariant the rest of this test is meaningful under
+
+    # Two distinct clean Requestors -> approved.
+    two = oracle.compute_state(
+        ts.parse_verdicts(
+            [_clean_verdict_body("Nia.Rossi"), _clean_verdict_body("Tariq.Morales")]
+        ),
+        required,
+    )
+    assert two["state"] == oracle.APPROVED
+    assert two["approvals"] == 2
+
+    # One distinct clean Requestor -> NOT enough (pending).
+    one = oracle.compute_state(
+        ts.parse_verdicts([_clean_verdict_body("Nia.Rossi")]), required
+    )
+    assert one["state"] == oracle.PENDING
+    assert one["approvals"] == 1
+
+    # Two comments from the SAME reviewer collapse to one approval (distinct-Requestor).
+    dup = oracle.compute_state(
+        ts.parse_verdicts(
+            [_clean_verdict_body("Nia.Rossi"), _clean_verdict_body("Nia.Rossi")]
+        ),
+        required,
+    )
+    assert dup["state"] == oracle.PENDING
+    assert dup["approvals"] == 1
+
+
+def test_enabled_approved_allows_merge(monkeypatch) -> None:
+    """Real flag=true + an oracle-approved state ⇒ the gate ALLOWS the merge."""
+    policy = _real_policy()
+    approved = oracle.compute_state(
+        ts.parse_verdicts(
+            [_clean_verdict_body("Nia.Rossi"), _clean_verdict_body("Tariq.Morales")]
+        ),
+        policy["reviewers_required"],
+    )
+    assert approved["state"] == oracle.APPROVED
+    _arm_with(monkeypatch, policy)
+    _stub_oracle(monkeypatch, approved)
+    assert hook.check(_bash(_MERGE)) is None
+
+
+# --------------------------------------------------------------- mutation bar
+
+
+def test_mutation_bar_reverting_config_flips_the_block(monkeypatch) -> None:
+    """Reverting the two config values flips the BLOCK to an ALLOW (revert→fail sim).
+
+    The SAME not-approved oracle state is evaluated twice: under the real
+    (activated) policy it BLOCKS; under a copy with the two values reverted
+    (``pr_review_gate_enabled=false``, ``reviewers_required=1``) it ALLOWS. If the
+    shipped config ever regresses to the reverted values, the block above stops
+    happening — which is exactly what this asserts must NOT be the live state.
+    """
+    real = _real_policy()
+    pending = {
+        "state": oracle.PENDING,
+        "approvals": 0,
+        "reviewers_required": real["reviewers_required"],
+        "unresolved_must_fix": [],
+    }
+    _stub_oracle(monkeypatch, pending)
+
+    # Activated (real) config: BLOCKS.
+    _arm_with(monkeypatch, real)
+    assert hook.check(_bash(_MERGE)) is not None
+
+    # Reverted copy: same not-approved PR now ALLOWS (dormant no-op).
+    reverted = copy.deepcopy(real)
+    reverted["pr_review_gate_enabled"] = False
+    reverted["reviewers_required"] = 1
+    _arm_with(monkeypatch, reverted)
+    assert hook.check(_bash(_MERGE)) is None
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/framework/tests/test_pr_review_state.py
+++ b/framework/tests/test_pr_review_state.py
@@ -290,3 +290,65 @@ def test_review_state_wrapper_surfaces_must_fix_from_real_body(monkeypatch):
     state = prs.review_state("acme/widget", 99, cfg=_Cfg())
     assert state["state"] == "changes_requested"
     assert len(state["unresolved_must_fix"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# N=2 end-to-end matrix (#203): the three review outcomes at reviewers_required=2,
+# driven through the full fetch→parse→compute chain on charter-format bodies whose
+# shape is taken from the real wave-6 multi-reviewer PR (#206: two distinct clean
+# Requestors — Nia.Rossi + Tariq.Morales) and a real blocking verdict (#93 shape).
+# This is the regression anchor for the live proof captured in the #203 PR body:
+# the oracle's N-of-M path, exercised end-to-end rather than only on hand-built
+# Verdict objects.
+# ---------------------------------------------------------------------------
+
+# Two distinct clean Requestors — the exact shape PR #206 carries.
+_N2_CLEAN_TARIQ = (
+    "Requestor: Tariq.Morales\nRequestee: Paloma.Gupta\nRequestOrReplied: Replied\n\n"
+    "**Review: verified — ships as-is**\nMust-fix: None\nTech-debt: None\n"
+)
+_N2_CLEAN_NIA = (
+    "Requestor: Nia.Rossi\nRequestee: Paloma.Gupta\nRequestOrReplied: Replied\n\n"
+    "**Review: LGTM — ships as-is**\nMust-fix: None\nTech-debt: None\n"
+)
+# A real blocking verdict (bold Must-fix label, one enumerated item — the #93 shape).
+_N2_MUSTFIX_NIA = (
+    "Requestor: Nia.Rossi\nRequestee: Paloma.Gupta\nRequestOrReplied: Request\n\n"
+    "**Review: one must-fix**\n**Must-fix:**\n1. Correct the recorded numbers.\n"
+    "**Tech-debt:** None\n"
+)
+
+
+def _n2_state(bodies, monkeypatch):
+    monkeypatch.setattr(ts, "_pr_comment_bodies", lambda _repo, _num: bodies)
+
+    class _Cfg:  # reviewers_required = 2 (the standing N=2 bar)
+        def get(self, _dotted, default=None):
+            return 2
+
+    return prs.review_state("acme/widget", 206, cfg=_Cfg())
+
+
+def test_n2_two_distinct_clean_requestors_approved(monkeypatch):
+    """2 distinct clean Requestors ⇒ approved, approvals=2 (the PR #206 case)."""
+    state = _n2_state([_N2_CLEAN_TARIQ, _N2_CLEAN_NIA], monkeypatch)
+    assert state["state"] == "approved"
+    assert state["approvals"] == 2
+    assert state["reviewers_required"] == 2
+    assert state["unresolved_must_fix"] == []
+
+
+def test_n2_one_clean_one_unresolved_mustfix_changes_requested(monkeypatch):
+    """1 clean + 1 unresolved Must-fix ⇒ changes_requested (must-fix precedence)."""
+    state = _n2_state([_N2_CLEAN_TARIQ, _N2_MUSTFIX_NIA], monkeypatch)
+    assert state["state"] == "changes_requested"
+    assert state["approvals"] == 1  # the clean reviewer still counts
+    assert len(state["unresolved_must_fix"]) == 1
+
+
+def test_n2_one_clean_only_pending(monkeypatch):
+    """1 clean approval only ⇒ pending (approvals below the required 2)."""
+    state = _n2_state([_N2_CLEAN_TARIQ], monkeypatch)
+    assert state["state"] == "pending"
+    assert state["approvals"] == 1
+    assert state["reviewers_required"] == 2

--- a/framework/tests/test_trust_signals.py
+++ b/framework/tests/test_trust_signals.py
@@ -530,6 +530,137 @@ def test_absent_reviewer_still_buckets_without_roster(tmp_path) -> None:
 
 
 # ===========================================================================
+# N=2 review process (#203): a single PR reviewed by TWO distinct reviewers.
+# These drive the REAL ``ts._account_pr`` (not a test mirror), so they are the
+# mutation bar for the attribution invariants that a 1-reviewer-era
+# implementation silently gets wrong: a catch must be credited to the RIGHT
+# Requestor (never dropped, never double-counted onto one reviewer), the author
+# must take one ``must_fix_received`` per blocking reviewer, and ``rework_cycles``
+# must count the PR ONCE regardless of how many reviewers blocked it.
+# ===========================================================================
+
+
+def _verdict_body(requestor: str, verdict: str, must_fix: str | None) -> str:
+    """A charter-format verdict comment; *must_fix* None → clean, str → blocking."""
+    mf = "Must-fix: None" if must_fix is None else f"Must-fix:\n1. {must_fix}"
+    return (
+        f"Requestor: {requestor}\n"
+        "Requestee: Paloma.Gupta\n"
+        f"RequestOrReplied: {verdict}\n\n"
+        "**Review**\n"
+        f"{mf}\n"
+        "Tech-debt: None\n"
+    )
+
+
+def test_two_distinct_reviewers_each_mustfix_credited_once(tmp_path) -> None:
+    """One PR, two DISTINCT reviewers each raise a must-fix (the N=2 case).
+
+    Every catch is credited to its own Requestor — exactly once each, never
+    dropped, never both folded onto one reviewer. The author takes one
+    ``must_fix_received`` per blocking reviewer (2), but the PR is a SINGLE
+    ``rework_cycles`` round.
+
+    Mutation bar (all in ``_account_pr``):
+      * moving ``rework_cycles += 1`` inside the per-verdict loop (the naive
+        1-reviewer shortcut) makes ``rework_cycles == 2`` → this test fails;
+      * crediting the catch to a single fixed reviewer instead of ``v.requestor``
+        drops one of the two ``must_fix_caught == 1`` assertions → fails;
+      * counting only the first blocking verdict makes ``must_fix_received == 1``
+        → fails.
+    """
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Paloma Gupta",
+        repo="o/r",
+        number=500,
+        comment_bodies=[
+            _verdict_body("Tariq.Morales", "Request", "Fix the thing."),
+            _verdict_body("Nia.Rossi", "Request", "Fix the other thing."),
+        ],
+        ci_red=False,
+    )
+    assert sigs["Paloma Gupta"].must_fix_received == 2  # one per blocking reviewer
+    assert sigs["Paloma Gupta"].rework_cycles == 1  # ONE PR, not one-per-verdict
+    assert sigs["Tariq Morales"].must_fix_caught == 1  # credited to the right reviewer
+    assert sigs["Nia Rossi"].must_fix_caught == 1  # the second catch is not dropped
+
+
+def test_two_reviewers_one_clean_one_mustfix_credits_only_blocker(tmp_path) -> None:
+    """One PR, two distinct reviewers: one clean approval, one must-fix.
+
+    Only the blocking reviewer earns the catch; the clean reviewer earns none.
+    The author takes exactly one ``must_fix_received`` and one ``rework_cycles``.
+
+    Mutation bar: crediting ``must_fix_caught`` off the clean verdict too (an
+    attribution that ignores ``v.changes_requested``) gives Tariq a phantom
+    bucket with a catch → the "Tariq absent" assertion fails. (A clean reviewer
+    produces no trust signal here — approvals are the oracle's concern, not this
+    scorer's — so a clean-only reviewer is legitimately not in the map.)
+    """
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Paloma Gupta",
+        repo="o/r",
+        number=501,
+        comment_bodies=[
+            _verdict_body("Tariq.Morales", "Replied", None),  # clean
+            _verdict_body("Nia.Rossi", "Request", "Fix this."),  # blocking
+        ],
+        ci_red=False,
+    )
+    assert sigs["Paloma Gupta"].must_fix_received == 1
+    assert sigs["Paloma Gupta"].rework_cycles == 1
+    assert sigs["Nia Rossi"].must_fix_caught == 1
+    assert "Tariq Morales" not in sigs  # clean reviewer earns no catch / no bucket
+
+
+def test_durable_ledger_attributes_two_distinct_reviewers(tmp_path) -> None:
+    """The #164 durable review-catch ledger, at N=2: two distinct reviewers each
+    recorded a catch on one PR, and both live comments were later amended clean.
+
+    The ledger stays authoritative for the whole PR — both catches survive the
+    amendment and land on the right (distinct) reviewers; the author still takes
+    two ``must_fix_received`` and one ``rework_cycles``.
+
+    Mutation bar: a 1-reviewer ledger read (e.g. only the first entry, or folding
+    every entry onto one reviewer) drops Nia's catch → the two
+    ``must_fix_caught == 1`` assertions fail. Reading the amended-clean live
+    comments instead of the ledger makes ``must_fix_received == 0`` → fails.
+    """
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ledger = [
+        {"repo": "o/r", "pr": 502, "requestor": "Tariq.Morales", "requestee": "Paloma.Gupta"},
+        {"repo": "o/r", "pr": 502, "requestor": "Nia.Rossi", "requestee": "Paloma.Gupta"},
+    ]
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Paloma Gupta",
+        repo="o/r",
+        number=502,
+        # Both blocking comments were amended in place to clean after the fix.
+        comment_bodies=[
+            _verdict_body("Tariq.Morales", "Replied", None),
+            _verdict_body("Nia.Rossi", "Replied", None),
+        ],
+        ci_red=False,
+        review_catches=ledger,
+    )
+    assert sigs["Paloma Gupta"].must_fix_received == 2  # ledger, not amended comments
+    assert sigs["Paloma Gupta"].rework_cycles == 1
+    assert sigs["Tariq Morales"].must_fix_caught == 1
+    assert sigs["Nia Rossi"].must_fix_caught == 1
+
+
+# ===========================================================================
 # Integration-branch resolution (#100): phase-aware branch.integration template.
 # ===========================================================================
 


### PR DESCRIPTION
## Phase 6 Wave 6 — Activate the review gate

Turns on what Wave 5 shipped dormant. **3 stories, 3 PRs, 0 changes-requested cycles, 6 clean reviewer verdicts** (every PR cleared its 2 distinct approvals first pass — the first wave run under the 2-reviewer regime). 13 files, +654/−15. Integrated head verified: ruff clean, **706 tests**, all three dual-deploy `--check` gates exit 0.

**Merging this arms the gate on `main`** — `reviewers_required=2` + `pr_review_gate_enabled=true` in this repo's runtime config. From the next PR onward the team self-gates. **Framework defaults stay DORMANT** (schema/`_DEFAULTS`/example unchanged) so downstream adopters still install inert.

| Story | Owner → Reviewers | What shipped |
|-------|-------------------|--------------|
| **S1 #202** flagship | Paloma → Nia + Tariq | Arm the gate + prove it live (throwaway PR blocked 0/2 → passed 2/2); integration test vs real config; charter merge-rule + escape hatch |
| **S3 #204** | Nia → Ibrahim + Tariq | Fold both W5 proposals (integration-owner; pin-contracts-to-code) + N=2 assignment rule into charter; both marked APPLIED |
| **S2 #203** | Ibrahim → Paloma + Tariq | Prove oracle N-of-M on real 2-reviewer data; mutation-prove no 1-reviewer assumption survives in trust/lifecycle |

**Escape hatch:** if the armed gate ever wedges the team, disarm via a direct config-only commit to `main` (a direct push is not gated; the gate is also fail-open on oracle error).

Tracked follow-ups (out of scope): #207 (fail-open scope), #208 (example.json), #211 (wave-end `--cr-cycles` at N≥2). Closes #202/#203/#204. Advances #102 (gate activation).
