### PR TITLE
S2: adopter-safety — example.json reviewers_required=1 + per-PR cr-cycles wording (#215, #208, #211)

### DIFF
--- a/.claude/skills/wave-end/SKILL.md
+++ b/.claude/skills/wave-end/SKILL.md
@@ -46,8 +46,11 @@ and reads the counters recorded here.
    ```
 
    Count them from the actual merged-PR set, not from memory: `--pr-count` = merged PRs
-   this wave, `--cr-cycles` = ChangesRequested verdicts across them, `--concentration` =
-   max(PRs by one author) × 100 / total.
+   this wave, `--cr-cycles` = **PRs** that took >=1 changes-requested round (per-PR, not
+   per-verdict — a PR with `reviewers_required=2` can carry 2 ChangesRequested verdicts in
+   one round; count the PR once). This mirrors `trust_signals.py`'s `rework_cycles` signal
+   ("PRs they authored that needed >=1 rework round") so the two counters never drift.
+   `--concentration` = max(PRs by one author) × 100 / total.
 4. Run `git worktree prune`
 5. Scan docs/ and diagrams for staleness against changes
 6. If this is the final wave of the phase, create a PR to the default branch (User

--- a/framework/assets/skills/wave-end/SKILL.md
+++ b/framework/assets/skills/wave-end/SKILL.md
@@ -46,8 +46,11 @@ and reads the counters recorded here.
    ```
 
    Count them from the actual merged-PR set, not from memory: `--pr-count` = merged PRs
-   this wave, `--cr-cycles` = ChangesRequested verdicts across them, `--concentration` =
-   max(PRs by one author) × 100 / total.
+   this wave, `--cr-cycles` = **PRs** that took >=1 changes-requested round (per-PR, not
+   per-verdict — a PR with `reviewers_required=2` can carry 2 ChangesRequested verdicts in
+   one round; count the PR once). This mirrors `trust_signals.py`'s `rework_cycles` signal
+   ("PRs they authored that needed >=1 rework round") so the two counters never drift.
+   `--concentration` = max(PRs by one author) × 100 / total.
 4. Run `git worktree prune`
 5. Scan docs/ and diagrams for staleness against changes
 6. If this is the final wave of the phase, create a PR to the default branch (User

--- a/framework/config/framework.config.example.json
+++ b/framework/config/framework.config.example.json
@@ -32,7 +32,7 @@
     "allow_emails": ["owner@example.com"]
   },
   "policy": {
-    "reviewers_required": 2,
+    "reviewers_required": 1,
     "pr_review_gate_enabled": false,
     "merge_model": "wave-branch",
     "admin_merge_exceptions": {

--- a/framework/tests/test_config_schema_sync.py
+++ b/framework/tests/test_config_schema_sync.py
@@ -38,6 +38,13 @@ def _schema_policy_defaults() -> dict:
     return {k: v["default"] for k, v in props.items() if "default" in v}
 
 
+def _example_policy() -> dict:
+    example = json.loads(
+        (_FRAMEWORK_ROOT / "config" / "framework.config.example.json").read_text(encoding="utf-8")
+    )
+    return example["policy"]
+
+
 def test_schema_and_runtime_defaults_agree_on_policy() -> None:
     """Every schema policy default == the runtime _DEFAULTS shadow, key for key."""
     assert _schema_policy_defaults() == _framework_config._DEFAULTS["policy"]
@@ -60,6 +67,21 @@ def test_new_lifecycle_keys_present_in_all_three_copies() -> None:
         assert schema.get(key) == default
         assert runtime.get(key) == default
         assert written.get(key) == default
+
+
+def test_example_reviewers_required_matches_schema_default() -> None:
+    """#208: the shipped (dormant) example must not silently carry a stricter bar.
+
+    ``framework.config.example.json`` ships with ``pr_review_gate_enabled: false`` — the
+    gate is off, so ``reviewers_required`` is inert today. But an adopter who copies the
+    example and later flips the gate on inherits whatever ``reviewers_required`` value the
+    example happened to carry. It must equal the schema/``_DEFAULTS`` default (1), not this
+    repo's deliberately-armed runtime value (2, see ``.claude/framework.config.json``),
+    else the adopter silently inherits a 2-reviewer bar they never chose.
+    """
+    schema_default = _schema_policy_defaults()["reviewers_required"]
+    assert _example_policy()["reviewers_required"] == schema_default
+    assert _example_policy()["pr_review_gate_enabled"] is False
 
 
 def test_skills_read_the_keys_from_config_not_hardcoded() -> None:


### PR DESCRIPTION
## Summary

Two adopter-safety fixes folded into S2 (#215):

- **#208** — `framework/config/framework.config.example.json` shipped
  `policy.reviewers_required: 2` while `pr_review_gate_enabled: false`. Because
  the gate is off, this was inert today — but an adopter who copies the
  example and later flips the gate on would silently inherit a 2-reviewer bar
  they never chose. Set it to `1`, matching the schema/`_DEFAULTS` default
  (verified both are `1`). This repo's own runtime
  `.claude/framework.config.json` (deliberately armed at `reviewers_required=2`,
  Phase 6 W6) is untouched — that's a separate, intentional value.

  Added a guard test in `framework/tests/test_config_schema_sync.py`
  (`test_example_reviewers_required_matches_schema_default`) asserting the
  example's `reviewers_required` equals the schema default, so this can't
  silently regress. Mutation-verified: flipping the example back to `2` fails
  the new test; restoring to `1` passes.

- **#211** — `framework/assets/skills/wave-end/SKILL.md` defined `--cr-cycles`
  as "ChangesRequested **verdicts** across them" (per-verdict). Under
  `reviewers_required>=2`, one changes-requested round can carry multiple
  verdicts (one per reviewer), double-counting against the scorer's per-PR
  `rework_cycles` signal. Rebound the wording to **per-PR** ("PRs that took
  >=1 changes-requested round") and cross-referenced `trust_signals.py`'s
  `rework_cycles` definition ("PRs they authored that needed >=1 rework
  round") so the two counters can't drift apart.

## Dual-deploy (#116)

Updated both the canonical `framework/assets/skills/wave-end/SKILL.md` and
synced the runtime copy via `python3 framework/install/reinstall.py`.
`reinstall.py --check` is clean.

`framework.config.example.json` has a single canonical location
(`framework/config/`, not `assets/`) — no runtime copy to sync.

## Manifest note for S3

`python3 framework/install/manifest.py --check` is clean (in sync) after this
change — no drift to flag. Golden manifest untouched, per S3 owning
regeneration this wave.

## Test plan

- [x] `cd framework && python3 -m pytest tests/ -q` — 707 passed (706 baseline + 1 new guard test)
- [x] `ruff check .` (repo root, matches CI's `ruff check .`) — clean
- [x] `python3 framework/install/reinstall.py --check` — in sync
- [x] `python3 framework/install/manifest.py --check` — in sync
- [x] Mutation-proved the new guard test (flip example back to 2 -> fails; restore to 1 -> passes)

Co-Authored-By: Ibrahim El-Amin <Ibrahim.El-Amin@gmail.com>
Co-Authored-By: Claude <noreply@anthropic.com>
