### PR TITLE
S1: fail-open the review-gate oracle on comment-fetch error (#214, #207)

### DIFF
--- a/framework/assets/hooks/validate_pr_review.py
+++ b/framework/assets/hooks/validate_pr_review.py
@@ -28,10 +28,22 @@ errors itself and ALLOWS (returns None) rather than relying only on the
 dispatcher's crash handling — an inability to *evaluate* the gate is never a
 block. An error must never manufacture a false "not approved" that stops a merge.
 
+This posture extends to the oracle's ``unknown`` state (#207/#214): when a
+transient comment-fetch/transport error keeps ``pr_review_state.review_state``
+from determining the PR's state at all, it returns ``state="unknown"`` rather
+than raising OR masking the failure as an ordinary ``"pending"``. This hook
+treats ``unknown`` exactly like a raised oracle exception — fail-open ALLOW —
+while still BLOCKING a genuine ``pending`` (the oracle successfully evaluated
+the PR and found too few approvals) or ``changes_requested`` (a standing
+Must-fix). A broken oracle must never be able to wedge the merge workflow, but
+it must also never fabricate an approval.
+
 Exit codes:
-  0 — allow (not a gated command, gate dormant, approved, or a fail-open
-      degradation: unresolvable repo/PR or an oracle error)
-  2 — block (gate enabled AND the oracle reports the PR is not approved)
+  0 — allow (not a gated command, gate dormant, approved, the oracle reports
+      "unknown", or a fail-open degradation: unresolvable repo/PR or an
+      oracle error)
+  2 — block (gate enabled AND the oracle reports the PR is genuinely not
+      approved: pending or changes_requested)
 """
 
 from __future__ import annotations
@@ -54,7 +66,7 @@ for _p in (_HERE, _LIB):
 from _framework_config import config  # noqa: E402
 from _framework_log import log_pretooluse_block  # noqa: E402
 from _repo_flag_parse import extract_repo  # noqa: E402
-from pr_review_state import APPROVED, review_state  # noqa: E402  (consume the oracle; no re-parse)
+from pr_review_state import APPROVED, UNKNOWN, review_state  # noqa: E402  (consume the oracle; no re-parse)
 
 #: Declares this hook's fail-direction to the dispatcher (#175): an uncaught
 #: exception allows the command rather than blocking on the hook's own bug. The
@@ -188,7 +200,12 @@ def check(input_data: dict) -> dict | None:
     except Exception:  # noqa: BLE001 — fail-open: degrade to allow, never block on our bug
         return None
 
-    if state.get("state") == APPROVED:
+    if state.get("state") in (APPROVED, UNKNOWN):
+        # UNKNOWN means the oracle couldn't fetch/parse the PR's comments (a
+        # transient error), NOT that it evaluated the PR and found it
+        # not-approved. Treat it exactly like an oracle exception: fail-open
+        # ALLOW. A broken comment fetch must never read as an ordinary
+        # "pending"/"changes_requested" and block the merge (#207/#214).
         return None
 
     reason = _block_reason(verb, f"#{pr}", state)

--- a/framework/assets/lib/pr_review_state.py
+++ b/framework/assets/lib/pr_review_state.py
@@ -53,16 +53,24 @@ never hard-fail the caller.
   shared config, which fail-opens to its schema default (1) when the config is
   missing/unreadable; a non-integer/negative value or a config-load exception
   degrades to :data:`_FAIL_OPEN_REVIEWERS_REQUIRED`.
-* :func:`review_state` catches comment-fetch / parse errors and returns a
-  ``pending`` state (approvals=0, no must-fix) rather than raising or inventing
-  an approval — the safe, non-blocking degradation.
+* :func:`review_state` catches comment-fetch / parse errors and returns an
+  ``unknown`` state (approvals=0, no must-fix) rather than raising or inventing
+  an approval — "couldn't determine the state" (#207/#214). This is
+  deliberately NOT ``pending``: ``pending`` means the oracle *evaluated* the PR
+  and found it genuinely not-yet-approved (a real, actionable state a caller
+  should block on); ``unknown`` means the oracle *could not evaluate* the PR at
+  all (a transient comment-fetch/transport error). Collapsing the two used to
+  let a flaky GitHub API call read identically to a real "not approved" and
+  BLOCK ``gh pr merge`` — the opposite of the fail-open promise. Callers (see
+  ``validate_pr_review.py``) must treat ``unknown`` like an oracle exception:
+  fail-open ALLOW, never block on it.
 
-State machine (PINNED CONTRACT — frozen for S2/S3)
-==================================================
+State machine (PINNED CONTRACT — frozen for S2/S3; ``unknown`` added #214)
+==========================================================================
 ``ReviewState`` is a plain dict::
 
     {
-      "state": "pending" | "changes_requested" | "approved",
+      "state": "pending" | "changes_requested" | "approved" | "unknown",
       "approvals": int,            # distinct reviewers (Requestors) with a
                                    # current clean/approved verdict
       "reviewers_required": int,   # policy.reviewers_required (fail-open default)
@@ -73,14 +81,26 @@ State machine (PINNED CONTRACT — frozen for S2/S3)
                                      AND unresolved_must_fix == []
     state == "changes_requested" iff any current verdict carries an unresolved
                                      Must-fix (takes precedence over approvals)
+    state == "unknown"           iff the oracle could not fetch/parse the PR's
+                                     comments at all (fail-open — never
+                                     produced by :func:`compute_state`, only by
+                                     the :func:`review_state` I/O wrapper on a
+                                     caught exception)
     else                             "pending"
+
+    INVARIANT: the oracle must NEVER fabricate an "approved" verdict. On any
+    doubt (including "unknown") it reports something a caller can safely
+    fail-open on instead of a false approval.
 
 CLI::
 
     python3 lib/pr_review_state.py <pr_number> --repo <owner/repo> [--json]
 
-Exit codes: 0 approved, 1 not-approved (pending / changes_requested). The I/O
-wrapper itself fail-opens to pending, so a fetch error prints pending / exit 1.
+Exit codes: 0 approved, 1 otherwise (pending / changes_requested / unknown). The
+I/O wrapper fail-opens to ``unknown`` on a fetch error (never ``pending``, and
+never a fabricated ``approved``), so the CLI prints ``UNKNOWN`` / exit 1 in that
+case — a caller scripting against this CLI's exit code should check ``--json``
+``state`` if it needs to distinguish "not approved" from "couldn't tell".
 """
 
 from __future__ import annotations
@@ -114,10 +134,16 @@ FAIL_OPEN = True
 #: non-zero bar; a value of 0 would make an unreviewed PR read "approved".
 _FAIL_OPEN_REVIEWERS_REQUIRED = 1
 
-# The three legal states, exported for callers/tests that assert the vocabulary.
+# The legal states, exported for callers/tests that assert the vocabulary.
 PENDING = "pending"
 CHANGES_REQUESTED = "changes_requested"
 APPROVED = "approved"
+#: "The oracle could not determine the state" (comment-fetch/transport error) —
+#: NOT a synonym for PENDING. Produced only by :func:`review_state`'s exception
+#: handler, never by :func:`compute_state`. Callers must fail-open ALLOW on this,
+#: exactly like an oracle exception (#207/#214) — never fabricate "approved",
+#: but also never let "couldn't tell" masquerade as "not approved" and block.
+UNKNOWN = "unknown"
 
 
 class MustFixEntry(TypedDict):
@@ -230,17 +256,21 @@ def review_state(repo: str, pr: int, *, cfg: Any = None) -> ReviewState:
     reads ``reviewers_required`` from shared config, and returns the pinned
     :class:`ReviewState`.
 
-    Fail-open: any comment-fetch / parse error returns a ``pending`` state
+    Fail-open: any comment-fetch / parse error returns an ``unknown`` state
     (approvals=0, no must-fix) rather than raising or inventing an approval — an
-    error must never manufacture a false "approved".
+    error must never manufacture a false "approved". ``unknown`` is deliberately
+    NOT ``pending``: it says "the oracle could not tell", which callers (the
+    ``validate_pr_review`` gate) must treat as a fail-open ALLOW, exactly like a
+    raised exception — a transient comment-fetch failure must never read as an
+    ordinary "not approved" and BLOCK a merge (#207/#214).
     """
     required = _reviewers_required(cfg)
     try:
         bodies = ts._pr_comment_bodies(repo, int(pr))
         verdicts = ts.parse_verdicts(bodies)
-    except Exception:  # noqa: BLE001 — fail-open: degrade to pending, never raise
+    except Exception:  # noqa: BLE001 — fail-open: degrade to unknown, never raise
         return {
-            "state": PENDING,
+            "state": UNKNOWN,
             "approvals": 0,
             "reviewers_required": required,
             "unresolved_must_fix": [],

--- a/framework/tests/test_pr_review_state.py
+++ b/framework/tests/test_pr_review_state.py
@@ -225,9 +225,18 @@ def test_reviewers_required_fail_open_defaults():
     assert prs._reviewers_required(_Cfg(3)) == 3
 
 
-def test_review_state_wrapper_fail_opens_to_pending_on_fetch_error(monkeypatch):
-    """A comment-fetch error returns pending — never a raised exception and
-    never a manufactured 'approved'."""
+def test_review_state_wrapper_fail_opens_to_unknown_on_fetch_error(monkeypatch):
+    """A comment-fetch error returns "unknown" — never a raised exception,
+    never a manufactured "approved", and (#207/#214) NOT masked as an ordinary
+    "pending". "pending" means the oracle evaluated the PR and found it
+    genuinely not-yet-approved; "unknown" means it couldn't evaluate the PR at
+    all (a transient fetch/transport error). Collapsing the two used to let a
+    flaky GitHub API call block `gh pr merge` exactly like a real "not
+    approved" — the opposite of a fail-open gate.
+
+    Mutation bar: reverting the except-handler in `review_state` back to
+    `state=PENDING` makes this fail.
+    """
 
     def _boom(_repo, _num):
         raise RuntimeError("gh exploded")
@@ -239,7 +248,9 @@ def test_review_state_wrapper_fail_opens_to_pending_on_fetch_error(monkeypatch):
             return 1
 
     state = prs.review_state("acme/widget", 7, cfg=_Cfg())
-    assert state["state"] == "pending"
+    assert state["state"] == "unknown"
+    assert state["state"] == prs.UNKNOWN
+    assert state["state"] != "pending"
     assert state["approvals"] == 0
     assert state["unresolved_must_fix"] == []
 

--- a/framework/tests/test_validate_pr_review.py
+++ b/framework/tests/test_validate_pr_review.py
@@ -29,6 +29,7 @@ _FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_FRAMEWORK_ROOT / "assets" / "hooks"))
 sys.path.insert(0, str(_FRAMEWORK_ROOT / "assets" / "lib"))
 
+import pr_review_state as oracle  # noqa: E402
 import validate_pr_review as hook  # noqa: E402
 
 
@@ -198,6 +199,45 @@ def test_oracle_error_allows(monkeypatch) -> None:
         raise RuntimeError("gh exploded")
 
     monkeypatch.setattr(hook, "review_state", _raise)
+    assert hook.check(_bash(_MERGE)) is None
+
+
+def test_oracle_unknown_state_allows(monkeypatch) -> None:
+    """FAIL_OPEN (#207/#214): an oracle "unknown" state ALLOWS, exactly like an
+    exception — it must NOT read as an ordinary "not approved" and block.
+    """
+    _arm(monkeypatch, enabled=True)
+    _stub_oracle(
+        monkeypatch,
+        {"state": oracle.UNKNOWN, "approvals": 0, "reviewers_required": 2, "unresolved_must_fix": []},
+    )
+    assert hook.check(_bash(_MERGE)) is None
+
+
+def test_comment_fetch_error_reads_unknown_and_gate_allows(monkeypatch) -> None:
+    """End-to-end (#207/#214): a comment-fetch/transport error must reach the
+    gate as "unknown", never silently as "pending" — a broken oracle must
+    never be able to wedge `gh pr merge`.
+
+    Deliberately does NOT stub `hook.review_state` — it exercises the REAL
+    `pr_review_state.review_state` oracle end-to-end (only the lower-level
+    `trust_signals._pr_comment_bodies` comment fetch is monkeypatched to fail,
+    exactly as a transient GitHub API error would). This also guards against a
+    state-string mismatch between the oracle and the gate (e.g. the gate
+    checking for a different literal than the oracle emits).
+
+    Mutation bar: reverting `review_state`'s except-handler back to
+    `state=PENDING` flips this PR to "not approved" and the gate BLOCKS
+    instead of allowing -> this test fails.
+    """
+    import trust_signals as ts
+
+    def _boom(_repo, _num):
+        raise RuntimeError("gh comment fetch exploded")
+
+    monkeypatch.setattr(ts, "_pr_comment_bodies", _boom)
+    _arm(monkeypatch, enabled=True)
+    # No oracle stub: hook.review_state is the real pr_review_state.review_state.
     assert hook.check(_bash(_MERGE)) is None
 
 


### PR DESCRIPTION
## What changed

Fixes the oracle fail-open gap from #207: `pr_review_state.review_state()` caught comment-fetch/transport errors and returned `state="pending"` — indistinguishable from a genuine "PR evaluated, not approved yet." That let a transient GitHub API failure BLOCK `gh pr merge`/`gh pr ready` exactly like a real not-approved PR, narrowing the gate's promise that "a broken oracle can never wedge the workflow."

- **`framework/assets/lib/pr_review_state.py`**: added a new sentinel state, `UNKNOWN = "unknown"`, to the `ReviewState` vocabulary (alongside `PENDING`/`CHANGES_REQUESTED`/`APPROVED`). `review_state()`'s `except Exception` handler (comment-fetch/parse error) now returns `state="unknown"` instead of `state="pending"`. `compute_state()` (the pure state machine) is untouched — it still only ever produces `pending`/`changes_requested`/`approved`; `unknown` is exclusively an I/O-wrapper degradation.
- **`framework/assets/hooks/validate_pr_review.py`**: `check()` now treats `state == UNKNOWN` the same as `APPROVED` for the ALLOW branch (`if state.get("state") in (APPROVED, UNKNOWN): return None`), i.e. fail-open ALLOW — identical treatment to a raised oracle exception. Genuine `pending`/`changes_requested` still BLOCK unchanged.

### `unknown` vs `pending` — the distinction this ships

- `pending`: the oracle successfully fetched and parsed the PR's comments and determined there are not (yet) enough clean approvals. This is real, actionable information a caller should block on.
- `unknown`: the oracle could not determine the state at all (a transient fetch/transport error). This is "couldn't tell," not "not approved," and must fail-open ALLOW.

**Invariant preserved**: the oracle still never fabricates `approved`. `unknown` is a third, distinct "I don't know" bucket — not a backdoor to a false approval, and not a false block either.

## Mutation-proof (revert → fail confirmed)

Verified by hand — temporarily reverted each of the two behavior changes, ran the affected tests, confirmed failure, then restored (diff-clean vs. original):

1. Reverted `review_state()`'s except-handler back to `state=PENDING` →
   - `test_pr_review_state.py::test_review_state_wrapper_fail_opens_to_unknown_on_fetch_error` FAILED
   - `test_validate_pr_review.py::test_comment_fetch_error_reads_unknown_and_gate_allows` FAILED (gate now BLOCKS instead of allowing)
2. Reverted `check()`'s allow-condition back to `if state.get("state") == APPROVED:` (dropping `UNKNOWN`) →
   - `test_validate_pr_review.py::test_oracle_unknown_state_allows` FAILED
   - `test_validate_pr_review.py::test_comment_fetch_error_reads_unknown_and_gate_allows` FAILED

Restored both files after each revert; `git diff` against the commit is clean.

## New tests

- `test_pr_review_state.py::test_review_state_wrapper_fail_opens_to_unknown_on_fetch_error` (renamed/rewritten from the old `..._to_pending_...` test): asserts a comment-fetch error yields `state="unknown"`, not `"pending"`.
- `test_validate_pr_review.py::test_oracle_unknown_state_allows`: stubbed-oracle check that `state="unknown"` ALLOWs.
- `test_validate_pr_review.py::test_comment_fetch_error_reads_unknown_and_gate_allows`: true end-to-end test — does **not** stub `hook.review_state`; only monkeypatches `trust_signals._pr_comment_bodies` to raise, exercising the real oracle through the real gate. This also guards against a state-string mismatch between the two modules.

## Test / lint / dual-deploy status

- `cd framework && python3 -m pytest tests/ -q` → **708 passed**.
- `ruff check` on all four changed files → **all checks passed**.
- `python3 framework/install/reinstall.py --check` → exit 0, in sync. (No action needed: hooks/lib are wired in-place via `.claude/settings.json` pointing at `framework/assets/hooks|lib/*` — they're canonical-by-reference per the reinstall docstring, so this fix required no `.claude/` copy sync. Only `skills/` is byte-mirrored.)
- `python3 framework/install/manifest.py --check` → exit 0, in sync.

## Manifest note for S3

No manifest drift — nothing for S3 to reconcile from this PR. The two edited files (`pr_review_state.py`, `validate_pr_review.py`) live in the hooks/lib trees, which are loaded in place rather than byte-mirrored, so they aren't part of the golden manifest's copy set.
