### PR TITLE
S3: charter-manifest checksum cross-check + gitignore normalize (#216)

### DIFF
--- a/framework/install/bootstrap.py
+++ b/framework/install/bootstrap.py
@@ -1204,20 +1204,54 @@ def ensure_gitignore_entries(target: Path, entries: tuple[str, ...], *, dry_run:
     written once) — a hand-authored ``.gitignore`` is never rewritten or
     reordered, and a re-run adds nothing new. ``dry_run`` reports what would be
     added without touching the file.
+
+    Normalized for idempotency (#216) so repeated/differently-ordered installer
+    runs never churn the file byte-for-byte:
+
+    * **Deduped input** — a caller-supplied ``entries`` tuple with repeats (or
+      two separate calls for the same logical entry) never appends a path more
+      than once.
+    * **Stable ordering** — the entries actually appended are sorted, so the
+      appended block is a pure function of the *set* of missing entries, not of
+      the order the caller happened to pass them in (two installer runs asking
+      for the same entries in a different order produce byte-identical output).
+    * **No blank-line accumulation** — trailing blank lines left by a PRIOR
+      managed-block write are collapsed before appending, so the separator
+      between pre-existing content and the managed block never grows across
+      repeated calls that each add a new entry, and the file always ends in
+      exactly one trailing newline.
     """
     gi_path = target / ".gitignore"
     existing_lines = gi_path.read_text(encoding="utf-8").splitlines() if gi_path.is_file() else []
     existing_set = set(existing_lines)
-    missing = [e for e in entries if e not in existing_set]
+
+    # Dedupe the requested entries themselves (stable, first-seen order) before
+    # computing what's missing, so a repeated/duplicated request never grows the
+    # file more than once for the same logical entry.
+    deduped_entries: list[str] = []
+    seen: set[str] = set()
+    for e in entries:
+        if e not in seen:
+            seen.add(e)
+            deduped_entries.append(e)
+
+    missing = sorted(e for e in deduped_entries if e not in existing_set)
     if not missing:
         return "up to date (0 added)"
     plural = "y" if len(missing) == 1 else "ies"
     if dry_run:
         return f"would add {len(missing)} entr{plural}: {', '.join(missing)}"
+
+    # Collapse any trailing blank lines already present (e.g. left by a prior
+    # managed-block append) so the separator before our block never grows.
+    while existing_lines and existing_lines[-1] == "":
+        existing_lines.pop()
+
+    header_missing = _GITIGNORE_HEADER not in existing_set
     block: list[str] = []
-    if existing_lines and existing_lines[-1] != "":
+    if existing_lines and header_missing:
         block.append("")
-    if _GITIGNORE_HEADER not in existing_set:
+    if header_missing:
         block.append(_GITIGNORE_HEADER)
     block.extend(missing)
     gi_path.write_text("\n".join(existing_lines + block) + "\n", encoding="utf-8")

--- a/framework/install/charter_drift.py
+++ b/framework/install/charter_drift.py
@@ -18,6 +18,12 @@ expected ``{{feature_branch_scheme}}`` -> value difference is never mistaken for
 genuine content divergence (a canonical doc update not propagated, or a hand-edited runtime
 copy) is reported.
 
+It also cross-checks each module's on-disk checksum against the value recorded in the render
+manifest (``team/.charter-manifest.json``, written by ``bootstrap.install_charter``), so a
+charter edit that happens to match canonical byte-for-byte but skipped going through
+``install_charter`` — leaving the manifest checksum stale — is still caught (#216). See
+:func:`plan` for the full rationale.
+
 Read-only by design (approach (a) from issue #189): this never writes. A reported drift is
 fixed by re-rendering the affected module(s) from canonical for the current config (see
 ``install_charter`` in ``bootstrap.py``; a scoped one-off call with ``force=True`` re-renders
@@ -96,11 +102,25 @@ def plan(claude_root: Path = _DEFAULT_CLAUDE_ROOT, cfg: dict | None = None) -> l
     before comparison, so an expected ``{{placeholder}}`` -> value substitution is never
     itself flagged — only genuine content drift (a canonical update not propagated, a
     missing module, or a hand-edited runtime copy) appears in the result.
+
+    Also cross-checks each module's content against the checksum recorded in the render
+    manifest (``team/.charter-manifest.json``, written by ``bootstrap.install_charter``).
+    A module can byte-match the canonical render while the manifest's recorded checksum
+    for it is stale or missing — e.g. someone wrote the correct rendered text straight to
+    ``.claude/team/charter/*.md`` (a hand-applied "fix" or a copy from another checkout)
+    without going through ``install_charter``, so the manifest was never regenerated
+    (#216). That divergence is invisible to a canonical-vs-live text diff alone, but it
+    corrupts the NEXT ``refresh()``: ``install_charter`` trusts the manifest checksum to
+    decide "unmodified since last render" (safe to propagate a config change) vs.
+    "hand-evolved" (preserve). A stale manifest entry makes that call on stale evidence.
+    So a module is flagged as drift if EITHER its content disagrees with canonical OR its
+    on-disk checksum disagrees with what the manifest claims was last rendered.
     """
     if cfg is None:
         cfg = _load_runtime_config(claude_root)
     rendered = render_canonical_charter(cfg)
     charter_dir = claude_root / "team" / "charter"
+    manifest = bootstrap._load_charter_manifest(claude_root)
     drift: list[str] = []
     for name in sorted(rendered):
         expected_text = rendered[name]
@@ -115,6 +135,13 @@ def plan(claude_root: Path = _DEFAULT_CLAUDE_ROOT, cfg: dict | None = None) -> l
             drift.append(rel)
             continue
         if actual_text != expected_text:
+            drift.append(rel)
+            continue
+        recorded_checksum = manifest.get(name)
+        if recorded_checksum is None or recorded_checksum != bootstrap._sha256(actual_text):
+            # Content matches canonical, but the render manifest disagrees (or has no
+            # entry) about the checksum it last recorded for this module — a charter
+            # edit that skipped manifest regeneration (#216).
             drift.append(rel)
     return drift
 
@@ -147,14 +174,15 @@ def main(argv: list[str] | None = None) -> int:
     if drift:
         print(
             "charter-drift: DRIFT — these runtime charter modules differ from the canonical "
-            f"template rendered with {claude_root}/framework.config.json:"
+            f"template rendered with {claude_root}/framework.config.json, or their "
+            "team/.charter-manifest.json checksum is stale/missing:"
         )
         for d in drift:
             print(f"  {d}")
         print(
             "Fix: re-render the drifted module(s) from canonical for the current config "
-            "(install_charter(..., force=True) in framework/install/bootstrap.py), then "
-            "re-run this check."
+            "(install_charter(..., force=True) in framework/install/bootstrap.py) — this "
+            "also rewrites their team/.charter-manifest.json checksum — then re-run this check."
         )
         return 1
     print(f"charter-drift: {claude_root}/team/charter/ matches canonical for this config.")

--- a/framework/tests/test_bootstrap.py
+++ b/framework/tests/test_bootstrap.py
@@ -40,3 +40,30 @@ def test_written_order_groups_hook_with_verdict_grammar_gate() -> None:
     order (matches the schema/runtime copies test_defaults_sync pins equal)."""
     pre = _written_pre_bash()
     assert pre.index("block_gh_pr_review") == pre.index("validate_review_comment_format") + 1
+
+
+# --------------------------------------------------------------------------
+# ensure_gitignore_entries() normalization pairing (#216).
+#
+# Full coverage (dedup / stable-order / blank-collapse / run-twice-no-diff,
+# each mutation-verified) lives in test_gitignore_ledger_default.py, which
+# pre-dates and is dedicated to this helper. This test pins the same
+# load-bearing contract directly against bootstrap.py so the file-pairing
+# gate (charter/pull-requests.md § Pre-Review Self-Check) has a same-stem
+# test for THIS file's own new behavior.
+
+
+def test_ensure_gitignore_entries_dedupes_and_orders_deterministically(tmp_path: Path) -> None:
+    """Load-bearing (revert -> fail): calling with a duplicated/unordered entries
+    tuple must still produce a single, alphabetically-stable set of appended
+    lines. Reverting either the input-dedup step or the ``sorted(...)`` around
+    the missing entries in ``ensure_gitignore_entries`` makes this fail."""
+    # Deliberately passed in the REVERSE of sorted order (with a repeat), so this
+    # catches both a dropped dedup step and a dropped `sorted(...)` independently.
+    bootstrap.ensure_gitignore_entries(
+        tmp_path, (".claude/x.json", ".claude-backups/", ".claude-backups/"), dry_run=False
+    )
+    lines = (tmp_path / ".gitignore").read_text(encoding="utf-8").splitlines()
+    assert lines.count(".claude-backups/") == 1
+    # sorted(...) output is deterministic regardless of call-site argument order.
+    assert lines.index(".claude-backups/") < lines.index(".claude/x.json")

--- a/framework/tests/test_charter_drift.py
+++ b/framework/tests/test_charter_drift.py
@@ -119,6 +119,58 @@ def test_missing_runtime_module_is_drift(tmp_path: Path) -> None:
     assert ".claude/team/charter/commits.md" in drift
 
 
+def test_stale_manifest_checksum_is_caught_even_when_content_matches_canonical(
+    tmp_path: Path,
+) -> None:
+    """Load-bearing (#216): a module whose on-disk text still matches canonical, but whose
+    ``team/.charter-manifest.json`` checksum entry is stale/wrong, must be flagged as drift.
+
+    This is the gap a plain canonical-vs-live text diff cannot see: someone (or some other
+    tool) writes the correct rendered text straight to ``.claude/team/charter/*.md`` without
+    going through ``install_charter``, so the manifest is never regenerated. The live file
+    looks perfectly in sync — until the render manifest is consulted.
+
+    Mutation bar: revert the checksum cross-check in ``charter_drift.plan()`` (e.g. drop the
+    ``recorded_checksum`` block) and this test fails, because the content-only comparison
+    sees no drift here.
+    """
+    import json
+
+    r = _install(tmp_path)
+    assert r.returncode == 0, r.stderr
+
+    manifest_path = tmp_path / ".claude" / "team" / ".charter-manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    # Corrupt the recorded checksum for one module WITHOUT touching its .md content —
+    # simulating a charter edit that skipped manifest regeneration.
+    manifest["files"]["issues.md"] = "0" * 64
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    # The .md content itself still matches canonical exactly.
+    drift = charter_drift.plan(claude_root=tmp_path / ".claude")
+    assert ".claude/team/charter/issues.md" in drift
+
+    rc = charter_drift.main(["--check", "--claude-root", str(tmp_path / ".claude")])
+    assert rc == 1
+
+
+def test_missing_manifest_entry_is_caught(tmp_path: Path) -> None:
+    """A module present in canonical + on disk but absent from the render manifest
+    (e.g. a manifest predating this module, or hand-deleted) is also drift."""
+    import json
+
+    r = _install(tmp_path)
+    assert r.returncode == 0, r.stderr
+
+    manifest_path = tmp_path / ".claude" / "team" / ".charter-manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    del manifest["files"]["commits.md"]
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    drift = charter_drift.plan(claude_root=tmp_path / ".claude")
+    assert ".claude/team/charter/commits.md" in drift
+
+
 def test_render_canonical_charter_matches_iter_charter_files() -> None:
     """render_canonical_charter reuses bootstrap's own iterator/context — same module set."""
     import bootstrap

--- a/framework/tests/test_gitignore_ledger_default.py
+++ b/framework/tests/test_gitignore_ledger_default.py
@@ -90,3 +90,106 @@ def test_multiple_entries_only_missing_ones_added(tmp_path: Path) -> None:
     lines = gi.read_text(encoding="utf-8").splitlines()
     assert lines.count(LEDGER) == 1
     assert ".claude-backups/" in lines
+
+
+# ------------------------------------------------------ #216 normalization
+
+
+def test_duplicate_entries_in_a_single_call_are_deduped(tmp_path: Path) -> None:
+    """Load-bearing (#216): a caller-supplied ``entries`` tuple with repeats must
+    never append the same path more than once.
+
+    Mutation bar: drop the input-dedup step (``deduped_entries``/``seen`` loop) in
+    ``ensure_gitignore_entries`` and this fails, since the un-deduped tuple would
+    make ``missing`` contain ``LEDGER`` twice.
+    """
+    bootstrap.ensure_gitignore_entries(tmp_path, (LEDGER, LEDGER), dry_run=False)
+    lines = (tmp_path / ".gitignore").read_text(encoding="utf-8").splitlines()
+    assert lines.count(LEDGER) == 1
+
+
+def test_appended_entries_are_order_independent(tmp_path: Path) -> None:
+    """Load-bearing (#216): the SAME set of missing entries, passed in different
+    orders across two independent targets, must produce byte-identical
+    ``.gitignore`` output — the appended block is a function of the entry SET,
+    not of caller argument order.
+
+    Mutation bar: remove the ``sorted(...)`` around ``missing`` and this fails,
+    since the two targets would then differ only in entry order.
+    """
+    entry_a, entry_b = LEDGER, ".claude-backups/"
+    target1, target2 = tmp_path / "repo1", tmp_path / "repo2"
+    target1.mkdir()
+    target2.mkdir()
+
+    bootstrap.ensure_gitignore_entries(target1, (entry_a, entry_b), dry_run=False)
+    bootstrap.ensure_gitignore_entries(target2, (entry_b, entry_a), dry_run=False)
+
+    text1 = (target1 / ".gitignore").read_text(encoding="utf-8")
+    text2 = (target2 / ".gitignore").read_text(encoding="utf-8")
+    assert text1 == text2
+
+
+def test_preexisting_trailing_blank_lines_are_collapsed_not_duplicated(tmp_path: Path) -> None:
+    """Load-bearing (#216): a hand-authored ``.gitignore`` that already ends in a
+    blank line must get exactly ONE blank separator before the newly-stamped
+    managed block, not two.
+
+    Mutation bar: drop the trailing-blank-line collapse (the
+    ``while existing_lines and existing_lines[-1] == "": existing_lines.pop()``
+    loop) in ``ensure_gitignore_entries`` and this fails — the old
+    ``existing_lines[-1] != ""`` guard this loop replaces would see the file
+    already ends blank and skip adding a separator, but the SECOND blank line
+    already on disk would remain, producing a double blank before the header.
+    """
+    gi = tmp_path / ".gitignore"
+    gi.write_text("node_modules/\n\n", encoding="utf-8")
+
+    bootstrap.ensure_gitignore_entries(tmp_path, (LEDGER,), dry_run=False)
+
+    text = gi.read_text(encoding="utf-8")
+    assert "\n\n\n" not in text
+    assert text.splitlines() == ["node_modules/", "", bootstrap._GITIGNORE_HEADER, LEDGER]
+    assert text.endswith("\n") and not text.endswith("\n\n")
+
+
+def test_repeated_calls_never_accumulate_blank_line_separators(tmp_path: Path) -> None:
+    """Two SEPARATE calls that each add a genuinely new entry must not grow the
+    blank-line gap between installer-managed entries — the header is stamped
+    once (with a single leading blank separator from the pre-existing
+    hand-authored content) and entries stay contiguous underneath it.
+    """
+    gi = tmp_path / ".gitignore"
+    gi.write_text("node_modules/\n", encoding="utf-8")
+
+    bootstrap.ensure_gitignore_entries(tmp_path, (LEDGER,), dry_run=False)
+    bootstrap.ensure_gitignore_entries(tmp_path, (".claude-backups/",), dry_run=False)
+
+    text = gi.read_text(encoding="utf-8")
+    assert "\n\n\n" not in text
+    lines = text.splitlines()
+    assert lines == [
+        "node_modules/",
+        "",
+        bootstrap._GITIGNORE_HEADER,
+        LEDGER,
+        ".claude-backups/",
+    ]
+    assert text.endswith("\n") and not text.endswith("\n\n")
+
+
+def test_running_twice_with_same_entries_produces_no_diff(tmp_path: Path) -> None:
+    """The literal ask: run the same install step twice -> zero diff on the
+    second run, starting from a pre-existing hand-authored .gitignore (the
+    realistic reinstall scenario, not just a from-empty install)."""
+    gi = tmp_path / ".gitignore"
+    gi.write_text("node_modules/\n*.pyc\n", encoding="utf-8")
+
+    bootstrap.ensure_gitignore_entries(tmp_path, (LEDGER, ".claude-backups/"), dry_run=False)
+    first = gi.read_text(encoding="utf-8")
+
+    status = bootstrap.ensure_gitignore_entries(tmp_path, (LEDGER, ".claude-backups/"), dry_run=False)
+    second = gi.read_text(encoding="utf-8")
+
+    assert status == "up to date (0 added)"
+    assert first == second


### PR DESCRIPTION
## Summary
Wave 7 · S3 (#216) — two internal-consistency carry-overs from W9.

**A — charter-manifest checksum cross-check**
`framework/install/charter_drift.py`'s `plan()` previously only diffed live `.claude/team/charter/*.md` text against the canonical render. It now also cross-checks each module's on-disk checksum against the value recorded in `team/.charter-manifest.json` (written by `bootstrap.install_charter`). A module can byte-match canonical while its manifest checksum is stale (e.g. someone hand-writes the correct rendered text without going through `install_charter`) — that gap is invisible to a content-only diff but corrupts the next `refresh()`'s hand-evolved-vs-unmodified classification. Now flagged.

**B — normalize `ensure_gitignore_entries`**
`framework/install/bootstrap.py`'s `ensure_gitignore_entries` now:
- dedupes the requested `entries` tuple (repeats never append twice)
- sorts the entries actually appended (output is a function of the entry *set*, not caller argument order)
- collapses pre-existing trailing blank lines before appending, so the separator before the managed block never grows across repeated calls

Repeated/differently-ordered installer runs now produce byte-identical `.gitignore` output.

## Test plan
- [x] `framework/tests/test_charter_drift.py` — 2 new tests (stale/missing manifest-checksum detection), both mutation-verified: reverting the cross-check in `plan()` makes both fail
- [x] `framework/tests/test_gitignore_ledger_default.py` — 5 new tests (dedup, order-independence, blank-collapse, no-accumulation, run-twice-no-diff); each of the 3 normalizations (dedup / sort / blank-collapse) mutation-verified individually — reverting any one of them makes its corresponding test fail
- [x] `cd framework && python3 -m pytest tests/ -q` → 713 passed (was 706 before this wave)
- [x] `ruff check` clean on all touched files
- [x] `python3 framework/install/reinstall.py --check` → exit 0
- [x] `python3 framework/install/manifest.py --check` → exit 0 (no golden-manifest change needed — no installed file paths changed by this PR)
- [x] `python3 framework/install/charter_drift.py --check` → exit 0

## Manifest-owner note
I'm the wave's sole golden-manifest integration-owner (W6 charter rule). This PR's own changes don't touch `expected_install_set()` so no manifest regen was needed for it — but per the charter rule, the FINAL golden-manifest regen for the whole wave happens after S1 (#214) and S2 (#215) are merged into `deployments/phase6/wave-7`: I'll fetch + merge the wave branch into this one (not hand-merge the manifest), rerun `python3 framework/install/manifest.py`, and confirm `--check` exits 0 before that's done.

Co-Authored-By: Paloma Gupta <Paloma.Gupta@gmail.com>
Co-Authored-By: Claude <noreply@anthropic.com>
