### PR TITLE
Phase 6 Wave 7 — Harden the armed gate rollup

### DIFF
--- a/.claude/skills/wave-end/SKILL.md
+++ b/.claude/skills/wave-end/SKILL.md
@@ -46,8 +46,11 @@ and reads the counters recorded here.
    ```
 
    Count them from the actual merged-PR set, not from memory: `--pr-count` = merged PRs
-   this wave, `--cr-cycles` = ChangesRequested verdicts across them, `--concentration` =
-   max(PRs by one author) × 100 / total.
+   this wave, `--cr-cycles` = **PRs** that took >=1 changes-requested round (per-PR, not
+   per-verdict — a PR with `reviewers_required=2` can carry 2 ChangesRequested verdicts in
+   one round; count the PR once). This mirrors `trust_signals.py`'s `rework_cycles` signal
+   ("PRs they authored that needed >=1 rework round") so the two counters never drift.
+   `--concentration` = max(PRs by one author) × 100 / total.
 4. Run `git worktree prune`
 5. Scan docs/ and diagrams for staleness against changes
 6. If this is the final wave of the phase, create a PR to the default branch (User

--- a/framework/assets/hooks/validate_pr_review.py
+++ b/framework/assets/hooks/validate_pr_review.py
@@ -28,10 +28,22 @@ errors itself and ALLOWS (returns None) rather than relying only on the
 dispatcher's crash handling — an inability to *evaluate* the gate is never a
 block. An error must never manufacture a false "not approved" that stops a merge.
 
+This posture extends to the oracle's ``unknown`` state (#207/#214): when a
+transient comment-fetch/transport error keeps ``pr_review_state.review_state``
+from determining the PR's state at all, it returns ``state="unknown"`` rather
+than raising OR masking the failure as an ordinary ``"pending"``. This hook
+treats ``unknown`` exactly like a raised oracle exception — fail-open ALLOW —
+while still BLOCKING a genuine ``pending`` (the oracle successfully evaluated
+the PR and found too few approvals) or ``changes_requested`` (a standing
+Must-fix). A broken oracle must never be able to wedge the merge workflow, but
+it must also never fabricate an approval.
+
 Exit codes:
-  0 — allow (not a gated command, gate dormant, approved, or a fail-open
-      degradation: unresolvable repo/PR or an oracle error)
-  2 — block (gate enabled AND the oracle reports the PR is not approved)
+  0 — allow (not a gated command, gate dormant, approved, the oracle reports
+      "unknown", or a fail-open degradation: unresolvable repo/PR or an
+      oracle error)
+  2 — block (gate enabled AND the oracle reports the PR is genuinely not
+      approved: pending or changes_requested)
 """
 
 from __future__ import annotations
@@ -54,7 +66,7 @@ for _p in (_HERE, _LIB):
 from _framework_config import config  # noqa: E402
 from _framework_log import log_pretooluse_block  # noqa: E402
 from _repo_flag_parse import extract_repo  # noqa: E402
-from pr_review_state import APPROVED, review_state  # noqa: E402  (consume the oracle; no re-parse)
+from pr_review_state import APPROVED, UNKNOWN, review_state  # noqa: E402  (consume the oracle; no re-parse)
 
 #: Declares this hook's fail-direction to the dispatcher (#175): an uncaught
 #: exception allows the command rather than blocking on the hook's own bug. The
@@ -188,7 +200,12 @@ def check(input_data: dict) -> dict | None:
     except Exception:  # noqa: BLE001 — fail-open: degrade to allow, never block on our bug
         return None
 
-    if state.get("state") == APPROVED:
+    if state.get("state") in (APPROVED, UNKNOWN):
+        # UNKNOWN means the oracle couldn't fetch/parse the PR's comments (a
+        # transient error), NOT that it evaluated the PR and found it
+        # not-approved. Treat it exactly like an oracle exception: fail-open
+        # ALLOW. A broken comment fetch must never read as an ordinary
+        # "pending"/"changes_requested" and block the merge (#207/#214).
         return None
 
     reason = _block_reason(verb, f"#{pr}", state)

--- a/framework/assets/lib/pr_review_state.py
+++ b/framework/assets/lib/pr_review_state.py
@@ -53,16 +53,24 @@ never hard-fail the caller.
   shared config, which fail-opens to its schema default (1) when the config is
   missing/unreadable; a non-integer/negative value or a config-load exception
   degrades to :data:`_FAIL_OPEN_REVIEWERS_REQUIRED`.
-* :func:`review_state` catches comment-fetch / parse errors and returns a
-  ``pending`` state (approvals=0, no must-fix) rather than raising or inventing
-  an approval — the safe, non-blocking degradation.
+* :func:`review_state` catches comment-fetch / parse errors and returns an
+  ``unknown`` state (approvals=0, no must-fix) rather than raising or inventing
+  an approval — "couldn't determine the state" (#207/#214). This is
+  deliberately NOT ``pending``: ``pending`` means the oracle *evaluated* the PR
+  and found it genuinely not-yet-approved (a real, actionable state a caller
+  should block on); ``unknown`` means the oracle *could not evaluate* the PR at
+  all (a transient comment-fetch/transport error). Collapsing the two used to
+  let a flaky GitHub API call read identically to a real "not approved" and
+  BLOCK ``gh pr merge`` — the opposite of the fail-open promise. Callers (see
+  ``validate_pr_review.py``) must treat ``unknown`` like an oracle exception:
+  fail-open ALLOW, never block on it.
 
-State machine (PINNED CONTRACT — frozen for S2/S3)
-==================================================
+State machine (PINNED CONTRACT — frozen for S2/S3; ``unknown`` added #214)
+==========================================================================
 ``ReviewState`` is a plain dict::
 
     {
-      "state": "pending" | "changes_requested" | "approved",
+      "state": "pending" | "changes_requested" | "approved" | "unknown",
       "approvals": int,            # distinct reviewers (Requestors) with a
                                    # current clean/approved verdict
       "reviewers_required": int,   # policy.reviewers_required (fail-open default)
@@ -73,14 +81,26 @@ State machine (PINNED CONTRACT — frozen for S2/S3)
                                      AND unresolved_must_fix == []
     state == "changes_requested" iff any current verdict carries an unresolved
                                      Must-fix (takes precedence over approvals)
+    state == "unknown"           iff the oracle could not fetch/parse the PR's
+                                     comments at all (fail-open — never
+                                     produced by :func:`compute_state`, only by
+                                     the :func:`review_state` I/O wrapper on a
+                                     caught exception)
     else                             "pending"
+
+    INVARIANT: the oracle must NEVER fabricate an "approved" verdict. On any
+    doubt (including "unknown") it reports something a caller can safely
+    fail-open on instead of a false approval.
 
 CLI::
 
     python3 lib/pr_review_state.py <pr_number> --repo <owner/repo> [--json]
 
-Exit codes: 0 approved, 1 not-approved (pending / changes_requested). The I/O
-wrapper itself fail-opens to pending, so a fetch error prints pending / exit 1.
+Exit codes: 0 approved, 1 otherwise (pending / changes_requested / unknown). The
+I/O wrapper fail-opens to ``unknown`` on a fetch error (never ``pending``, and
+never a fabricated ``approved``), so the CLI prints ``UNKNOWN`` / exit 1 in that
+case — a caller scripting against this CLI's exit code should check ``--json``
+``state`` if it needs to distinguish "not approved" from "couldn't tell".
 """
 
 from __future__ import annotations
@@ -114,10 +134,16 @@ FAIL_OPEN = True
 #: non-zero bar; a value of 0 would make an unreviewed PR read "approved".
 _FAIL_OPEN_REVIEWERS_REQUIRED = 1
 
-# The three legal states, exported for callers/tests that assert the vocabulary.
+# The legal states, exported for callers/tests that assert the vocabulary.
 PENDING = "pending"
 CHANGES_REQUESTED = "changes_requested"
 APPROVED = "approved"
+#: "The oracle could not determine the state" (comment-fetch/transport error) —
+#: NOT a synonym for PENDING. Produced only by :func:`review_state`'s exception
+#: handler, never by :func:`compute_state`. Callers must fail-open ALLOW on this,
+#: exactly like an oracle exception (#207/#214) — never fabricate "approved",
+#: but also never let "couldn't tell" masquerade as "not approved" and block.
+UNKNOWN = "unknown"
 
 
 class MustFixEntry(TypedDict):
@@ -230,17 +256,21 @@ def review_state(repo: str, pr: int, *, cfg: Any = None) -> ReviewState:
     reads ``reviewers_required`` from shared config, and returns the pinned
     :class:`ReviewState`.
 
-    Fail-open: any comment-fetch / parse error returns a ``pending`` state
+    Fail-open: any comment-fetch / parse error returns an ``unknown`` state
     (approvals=0, no must-fix) rather than raising or inventing an approval — an
-    error must never manufacture a false "approved".
+    error must never manufacture a false "approved". ``unknown`` is deliberately
+    NOT ``pending``: it says "the oracle could not tell", which callers (the
+    ``validate_pr_review`` gate) must treat as a fail-open ALLOW, exactly like a
+    raised exception — a transient comment-fetch failure must never read as an
+    ordinary "not approved" and BLOCK a merge (#207/#214).
     """
     required = _reviewers_required(cfg)
     try:
         bodies = ts._pr_comment_bodies(repo, int(pr))
         verdicts = ts.parse_verdicts(bodies)
-    except Exception:  # noqa: BLE001 — fail-open: degrade to pending, never raise
+    except Exception:  # noqa: BLE001 — fail-open: degrade to unknown, never raise
         return {
-            "state": PENDING,
+            "state": UNKNOWN,
             "approvals": 0,
             "reviewers_required": required,
             "unresolved_must_fix": [],

--- a/framework/assets/skills/wave-end/SKILL.md
+++ b/framework/assets/skills/wave-end/SKILL.md
@@ -46,8 +46,11 @@ and reads the counters recorded here.
    ```
 
    Count them from the actual merged-PR set, not from memory: `--pr-count` = merged PRs
-   this wave, `--cr-cycles` = ChangesRequested verdicts across them, `--concentration` =
-   max(PRs by one author) × 100 / total.
+   this wave, `--cr-cycles` = **PRs** that took >=1 changes-requested round (per-PR, not
+   per-verdict — a PR with `reviewers_required=2` can carry 2 ChangesRequested verdicts in
+   one round; count the PR once). This mirrors `trust_signals.py`'s `rework_cycles` signal
+   ("PRs they authored that needed >=1 rework round") so the two counters never drift.
+   `--concentration` = max(PRs by one author) × 100 / total.
 4. Run `git worktree prune`
 5. Scan docs/ and diagrams for staleness against changes
 6. If this is the final wave of the phase, create a PR to the default branch (User

--- a/framework/config/framework.config.example.json
+++ b/framework/config/framework.config.example.json
@@ -32,7 +32,7 @@
     "allow_emails": ["owner@example.com"]
   },
   "policy": {
-    "reviewers_required": 2,
+    "reviewers_required": 1,
     "pr_review_gate_enabled": false,
     "merge_model": "wave-branch",
     "admin_merge_exceptions": {

--- a/framework/install/bootstrap.py
+++ b/framework/install/bootstrap.py
@@ -1204,20 +1204,54 @@ def ensure_gitignore_entries(target: Path, entries: tuple[str, ...], *, dry_run:
     written once) — a hand-authored ``.gitignore`` is never rewritten or
     reordered, and a re-run adds nothing new. ``dry_run`` reports what would be
     added without touching the file.
+
+    Normalized for idempotency (#216) so repeated/differently-ordered installer
+    runs never churn the file byte-for-byte:
+
+    * **Deduped input** — a caller-supplied ``entries`` tuple with repeats (or
+      two separate calls for the same logical entry) never appends a path more
+      than once.
+    * **Stable ordering** — the entries actually appended are sorted, so the
+      appended block is a pure function of the *set* of missing entries, not of
+      the order the caller happened to pass them in (two installer runs asking
+      for the same entries in a different order produce byte-identical output).
+    * **No blank-line accumulation** — trailing blank lines left by a PRIOR
+      managed-block write are collapsed before appending, so the separator
+      between pre-existing content and the managed block never grows across
+      repeated calls that each add a new entry, and the file always ends in
+      exactly one trailing newline.
     """
     gi_path = target / ".gitignore"
     existing_lines = gi_path.read_text(encoding="utf-8").splitlines() if gi_path.is_file() else []
     existing_set = set(existing_lines)
-    missing = [e for e in entries if e not in existing_set]
+
+    # Dedupe the requested entries themselves (stable, first-seen order) before
+    # computing what's missing, so a repeated/duplicated request never grows the
+    # file more than once for the same logical entry.
+    deduped_entries: list[str] = []
+    seen: set[str] = set()
+    for e in entries:
+        if e not in seen:
+            seen.add(e)
+            deduped_entries.append(e)
+
+    missing = sorted(e for e in deduped_entries if e not in existing_set)
     if not missing:
         return "up to date (0 added)"
     plural = "y" if len(missing) == 1 else "ies"
     if dry_run:
         return f"would add {len(missing)} entr{plural}: {', '.join(missing)}"
+
+    # Collapse any trailing blank lines already present (e.g. left by a prior
+    # managed-block append) so the separator before our block never grows.
+    while existing_lines and existing_lines[-1] == "":
+        existing_lines.pop()
+
+    header_missing = _GITIGNORE_HEADER not in existing_set
     block: list[str] = []
-    if existing_lines and existing_lines[-1] != "":
+    if existing_lines and header_missing:
         block.append("")
-    if _GITIGNORE_HEADER not in existing_set:
+    if header_missing:
         block.append(_GITIGNORE_HEADER)
     block.extend(missing)
     gi_path.write_text("\n".join(existing_lines + block) + "\n", encoding="utf-8")

--- a/framework/install/charter_drift.py
+++ b/framework/install/charter_drift.py
@@ -18,6 +18,12 @@ expected ``{{feature_branch_scheme}}`` -> value difference is never mistaken for
 genuine content divergence (a canonical doc update not propagated, or a hand-edited runtime
 copy) is reported.
 
+It also cross-checks each module's on-disk checksum against the value recorded in the render
+manifest (``team/.charter-manifest.json``, written by ``bootstrap.install_charter``), so a
+charter edit that happens to match canonical byte-for-byte but skipped going through
+``install_charter`` — leaving the manifest checksum stale — is still caught (#216). See
+:func:`plan` for the full rationale.
+
 Read-only by design (approach (a) from issue #189): this never writes. A reported drift is
 fixed by re-rendering the affected module(s) from canonical for the current config (see
 ``install_charter`` in ``bootstrap.py``; a scoped one-off call with ``force=True`` re-renders
@@ -96,11 +102,25 @@ def plan(claude_root: Path = _DEFAULT_CLAUDE_ROOT, cfg: dict | None = None) -> l
     before comparison, so an expected ``{{placeholder}}`` -> value substitution is never
     itself flagged — only genuine content drift (a canonical update not propagated, a
     missing module, or a hand-edited runtime copy) appears in the result.
+
+    Also cross-checks each module's content against the checksum recorded in the render
+    manifest (``team/.charter-manifest.json``, written by ``bootstrap.install_charter``).
+    A module can byte-match the canonical render while the manifest's recorded checksum
+    for it is stale or missing — e.g. someone wrote the correct rendered text straight to
+    ``.claude/team/charter/*.md`` (a hand-applied "fix" or a copy from another checkout)
+    without going through ``install_charter``, so the manifest was never regenerated
+    (#216). That divergence is invisible to a canonical-vs-live text diff alone, but it
+    corrupts the NEXT ``refresh()``: ``install_charter`` trusts the manifest checksum to
+    decide "unmodified since last render" (safe to propagate a config change) vs.
+    "hand-evolved" (preserve). A stale manifest entry makes that call on stale evidence.
+    So a module is flagged as drift if EITHER its content disagrees with canonical OR its
+    on-disk checksum disagrees with what the manifest claims was last rendered.
     """
     if cfg is None:
         cfg = _load_runtime_config(claude_root)
     rendered = render_canonical_charter(cfg)
     charter_dir = claude_root / "team" / "charter"
+    manifest = bootstrap._load_charter_manifest(claude_root)
     drift: list[str] = []
     for name in sorted(rendered):
         expected_text = rendered[name]
@@ -115,6 +135,13 @@ def plan(claude_root: Path = _DEFAULT_CLAUDE_ROOT, cfg: dict | None = None) -> l
             drift.append(rel)
             continue
         if actual_text != expected_text:
+            drift.append(rel)
+            continue
+        recorded_checksum = manifest.get(name)
+        if recorded_checksum is None or recorded_checksum != bootstrap._sha256(actual_text):
+            # Content matches canonical, but the render manifest disagrees (or has no
+            # entry) about the checksum it last recorded for this module — a charter
+            # edit that skipped manifest regeneration (#216).
             drift.append(rel)
     return drift
 
@@ -147,14 +174,15 @@ def main(argv: list[str] | None = None) -> int:
     if drift:
         print(
             "charter-drift: DRIFT — these runtime charter modules differ from the canonical "
-            f"template rendered with {claude_root}/framework.config.json:"
+            f"template rendered with {claude_root}/framework.config.json, or their "
+            "team/.charter-manifest.json checksum is stale/missing:"
         )
         for d in drift:
             print(f"  {d}")
         print(
             "Fix: re-render the drifted module(s) from canonical for the current config "
-            "(install_charter(..., force=True) in framework/install/bootstrap.py), then "
-            "re-run this check."
+            "(install_charter(..., force=True) in framework/install/bootstrap.py) — this "
+            "also rewrites their team/.charter-manifest.json checksum — then re-run this check."
         )
         return 1
     print(f"charter-drift: {claude_root}/team/charter/ matches canonical for this config.")

--- a/framework/tests/test_bootstrap.py
+++ b/framework/tests/test_bootstrap.py
@@ -40,3 +40,30 @@ def test_written_order_groups_hook_with_verdict_grammar_gate() -> None:
     order (matches the schema/runtime copies test_defaults_sync pins equal)."""
     pre = _written_pre_bash()
     assert pre.index("block_gh_pr_review") == pre.index("validate_review_comment_format") + 1
+
+
+# --------------------------------------------------------------------------
+# ensure_gitignore_entries() normalization pairing (#216).
+#
+# Full coverage (dedup / stable-order / blank-collapse / run-twice-no-diff,
+# each mutation-verified) lives in test_gitignore_ledger_default.py, which
+# pre-dates and is dedicated to this helper. This test pins the same
+# load-bearing contract directly against bootstrap.py so the file-pairing
+# gate (charter/pull-requests.md § Pre-Review Self-Check) has a same-stem
+# test for THIS file's own new behavior.
+
+
+def test_ensure_gitignore_entries_dedupes_and_orders_deterministically(tmp_path: Path) -> None:
+    """Load-bearing (revert -> fail): calling with a duplicated/unordered entries
+    tuple must still produce a single, alphabetically-stable set of appended
+    lines. Reverting either the input-dedup step or the ``sorted(...)`` around
+    the missing entries in ``ensure_gitignore_entries`` makes this fail."""
+    # Deliberately passed in the REVERSE of sorted order (with a repeat), so this
+    # catches both a dropped dedup step and a dropped `sorted(...)` independently.
+    bootstrap.ensure_gitignore_entries(
+        tmp_path, (".claude/x.json", ".claude-backups/", ".claude-backups/"), dry_run=False
+    )
+    lines = (tmp_path / ".gitignore").read_text(encoding="utf-8").splitlines()
+    assert lines.count(".claude-backups/") == 1
+    # sorted(...) output is deterministic regardless of call-site argument order.
+    assert lines.index(".claude-backups/") < lines.index(".claude/x.json")

--- a/framework/tests/test_charter_drift.py
+++ b/framework/tests/test_charter_drift.py
@@ -119,6 +119,58 @@ def test_missing_runtime_module_is_drift(tmp_path: Path) -> None:
     assert ".claude/team/charter/commits.md" in drift
 
 
+def test_stale_manifest_checksum_is_caught_even_when_content_matches_canonical(
+    tmp_path: Path,
+) -> None:
+    """Load-bearing (#216): a module whose on-disk text still matches canonical, but whose
+    ``team/.charter-manifest.json`` checksum entry is stale/wrong, must be flagged as drift.
+
+    This is the gap a plain canonical-vs-live text diff cannot see: someone (or some other
+    tool) writes the correct rendered text straight to ``.claude/team/charter/*.md`` without
+    going through ``install_charter``, so the manifest is never regenerated. The live file
+    looks perfectly in sync — until the render manifest is consulted.
+
+    Mutation bar: revert the checksum cross-check in ``charter_drift.plan()`` (e.g. drop the
+    ``recorded_checksum`` block) and this test fails, because the content-only comparison
+    sees no drift here.
+    """
+    import json
+
+    r = _install(tmp_path)
+    assert r.returncode == 0, r.stderr
+
+    manifest_path = tmp_path / ".claude" / "team" / ".charter-manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    # Corrupt the recorded checksum for one module WITHOUT touching its .md content —
+    # simulating a charter edit that skipped manifest regeneration.
+    manifest["files"]["issues.md"] = "0" * 64
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    # The .md content itself still matches canonical exactly.
+    drift = charter_drift.plan(claude_root=tmp_path / ".claude")
+    assert ".claude/team/charter/issues.md" in drift
+
+    rc = charter_drift.main(["--check", "--claude-root", str(tmp_path / ".claude")])
+    assert rc == 1
+
+
+def test_missing_manifest_entry_is_caught(tmp_path: Path) -> None:
+    """A module present in canonical + on disk but absent from the render manifest
+    (e.g. a manifest predating this module, or hand-deleted) is also drift."""
+    import json
+
+    r = _install(tmp_path)
+    assert r.returncode == 0, r.stderr
+
+    manifest_path = tmp_path / ".claude" / "team" / ".charter-manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    del manifest["files"]["commits.md"]
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    drift = charter_drift.plan(claude_root=tmp_path / ".claude")
+    assert ".claude/team/charter/commits.md" in drift
+
+
 def test_render_canonical_charter_matches_iter_charter_files() -> None:
     """render_canonical_charter reuses bootstrap's own iterator/context — same module set."""
     import bootstrap

--- a/framework/tests/test_config_schema_sync.py
+++ b/framework/tests/test_config_schema_sync.py
@@ -38,6 +38,13 @@ def _schema_policy_defaults() -> dict:
     return {k: v["default"] for k, v in props.items() if "default" in v}
 
 
+def _example_policy() -> dict:
+    example = json.loads(
+        (_FRAMEWORK_ROOT / "config" / "framework.config.example.json").read_text(encoding="utf-8")
+    )
+    return example["policy"]
+
+
 def test_schema_and_runtime_defaults_agree_on_policy() -> None:
     """Every schema policy default == the runtime _DEFAULTS shadow, key for key."""
     assert _schema_policy_defaults() == _framework_config._DEFAULTS["policy"]
@@ -60,6 +67,21 @@ def test_new_lifecycle_keys_present_in_all_three_copies() -> None:
         assert schema.get(key) == default
         assert runtime.get(key) == default
         assert written.get(key) == default
+
+
+def test_example_reviewers_required_matches_schema_default() -> None:
+    """#208: the shipped (dormant) example must not silently carry a stricter bar.
+
+    ``framework.config.example.json`` ships with ``pr_review_gate_enabled: false`` — the
+    gate is off, so ``reviewers_required`` is inert today. But an adopter who copies the
+    example and later flips the gate on inherits whatever ``reviewers_required`` value the
+    example happened to carry. It must equal the schema/``_DEFAULTS`` default (1), not this
+    repo's deliberately-armed runtime value (2, see ``.claude/framework.config.json``),
+    else the adopter silently inherits a 2-reviewer bar they never chose.
+    """
+    schema_default = _schema_policy_defaults()["reviewers_required"]
+    assert _example_policy()["reviewers_required"] == schema_default
+    assert _example_policy()["pr_review_gate_enabled"] is False
 
 
 def test_skills_read_the_keys_from_config_not_hardcoded() -> None:

--- a/framework/tests/test_gitignore_ledger_default.py
+++ b/framework/tests/test_gitignore_ledger_default.py
@@ -90,3 +90,106 @@ def test_multiple_entries_only_missing_ones_added(tmp_path: Path) -> None:
     lines = gi.read_text(encoding="utf-8").splitlines()
     assert lines.count(LEDGER) == 1
     assert ".claude-backups/" in lines
+
+
+# ------------------------------------------------------ #216 normalization
+
+
+def test_duplicate_entries_in_a_single_call_are_deduped(tmp_path: Path) -> None:
+    """Load-bearing (#216): a caller-supplied ``entries`` tuple with repeats must
+    never append the same path more than once.
+
+    Mutation bar: drop the input-dedup step (``deduped_entries``/``seen`` loop) in
+    ``ensure_gitignore_entries`` and this fails, since the un-deduped tuple would
+    make ``missing`` contain ``LEDGER`` twice.
+    """
+    bootstrap.ensure_gitignore_entries(tmp_path, (LEDGER, LEDGER), dry_run=False)
+    lines = (tmp_path / ".gitignore").read_text(encoding="utf-8").splitlines()
+    assert lines.count(LEDGER) == 1
+
+
+def test_appended_entries_are_order_independent(tmp_path: Path) -> None:
+    """Load-bearing (#216): the SAME set of missing entries, passed in different
+    orders across two independent targets, must produce byte-identical
+    ``.gitignore`` output — the appended block is a function of the entry SET,
+    not of caller argument order.
+
+    Mutation bar: remove the ``sorted(...)`` around ``missing`` and this fails,
+    since the two targets would then differ only in entry order.
+    """
+    entry_a, entry_b = LEDGER, ".claude-backups/"
+    target1, target2 = tmp_path / "repo1", tmp_path / "repo2"
+    target1.mkdir()
+    target2.mkdir()
+
+    bootstrap.ensure_gitignore_entries(target1, (entry_a, entry_b), dry_run=False)
+    bootstrap.ensure_gitignore_entries(target2, (entry_b, entry_a), dry_run=False)
+
+    text1 = (target1 / ".gitignore").read_text(encoding="utf-8")
+    text2 = (target2 / ".gitignore").read_text(encoding="utf-8")
+    assert text1 == text2
+
+
+def test_preexisting_trailing_blank_lines_are_collapsed_not_duplicated(tmp_path: Path) -> None:
+    """Load-bearing (#216): a hand-authored ``.gitignore`` that already ends in a
+    blank line must get exactly ONE blank separator before the newly-stamped
+    managed block, not two.
+
+    Mutation bar: drop the trailing-blank-line collapse (the
+    ``while existing_lines and existing_lines[-1] == "": existing_lines.pop()``
+    loop) in ``ensure_gitignore_entries`` and this fails — the old
+    ``existing_lines[-1] != ""`` guard this loop replaces would see the file
+    already ends blank and skip adding a separator, but the SECOND blank line
+    already on disk would remain, producing a double blank before the header.
+    """
+    gi = tmp_path / ".gitignore"
+    gi.write_text("node_modules/\n\n", encoding="utf-8")
+
+    bootstrap.ensure_gitignore_entries(tmp_path, (LEDGER,), dry_run=False)
+
+    text = gi.read_text(encoding="utf-8")
+    assert "\n\n\n" not in text
+    assert text.splitlines() == ["node_modules/", "", bootstrap._GITIGNORE_HEADER, LEDGER]
+    assert text.endswith("\n") and not text.endswith("\n\n")
+
+
+def test_repeated_calls_never_accumulate_blank_line_separators(tmp_path: Path) -> None:
+    """Two SEPARATE calls that each add a genuinely new entry must not grow the
+    blank-line gap between installer-managed entries — the header is stamped
+    once (with a single leading blank separator from the pre-existing
+    hand-authored content) and entries stay contiguous underneath it.
+    """
+    gi = tmp_path / ".gitignore"
+    gi.write_text("node_modules/\n", encoding="utf-8")
+
+    bootstrap.ensure_gitignore_entries(tmp_path, (LEDGER,), dry_run=False)
+    bootstrap.ensure_gitignore_entries(tmp_path, (".claude-backups/",), dry_run=False)
+
+    text = gi.read_text(encoding="utf-8")
+    assert "\n\n\n" not in text
+    lines = text.splitlines()
+    assert lines == [
+        "node_modules/",
+        "",
+        bootstrap._GITIGNORE_HEADER,
+        LEDGER,
+        ".claude-backups/",
+    ]
+    assert text.endswith("\n") and not text.endswith("\n\n")
+
+
+def test_running_twice_with_same_entries_produces_no_diff(tmp_path: Path) -> None:
+    """The literal ask: run the same install step twice -> zero diff on the
+    second run, starting from a pre-existing hand-authored .gitignore (the
+    realistic reinstall scenario, not just a from-empty install)."""
+    gi = tmp_path / ".gitignore"
+    gi.write_text("node_modules/\n*.pyc\n", encoding="utf-8")
+
+    bootstrap.ensure_gitignore_entries(tmp_path, (LEDGER, ".claude-backups/"), dry_run=False)
+    first = gi.read_text(encoding="utf-8")
+
+    status = bootstrap.ensure_gitignore_entries(tmp_path, (LEDGER, ".claude-backups/"), dry_run=False)
+    second = gi.read_text(encoding="utf-8")
+
+    assert status == "up to date (0 added)"
+    assert first == second

--- a/framework/tests/test_pr_review_state.py
+++ b/framework/tests/test_pr_review_state.py
@@ -225,9 +225,18 @@ def test_reviewers_required_fail_open_defaults():
     assert prs._reviewers_required(_Cfg(3)) == 3
 
 
-def test_review_state_wrapper_fail_opens_to_pending_on_fetch_error(monkeypatch):
-    """A comment-fetch error returns pending — never a raised exception and
-    never a manufactured 'approved'."""
+def test_review_state_wrapper_fail_opens_to_unknown_on_fetch_error(monkeypatch):
+    """A comment-fetch error returns "unknown" — never a raised exception,
+    never a manufactured "approved", and (#207/#214) NOT masked as an ordinary
+    "pending". "pending" means the oracle evaluated the PR and found it
+    genuinely not-yet-approved; "unknown" means it couldn't evaluate the PR at
+    all (a transient fetch/transport error). Collapsing the two used to let a
+    flaky GitHub API call block `gh pr merge` exactly like a real "not
+    approved" — the opposite of a fail-open gate.
+
+    Mutation bar: reverting the except-handler in `review_state` back to
+    `state=PENDING` makes this fail.
+    """
 
     def _boom(_repo, _num):
         raise RuntimeError("gh exploded")
@@ -239,7 +248,9 @@ def test_review_state_wrapper_fail_opens_to_pending_on_fetch_error(monkeypatch):
             return 1
 
     state = prs.review_state("acme/widget", 7, cfg=_Cfg())
-    assert state["state"] == "pending"
+    assert state["state"] == "unknown"
+    assert state["state"] == prs.UNKNOWN
+    assert state["state"] != "pending"
     assert state["approvals"] == 0
     assert state["unresolved_must_fix"] == []
 

--- a/framework/tests/test_validate_pr_review.py
+++ b/framework/tests/test_validate_pr_review.py
@@ -29,6 +29,7 @@ _FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_FRAMEWORK_ROOT / "assets" / "hooks"))
 sys.path.insert(0, str(_FRAMEWORK_ROOT / "assets" / "lib"))
 
+import pr_review_state as oracle  # noqa: E402
 import validate_pr_review as hook  # noqa: E402
 
 
@@ -198,6 +199,45 @@ def test_oracle_error_allows(monkeypatch) -> None:
         raise RuntimeError("gh exploded")
 
     monkeypatch.setattr(hook, "review_state", _raise)
+    assert hook.check(_bash(_MERGE)) is None
+
+
+def test_oracle_unknown_state_allows(monkeypatch) -> None:
+    """FAIL_OPEN (#207/#214): an oracle "unknown" state ALLOWS, exactly like an
+    exception — it must NOT read as an ordinary "not approved" and block.
+    """
+    _arm(monkeypatch, enabled=True)
+    _stub_oracle(
+        monkeypatch,
+        {"state": oracle.UNKNOWN, "approvals": 0, "reviewers_required": 2, "unresolved_must_fix": []},
+    )
+    assert hook.check(_bash(_MERGE)) is None
+
+
+def test_comment_fetch_error_reads_unknown_and_gate_allows(monkeypatch) -> None:
+    """End-to-end (#207/#214): a comment-fetch/transport error must reach the
+    gate as "unknown", never silently as "pending" — a broken oracle must
+    never be able to wedge `gh pr merge`.
+
+    Deliberately does NOT stub `hook.review_state` — it exercises the REAL
+    `pr_review_state.review_state` oracle end-to-end (only the lower-level
+    `trust_signals._pr_comment_bodies` comment fetch is monkeypatched to fail,
+    exactly as a transient GitHub API error would). This also guards against a
+    state-string mismatch between the oracle and the gate (e.g. the gate
+    checking for a different literal than the oracle emits).
+
+    Mutation bar: reverting `review_state`'s except-handler back to
+    `state=PENDING` flips this PR to "not approved" and the gate BLOCKS
+    instead of allowing -> this test fails.
+    """
+    import trust_signals as ts
+
+    def _boom(_repo, _num):
+        raise RuntimeError("gh comment fetch exploded")
+
+    monkeypatch.setattr(ts, "_pr_comment_bodies", _boom)
+    _arm(monkeypatch, enabled=True)
+    # No oracle stub: hook.review_state is the real pr_review_state.review_state.
     assert hook.check(_bash(_MERGE)) is None
 
 


### PR DESCRIPTION
## Phase 6 Wave 7 — Harden the armed gate (rollup)

Meta #213. Rolls up all 3 stories of the gate-hardening wave into `main`. First wave whose
**story merges were themselves governed by the live 2-reviewer gate** (each cleared 2 distinct
clean reviewer verdicts before the oracle allowed the merge).

### Stories
- **S1 #214 / PR #218 (Paloma-authored? no — Tariq.Morales → Nia + Paloma):** fail-open the
  review-gate oracle on comment-**fetch** error. `pr_review_state.review_state()` now returns a new
  `unknown` sentinel (not `pending`) on transport error; `validate_pr_review` treats `unknown` as
  fail-open **ALLOW** while genuine `pending`/`changes_requested` still BLOCK. Closes #207. The
  oracle still can never fabricate `approved`. End-to-end test pins fetch-error → ALLOW.
- **S2 #215 / PR #217 (Ibrahim.El-Amin → Paloma + Tariq):** `framework.config.example.json`
  `reviewers_required` 2→1 (adopters who later enable the gate no longer inherit a silent 2-bar;
  closes #208) + guard test pinning it to the schema default; wave-end `--cr-cycles` wording rebound
  to per-PR to match `trust_signals.rework_cycles` at N≥2 (closes #211). Runtime copy synced.
- **S3 #216 / PR #219 (Paloma.Gupta → Nia + Ibrahim):** `charter_drift.py` now cross-checks each
  rendered charter module's on-disk sha256 against the manifest (catches byte-match-but-stale-manifest);
  `ensure_gitignore_entries` normalized for idempotency (dedup/sort/blank-collapse). Paloma held sole
  golden-manifest integration-owner (no regen needed — zero installed-path changes).

### Verification
- **717 tests pass** (706 baseline + 11 new load-bearing tests; every fix mutation-proved: revert → red).
- `reinstall.py --check`, `manifest.py --check`, `charter_drift.py --check` all exit 0 (dual-deploy #116).
- 6/6 clean reviewer verdicts across 3 PRs; **0 changes-requested cycles**; 3 distinct authors (33%).
- This repo's armed runtime `.claude/framework.config.json` (reviewers_required=2, gate enabled) untouched.

### Debt closed
#207, #208, #211 (the 3 gate-activation follow-ups) + 2 W9 carry-overs (charter-manifest checksum
cross-check; gitignore normalize). Deferred-debt tail cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
