### PR TITLE
S3: cli_bridge_soft_degrade + --compare CI gate (closes #148, #224)

### DIFF
--- a/.github/workflows/install-quality-gate.yml
+++ b/.github/workflows/install-quality-gate.yml
@@ -1,0 +1,64 @@
+name: install-quality-gate
+
+# Arms the install-quality harness's run-over-run regression gate (#104 §4 / #148 / #224).
+# Runs the deterministic `cli_bridge_soft_degrade` cell (B13) through the REAL CLI bridge and
+# diffs it against the committed baseline with `--compare`; the harness exits non-zero on a
+# REGRESSION verdict or any failed graded metric, failing this job.
+#
+# Scope note: the gate runs the trend-free B13 cell only. The full matrix carries wall-clock
+# `*_duration_s` trend metrics whose run-over-run budget is machine-dependent and would make a
+# cross-runner `--compare` flaky; the soft-degrade cell is pass/fail and deterministic.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches:
+      - main
+      - "deployments/**"
+    paths:
+      - "framework/harness/**"
+      - "framework/install/**"
+      - "python/src/real_team/**"
+      - "framework/tests/install_quality/**"
+      - "framework/tests/test_install_harness.py"
+      - ".github/workflows/install-quality-gate.yml"
+
+jobs:
+  compare-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install the CLI (real_team + typer/rich)
+        # The B13 soft-degrade fixture runs `2real-team init` from an isolated copy of the
+        # real_team package, so the package and its deps must be importable by this interpreter.
+        working-directory: python
+        run: |
+          pip install -e ".[dev]" 2>/dev/null || pip install -e .
+          pip install pytest
+
+      - name: Harness self-tests (incl. the B13 end-to-end soft-degrade cell)
+        env:
+          ENVIRONMENT: test
+        run: pytest framework/tests/test_install_harness.py -q
+
+      - name: Seed the committed baseline into the runtime runs dir
+        # runs/ is .gitignored (envelopes are generated artifacts); the source-controlled
+        # baseline lives under baselines/ and is copied in so `--compare` finds a prior run.
+        run: |
+          mkdir -p framework/tests/install_quality/runs
+          cp framework/tests/install_quality/baselines/cli_soft_degrade.baseline.json \
+             framework/tests/install_quality/runs/baseline.json
+
+      - name: Compare gate — fail on any metric regression
+        run: |
+          python3 -m framework.harness \
+            --buckets B13 \
+            --installers cli_soft_degrade \
+            --no-dogfood \
+            --compare

--- a/framework/harness/buckets.py
+++ b/framework/harness/buckets.py
@@ -15,6 +15,7 @@ Stdlib only.
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -24,7 +25,13 @@ from typing import Callable
 from .real_provision import make_real_provisioner
 
 _FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+_REPO_ROOT = _FRAMEWORK_ROOT.parent
 _BOOTSTRAP = _FRAMEWORK_ROOT / "install" / "bootstrap.py"
+
+#: Repo-root data dirs the CLI resolves via ``parents[2]`` in a source checkout. The
+#: soft-degrade fixture copies these (so team scaffolding still works) but deliberately
+#: OMITS ``framework/`` so the bridge's ``resolve_framework_root()`` returns None.
+_CLI_SOURCE_DATA_DIRS = ("presets", "templates", "skills")
 
 #: Default B9 scale (trivial .py files). #103 proposes ~2000; kept lower for CI wall-clock,
 #: overridable via ``--scale`` so the scale check can be dialed up on demand.
@@ -196,6 +203,27 @@ def _prov_invalid_config(wd: Path, opts: dict) -> dict:
     return {"config_json": str(bad)}
 
 
+def _prov_cli_soft_degrade(wd: Path, opts: dict) -> dict:
+    """Isolated *source-checkout* fixture MISSING the framework payload.
+
+    Lays ``<wd>/iso/python/src/real_team`` (a copy of the CLI package) plus the
+    ``presets/templates/skills`` data dirs at the package's ``parents[2]`` — but NO
+    ``framework/``. Run through ``run_cli_soft_degrade`` (which puts ``iso/python/src`` on
+    ``PYTHONPATH``), ``resolve_framework_root()`` finds neither ``_bundled/framework`` nor a
+    repo-root ``framework/``, so the bridge soft-degrades while team scaffolding still lands.
+    Returns the importable package root in ``extra.iso_src`` for the runner.
+    """
+    iso = wd / "iso"
+    src = iso / "python" / "src"
+    src.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(_REPO_ROOT / "python" / "src" / "real_team", src / "real_team")
+    for data in _CLI_SOURCE_DATA_DIRS:
+        origin = _REPO_ROOT / data
+        if origin.is_dir():
+            shutil.copytree(origin, iso / data)
+    return {"extra": {"iso_src": str(src)}}
+
+
 def _prov_large(wd: Path, opts: dict) -> dict:
     n = int(opts.get("scale", DEFAULT_B9_FILES))
     gen = wd / "gen"
@@ -333,6 +361,15 @@ def build_buckets() -> list[Bucket]:
                 # out of the way — B9 stresses scale/timing, not the fresh-vs-existing verdict.
                 _bootstrap_flags("--with-ontology", "--expect", "any", "--owner", "acme")),
         ]),
+        Bucket("B13", "cli-bridge-soft-degrade", _prov_cli_soft_degrade, [
+            Leg("soft-degrade", ("cli_soft_degrade",),
+                ["cli_bridge_soft_degrade", "install_exit_status",
+                 "non_interactive_zero_prompts"],
+                {"model": "single-repo", "installer": "cli", "bundled_assets": "absent",
+                 "team": True},
+                _bootstrap_flags("--preset", "library", "--owner", "acme"),
+                target_subdir="proj"),
+        ], installers_hint=("cli_soft_degrade",)),
         # --- [real] flag-gated OFF by default (owner-decision 1); provisioned by cloning the
         # live source at a pinned SHA into scratch (#153) only under --include-real. ---
         Bucket("B10", "meta-real-world", make_real_provisioner("B10"), [

--- a/framework/harness/installers.py
+++ b/framework/harness/installers.py
@@ -43,7 +43,7 @@ class RunResult:
         return f"{self.stdout}\n{self.stderr}"
 
 
-def _run(argv: list[str], *, cwd: Path | None = None) -> RunResult:
+def _run(argv: list[str], *, cwd: Path | None = None, env: dict | None = None) -> RunResult:
     start = time.monotonic()
     try:
         cp = subprocess.run(
@@ -53,6 +53,7 @@ def _run(argv: list[str], *, cwd: Path | None = None) -> RunResult:
             stdin=subprocess.DEVNULL,  # zero-prompt contract: any prompt EOFErrors
             timeout=INSTALL_TIMEOUT_S,
             cwd=str(cwd) if cwd else None,
+            env=env,
         )
         return RunResult(argv, cp.returncode, cp.stdout, cp.stderr, time.monotonic() - start)
     except subprocess.TimeoutExpired as exc:
@@ -93,6 +94,36 @@ def run_cli(target: Path, flags: list[str]) -> RunResult:
         *flags,
     ]
     return _run(argv)
+
+
+def run_cli_soft_degrade(target: Path, flags: list[str], pkg_src: Path) -> RunResult:
+    """``2real-team init`` run from an ISOLATED package copy whose framework payload is
+    unreachable — exercises the CLI bridge's **soft-degrade** (#139).
+
+    ``pkg_src`` is a directory on which ``real_team`` is importable but whose ``parents[2]``
+    (the resolved repo-root the bridge probes) holds ``presets/templates/skills`` yet **no**
+    ``framework/`` and no ``_bundled/framework``. So ``framework_install.resolve_framework_root``
+    returns None: the CLI still lays the mustache team scaffolding + root ``CLAUDE.md``, prints
+    the soft notice, skips the ``bootstrap.py`` runtime step, and exits 0. Prepending ``pkg_src``
+    to ``PYTHONPATH`` shadows any installed ``real_team`` so the copy (not the editable install)
+    is what runs.
+    """
+    argv = [
+        sys.executable,
+        "-c",
+        "import sys; from real_team.cli import app; app()",
+        "init",
+        "--target",
+        str(target),
+        "--non-interactive",
+        *flags,
+    ]
+    prior = os.environ.get("PYTHONPATH", "")
+    env = {
+        **os.environ,
+        "PYTHONPATH": str(pkg_src) + (os.pathsep + prior if prior else ""),
+    }
+    return _run(argv, env=env)
 
 
 def run_reinstall_check() -> RunResult:

--- a/framework/harness/metrics.py
+++ b/framework/harness/metrics.py
@@ -159,6 +159,34 @@ def m_invalid_config_refused(ctx: CellContext) -> Measurement:
     )
 
 
+def m_cli_bridge_soft_degrade(ctx: CellContext) -> Measurement:
+    """CLI bridge degrades gracefully when the bundled framework payload is absent (#139).
+
+    Pass iff ``2real-team init`` printed the soft-degrade notice and still exited 0 — the
+    mustache team scaffolding (charter + root ``CLAUDE.md``) is laid, and the ``bootstrap.py``
+    runtime step was SKIPPED (no ``.claude/framework.config.json``), i.e. no error raised.
+    """
+    r = ctx.primary
+    out = r.out
+    notice = "bundled assets not found" in out or "Framework runtime not installed" in out
+    team_scaffolded = (ctx.workdir / ".claude" / "team" / "charter.md").is_file()
+    claude_md = (ctx.workdir / "CLAUDE.md").is_file()
+    # The runtime step must be skipped: the bridge returned None, so no framework.config.json.
+    runtime_skipped = not (ctx.workdir / ".claude" / "framework.config.json").is_file()
+    ok = (
+        r.returncode == 0 and not r.timed_out
+        and notice and team_scaffolded and claude_md and runtime_skipped
+    )
+    return Measurement(
+        value=ok, passed=ok,
+        expected={"exit": 0, "soft_notice": True, "team_scaffolded": True,
+                  "root_CLAUDE.md": True, "runtime_step": "skipped"},
+        observed={"exit": r.returncode, "timed_out": r.timed_out, "notice": notice,
+                  "charter": team_scaffolded, "claude_md": claude_md,
+                  "runtime_skipped": runtime_skipped, "stdout_excerpt": _excerpt(out)},
+    )
+
+
 def m_non_interactive_zero_prompts(ctx: CellContext) -> Measurement:
     # stdin is always closed; a prompt would EOFError/hang -> our timeout (124).
     ok = not ctx.primary.timed_out
@@ -569,6 +597,7 @@ _reg("install_exit_status", "A", KIND_PASS_FAIL, m_install_exit_status)
 _reg("repo_state_gate_correct", "A", KIND_PASS_FAIL, m_repo_state_gate_correct)
 _reg("invalid_config_refused", "A", KIND_PASS_FAIL, m_invalid_config_refused)
 _reg("non_interactive_zero_prompts", "A", KIND_PASS_FAIL, m_non_interactive_zero_prompts)
+_reg("cli_bridge_soft_degrade", "A", KIND_PASS_FAIL, m_cli_bridge_soft_degrade)
 _reg("files_installed_complete", "B", KIND_SCORED, m_files_installed_complete)
 _reg("no_unexpected_files", "B", KIND_PASS_FAIL, m_no_unexpected_files)
 _reg("install_snapshot_recorded", "B", KIND_PASS_FAIL, m_install_snapshot_recorded)

--- a/framework/harness/runner.py
+++ b/framework/harness/runner.py
@@ -143,9 +143,17 @@ def run_cell(bucket: Bucket, leg: Leg, installer: str, opts: dict, scratch: Path
         target.mkdir(parents=True, exist_ok=True)
 
         before = snapshot(target)
-        flags = (leg.cli_flags or leg.build_flags)(workdir) if installer == "cli" \
-            else leg.build_flags(workdir)
-        primary = _install(installer, target, flags)
+        if installer == "cli_soft_degrade":
+            # Isolated-checkout leg (B13): run the CLI from a copy whose framework payload is
+            # unreachable so the bridge soft-degrades. The importable package root is in
+            # the fixture's ``extra.iso_src`` (see buckets._prov_cli_soft_degrade).
+            primary = installers.run_cli_soft_degrade(
+                target, leg.build_flags(workdir), Path(fixture["extra"]["iso_src"])
+            )
+        else:
+            flags = (leg.cli_flags or leg.build_flags)(workdir) if installer == "cli" \
+                else leg.build_flags(workdir)
+            primary = _install(installer, target, flags)
         after = snapshot(target)
 
         ctx = CellContext(

--- a/framework/tests/install_quality/baselines/cli_soft_degrade.baseline.json
+++ b/framework/tests/install_quality/baselines/cli_soft_degrade.baseline.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": 1,
+  "run": {
+    "run_id": "2026-07-07T13:17:17Z-2e5c9e9",
+    "git_sha": "2e5c9e93e93604ca3fde9e4d175aad12ebc5a128",
+    "started_at": "2026-07-07T13:17:17Z",
+    "finished_at": "2026-07-07T13:17:18Z",
+    "harness_version": "0.1.0",
+    "host_kind": "local",
+    "installers": [
+      "cli_soft_degrade"
+    ],
+    "buckets": [
+      "B13"
+    ]
+  },
+  "records": [
+    {
+      "record_id": "B13/cli_soft_degrade/soft-degrade/cli_bridge_soft_degrade",
+      "bucket": "B13",
+      "fixture": "cli-bridge-soft-degrade",
+      "installer": "cli_soft_degrade",
+      "permutation": {
+        "model": "single-repo",
+        "installer": "cli",
+        "bundled_assets": "absent",
+        "team": true
+      },
+      "metric": "cli_bridge_soft_degrade",
+      "category": "A",
+      "kind": "pass_fail",
+      "value": true,
+      "pass": true,
+      "expected": {
+        "exit": 0,
+        "soft_notice": true,
+        "team_scaffolded": true,
+        "root_CLAUDE.md": true,
+        "runtime_step": "skipped"
+      },
+      "observed": {
+        "exit": 0,
+        "timed_out": false,
+        "notice": true,
+        "charter": true,
+        "claude_md": true,
+        "runtime_skipped": true,
+        "stdout_excerpt": "Generating team for proj...\n\nCreated 15 files:\n  .claude/team/charter.md\n  .claude/team/roster/manager_greta_yamamoto.md\n  .claude/team/roster/tech_lead_sakura_ueda.md\n  .claude/team/roster/software_engineer_kwame_vargas.md\n  .claude/team/roster/software_engineer_marco_okonkwo.md\n  .claude/team/roster/qa_engineer_yuki_singh.md\n  .claude/team/trust_matrix.md\n  .claude/team/feedback_log.md\n  CLAUDE.md\n  .claude/skills/retro.md\n  .claude/skills/wave-start.md\n  .claude/skills/wave-end.md\n  .claude/skills/review-pr.md\n  .claude/skills/plan-phase.md\n  .claude/skills/close-stale-issues.md\n\nFramework  \u2026[truncated]"
+      },
+      "duration_s": 0.0,
+      "timestamp": "2026-07-07T13:17:18Z",
+      "git_sha": "2e5c9e93e93604ca3fde9e4d175aad12ebc5a128",
+      "notes": ""
+    },
+    {
+      "record_id": "B13/cli_soft_degrade/soft-degrade/install_exit_status",
+      "bucket": "B13",
+      "fixture": "cli-bridge-soft-degrade",
+      "installer": "cli_soft_degrade",
+      "permutation": {
+        "model": "single-repo",
+        "installer": "cli",
+        "bundled_assets": "absent",
+        "team": true
+      },
+      "metric": "install_exit_status",
+      "category": "A",
+      "kind": "pass_fail",
+      "value": true,
+      "pass": true,
+      "expected": {
+        "exit": 0
+      },
+      "observed": {
+        "exit": 0,
+        "timed_out": false
+      },
+      "duration_s": 0.0,
+      "timestamp": "2026-07-07T13:17:18Z",
+      "git_sha": "2e5c9e93e93604ca3fde9e4d175aad12ebc5a128",
+      "notes": ""
+    },
+    {
+      "record_id": "B13/cli_soft_degrade/soft-degrade/non_interactive_zero_prompts",
+      "bucket": "B13",
+      "fixture": "cli-bridge-soft-degrade",
+      "installer": "cli_soft_degrade",
+      "permutation": {
+        "model": "single-repo",
+        "installer": "cli",
+        "bundled_assets": "absent",
+        "team": true
+      },
+      "metric": "non_interactive_zero_prompts",
+      "category": "A",
+      "kind": "pass_fail",
+      "value": true,
+      "pass": true,
+      "expected": {
+        "completed_without_stdin": true
+      },
+      "observed": {
+        "timed_out": false,
+        "duration_s": 0.327
+      },
+      "duration_s": 0.0,
+      "timestamp": "2026-07-07T13:17:18Z",
+      "git_sha": "2e5c9e93e93604ca3fde9e4d175aad12ebc5a128",
+      "notes": ""
+    }
+  ],
+  "rollup": {
+    "per_bucket_pass_rate": {
+      "B13": 1.0
+    },
+    "per_category_pass_rate": {
+      "A": 1.0
+    },
+    "install_success_rate": 1.0,
+    "reinstall_parity_clean": null,
+    "trend": {}
+  }
+}

--- a/framework/tests/test_install_harness.py
+++ b/framework/tests/test_install_harness.py
@@ -25,6 +25,7 @@ import install_config  # noqa: E402  (framework/install sibling — the resolved
 from framework.harness import (  # noqa: E402
     buckets,
     compare,
+    installers,
     manifest,
     metrics,
     real_provision,
@@ -297,6 +298,107 @@ def test_no_backup_litter_ignores_preexisting_checked_in_baks(tmp_path: Path) ->
     assert m2.observed["baks"] == ["CLAUDE.md.20260705T000000Z.bak"]
 
 
+# -------------------------------- #148/#224: cli_bridge_soft_degrade metric + fixture
+
+
+def _soft_result(out: str, *, rc: int = 0, timed_out: bool = False) -> installers.RunResult:
+    return installers.RunResult(argv=[], returncode=rc, stdout=out, stderr="",
+                                duration_s=0.1, timed_out=timed_out)
+
+
+def _lay_soft_degrade_tree(root: Path, *, charter: bool = True,
+                           claude_md: bool = True, runtime: bool = False) -> Path:
+    """A post-run target tree in the soft-degrade shape (team scaffolded, runtime skipped).
+
+    The soft-notice is asserted from the RunResult stdout the caller passes, not from disk.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    if charter:
+        (root / ".claude" / "team").mkdir(parents=True, exist_ok=True)
+        (root / ".claude" / "team" / "charter.md").write_text("charter\n", encoding="utf-8")
+    if claude_md:
+        (root / "CLAUDE.md").write_text("# team\n", encoding="utf-8")
+    if runtime:  # the runtime step did NOT skip (bundled assets were present) — a regression
+        (root / ".claude").mkdir(parents=True, exist_ok=True)
+        (root / ".claude" / "framework.config.json").write_text("{}\n", encoding="utf-8")
+    return root
+
+
+def test_cli_bridge_soft_degrade_passes_on_notice_and_skipped_runtime(tmp_path: Path) -> None:
+    """Green: soft notice + exit 0 + team scaffolded (charter + CLAUDE.md) + runtime skipped."""
+    _lay_soft_degrade_tree(tmp_path)
+    ctx = metrics.CellContext(
+        workdir=tmp_path, installer="cli_soft_degrade", permutation={},
+        primary=_soft_result("Framework runtime not installed: bundled assets not found\n"),
+    )
+    m = metrics.m_cli_bridge_soft_degrade(ctx)
+    assert m.passed is True and m.value is True
+
+
+def test_cli_bridge_soft_degrade_fails_each_broken_condition(tmp_path: Path) -> None:
+    """Each pass-condition is load-bearing — dropping any one flips the metric to FAIL."""
+    notice = "Framework runtime not installed: bundled assets not found\n"
+
+    # (a) non-zero exit — the bridge raised instead of soft-degrading.
+    d = tmp_path / "a"
+    _lay_soft_degrade_tree(d)
+    assert metrics.m_cli_bridge_soft_degrade(metrics.CellContext(
+        workdir=d, installer="cli_soft_degrade", permutation={},
+        primary=_soft_result(notice, rc=1))).passed is False
+
+    # (b) no soft notice in stdout — degraded silently.
+    d = tmp_path / "b"
+    _lay_soft_degrade_tree(d)
+    assert metrics.m_cli_bridge_soft_degrade(metrics.CellContext(
+        workdir=d, installer="cli_soft_degrade", permutation={},
+        primary=_soft_result("Installed the framework runtime.\n"))).passed is False
+
+    # (c) team scaffolding absent — charter not laid.
+    d = tmp_path / "c"
+    _lay_soft_degrade_tree(d, charter=False)
+    assert metrics.m_cli_bridge_soft_degrade(metrics.CellContext(
+        workdir=d, installer="cli_soft_degrade", permutation={},
+        primary=_soft_result(notice))).passed is False
+
+    # (d) root CLAUDE.md missing.
+    d = tmp_path / "d"
+    _lay_soft_degrade_tree(d, claude_md=False)
+    assert metrics.m_cli_bridge_soft_degrade(metrics.CellContext(
+        workdir=d, installer="cli_soft_degrade", permutation={},
+        primary=_soft_result(notice))).passed is False
+
+    # (e) runtime step NOT skipped — framework.config.json present means the bridge did NOT
+    #     degrade; that is the regression the gate must catch.
+    d = tmp_path / "e"
+    _lay_soft_degrade_tree(d, runtime=True)
+    assert metrics.m_cli_bridge_soft_degrade(metrics.CellContext(
+        workdir=d, installer="cli_soft_degrade", permutation={},
+        primary=_soft_result(notice))).passed is False
+
+    # (f) timed out (hang) — not a graceful degrade.
+    d = tmp_path / "f"
+    _lay_soft_degrade_tree(d)
+    assert metrics.m_cli_bridge_soft_degrade(metrics.CellContext(
+        workdir=d, installer="cli_soft_degrade", permutation={},
+        primary=_soft_result(notice, rc=124, timed_out=True))).passed is False
+
+
+def test_prov_cli_soft_degrade_isolates_framework(tmp_path: Path) -> None:
+    """The fixture copies real_team + data dirs but OMITS framework/ so the bridge can't
+    resolve it; the importable package root is exposed in extra.iso_src."""
+    wd = tmp_path / "wd"
+    wd.mkdir()
+    fixture = buckets._prov_cli_soft_degrade(wd, {})
+    iso_src = Path(fixture["extra"]["iso_src"])
+    assert (iso_src / "real_team" / "cli.py").is_file()          # CLI package copied
+    assert iso_src.parents[1] == wd / "iso"
+    # parents[2] of the package (= <wd>/iso) has presets but NOT framework — the whole point.
+    pkg_parents2 = (iso_src / "real_team").parents[2]
+    assert (pkg_parents2 / "presets").is_dir()
+    assert not (pkg_parents2 / "framework").exists()
+    assert not (iso_src / "real_team" / "_bundled").exists()
+
+
 # --------------------------------------------------------------- buckets matrix
 
 
@@ -350,6 +452,27 @@ def test_run_matrix_hermetic_bucket_all_green(bucket_id: str) -> None:
     assert graded, "no graded metrics produced"
     failed = [r for r in graded if not r["pass"]]
     assert not failed, f"unexpected failures: {[r['record_id'] for r in failed]}"
+    assert doc["rollup"]["install_success_rate"] == 1.0
+
+
+def test_run_matrix_b13_cli_soft_degrade_all_green() -> None:
+    """B13 end-to-end through the REAL CLI bridge: with the framework payload isolated away,
+    `2real-team init` soft-degrades (notice + exit 0) and every graded metric passes.
+
+    Requires the `real_team` CLI (+ typer/rich) importable by this interpreter — the harness
+    invokes it via ``sys.executable``. Skips cleanly where the CLI is not installed (e.g. the
+    stdlib-only ``framework`` CI job); the ``install-quality-gate`` workflow installs it."""
+    pytest.importorskip("real_team")
+    pytest.importorskip("typer")
+    env = run_matrix({"buckets": ["B13"], "installers": ["cli_soft_degrade"], "dogfood": False})
+    doc = env.to_dict()
+    graded = [r for r in doc["records"] if r["pass"] is not None
+              and r["kind"] in ("pass_fail", "scored")]
+    assert graded, "no graded metrics produced"
+    sd = [r for r in doc["records"] if r["metric"] == "cli_bridge_soft_degrade"]
+    assert len(sd) == 1 and sd[0]["pass"] is True, sd
+    failed = [r for r in graded if not r["pass"]]
+    assert not failed, f"unexpected failures: {[(r['record_id'], r['observed']) for r in failed]}"
     assert doc["rollup"]["install_success_rate"] == 1.0
 
 


### PR DESCRIPTION
## S3 — cli_bridge_soft_degrade + `--compare` CI gate

Closes #148, #224 (Phase 6 Wave 8, meta #221). Author: Tariq Morales.

Two Phase-5 harness follow-ups, entirely within harness code + `.github/workflows/` — **file-disjoint from S1 (`framework/install/` + product CLI) and S2 (ontology-freshness + `test_meta_child_install.py`).**

### 1. Implement + grade `cli_bridge_soft_degrade` (defined in #139, was unimplemented)
- **Fixture** `_prov_cli_soft_degrade` (new bucket **B13**): a faithful *"bundled assets absent in a source checkout"* scenario — copies the `real_team` CLI package + `presets/templates/skills` into an isolated tree but **omits `framework/`**, so `resolve_framework_root()` finds neither `_bundled/framework` nor a repo-root `framework/` and returns `None`.
- **Installer** `installers.run_cli_soft_degrade` runs `2real-team init` from that copy (PYTHONPATH-shadowed) so the **real** CLI bridge takes its soft-degrade path.
- **Metric** `m_cli_bridge_soft_degrade` (category A, pass_fail) grades: **exit 0** + soft notice printed + team scaffolding laid (charter + root `CLAUDE.md`) + `bootstrap.py` runtime step **skipped** (no `.claude/framework.config.json`).

### 2. Arm `--compare` as a CI regression gate
- New workflow **`.github/workflows/install-quality-gate.yml`**: installs the CLI, runs the harness self-tests (incl. the B13 end-to-end cell), seeds the committed baseline into the runtime runs dir, then runs `--compare`. The harness exits non-zero on a **REGRESSION** verdict or any failed graded metric → job red.
- **Committed baseline** at `framework/tests/install_quality/baselines/cli_soft_degrade.baseline.json` (the `runs/` dir is `.gitignored` — envelopes are generated artifacts, so the source-controlled baseline lives under `baselines/` and is copied in at CI time).
- Gate scoped to the **trend-free** B13 cell so `--compare` is deterministic across runners (the full matrix carries machine-dependent `*_duration_s` trend budgets).

### Evidence — gate green on baseline, RED on regression
```
GREEN: install_success_rate : 1.00  (3/3 graded)   verdict: STABLE       EXIT=0
RED  : install_success_rate : 0.67  (2/3 graded)   verdict: REGRESSION   EXIT=1
       FAIL  B13/cli_soft_degrade/soft-degrade/cli_bridge_soft_degrade
       REGRESSION: B13/cli_soft_degrade/soft-degrade/cli_bridge_soft_degrade
```
(RED produced by deliberately de-isolating the fixture so the bridge succeeds → notice absent + runtime not skipped → the metric flips pass→fail; reverted after capture.)

### Mutation-proved (each flips the matching new test red, then reverted)
- drop `runtime_skipped` from the pass condition → `test_cli_bridge_soft_degrade_fails_each_broken_condition` fails
- drop the notice check → same test fails
- force the metric `ok=False` → `test_...passes_on_notice_and_skipped_runtime` fails
- fixture also copies `framework/` (isolation defeated) → `test_prov_cli_soft_degrade_isolates_framework` **and** `test_run_matrix_b13_cli_soft_degrade_all_green` fail

### Gates
- `reinstall.py --check` → **exit 0**
- `manifest.py --check` → **exit 0**
- `charter_drift.py --check` → **exit 0**
- `ruff check framework/` + `ruff check src/ tests/` → clean
- Full suites: **framework 721 passed** (+4 new), **python 126 passed**

### Dual-deploy (#116)
N/A — the harness is dev/test tooling and never ships to a target `.claude/`; `reinstall.py --check` exit 0 confirms no canonical↔runtime drift.

### Acceptance
- [x] Implement the fixture + grade `cli_bridge_soft_degrade`
- [x] Commit a baseline + wire `--compare` as a CI job that fails on regressions
- [x] CI job green on the baseline; a deliberately-regressed metric makes it RED (demonstrated above)
- [x] Stays within harness code + `.github/workflows/` — file-disjoint from S1/S2
- [x] Dual-deploy where applicable (N/A, justified); all `--check` gates exit 0; mutation-proved

Reviewers: Ibrahim El-Amin, Paloma Gupta
