### PR TITLE
S3: document amend-in-place + rollup escape-hatch; mechanize review-load in wave-end (closes #231)

### DIFF
--- a/.claude/skills/wave-end/SKILL.md
+++ b/.claude/skills/wave-end/SKILL.md
@@ -51,6 +51,24 @@ and reads the counters recorded here.
    one round; count the PR once). This mirrors `trust_signals.py`'s `rework_cycles` signal
    ("PRs they authored that needed >=1 rework round") so the two counters never drift.
    `--concentration` = max(PRs by one author) × 100 / total.
+
+   **Emit review-load next to concentration** (#231): concentration tracks *authoring*
+   load; the companion number is *reviewing* load — per-reviewer verdict counts, so a
+   lopsided slate (one reviewer carrying most verdicts) is a tracked number rather than
+   something you balance by eye. Compute it with the skill's bundled `review_load.py`,
+   resolved the same dual-deploy way as `$LIB` (installed copy first, framework-source
+   fallback), and record the line alongside the counters — `/wave-retro` reads it into the
+   feedback log's review-load note:
+
+   ```bash
+   RL="$REPO_ROOT/.claude/skills/wave-end/review_load.py"
+   [ -f "$RL" ] || RL="$REPO_ROOT/framework/assets/skills/wave-end/review_load.py"
+   python3 "$RL" counts "$W"   # {reviewer: {verdicts, prs_reviewed}}, roster-canonicalized
+   ```
+
+   A "verdict" is one review turn by its `Requestor:` (both `Request` and the
+   amended-in-place `Replied` count once — the amendment convention edits the comment in
+   place, so it never inflates the count; see [pull-requests.md](../../team/charter/pull-requests.md)).
 4. Run `git worktree prune`
 5. Scan docs/ and diagrams for staleness against changes
 6. If this is the final wave of the phase, create a PR to the default branch (User

--- a/.claude/skills/wave-end/review_load.py
+++ b/.claude/skills/wave-end/review_load.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Per-reviewer review-load counts for a wave (W11/W12/W13 proposal; #231).
+
+Backs the ``/wave-end`` skill's review-load step: emit how the wave's review
+verdicts were spread across reviewers, so lopsided load (one reviewer carrying
+most of the verdicts) is a *tracked number* recorded next to concentration —
+not something the orchestrator eyeballs by hand.
+
+Layering mirrors ``trust_signals.py`` (and ``promotion-audit/helpers.py``): a
+pure counting/render core, callable standalone on hand-built verdict data; a
+thin SCM/I-O layer that wires it to the live merged-PR set via ``gh``; a CLI.
+The pure core is what the tests mutation-prove — the arithmetic (one verdict
+comment per review turn, one distinct PR per reviewer) is the whole value.
+
+Reuse, not re-implementation: verdict parsing and roster identity-folding live
+in ``trust_signals`` and are imported here (read-only) so the two never drift on
+what a "verdict" is or how ``Nia.Rossi`` / ``Nia Rossi (Staff)`` fold to one
+identity. This module never mutates ``trust_signals`` state — it only reads.
+
+A "verdict" is any comment carrying the charter's ``RequestOrReplied:`` line
+(see ``team/charter/issues.md``); both ``Request`` and the amended-in-place
+``Replied`` forms count as one review turn by that ``Requestor:``. Because the
+count is over the *comment*, a reviewer who posts a ``Request`` and later amends
+it in place to ``Replied`` is still one verdict on that PR — the amendment
+convention (see ``pull-requests.md``) does not inflate the load count.
+
+CLI:
+  review_load.py counts <wave> [--label L] [--status PATH]
+      Emit per-reviewer review-load as JSON: ``{reviewer: {verdicts,
+      prs_reviewed}}``, roster-canonicalized, sorted by reviewer name. Reads the
+      live merged-PR set + their verdict comments over ``gh`` — read-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+# The skill dir (assets/skills/wave-end or .claude/skills/wave-end) is a sibling of
+# hooks/ and lib/ under a common parent (assets/ or .claude/) in BOTH the source tree
+# and an installed tree — the same lib->hooks bridge trust_signals.py / helpers.py use.
+_SKILL_DIR = Path(__file__).resolve().parent
+_ROOT_DIR = _SKILL_DIR.parent.parent
+_HOOKS_DIR = _ROOT_DIR / "hooks"
+_LIB_DIR = _ROOT_DIR / "lib"
+sys.path.insert(0, str(_HOOKS_DIR))
+sys.path.insert(0, str(_LIB_DIR))
+
+import trust_signals as ts  # noqa: E402
+from _framework_config import config  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Pure counting / rendering core (no I/O)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ReviewLoad:
+    """One reviewer's load over a wave.
+
+    ``verdicts`` = review turns they authored (each verdict comment counts once,
+    whether ``Request`` or the amended ``Replied``). ``prs_reviewed`` = distinct
+    PRs they posted at least one verdict on — the load-balance measure.
+    """
+
+    verdicts: int = 0
+    prs_reviewed: int = 0
+
+
+def review_load(prs, *, canon=None) -> dict[str, ReviewLoad]:
+    """Pure: fold a wave's verdict comments into ``{reviewer: ReviewLoad}``.
+
+    ``prs`` is an iterable of ``(pr_key, comment_bodies)`` — ``pr_key`` any
+    hashable PR identity, ``comment_bodies`` the list of that PR's issue-comment
+    body strings. ``canon`` is an optional ``name -> canonical_name`` mapper
+    (default identity); pass ``trust_signals._canonicalizer(cfg)`` to fold name
+    variants to their roster identity exactly as the scorer does.
+
+    Verdicts with no ``Requestor:`` are skipped (nobody to attribute the load
+    to). Ordering of ``prs`` never affects the counts — the result is a pure
+    function of the multiset of (reviewer, pr) pairs.
+    """
+    canon = canon or (lambda n: n)
+    out: dict[str, ReviewLoad] = {}
+    for pr_key, comment_bodies in prs:
+        seen_this_pr: set[str] = set()
+        for v in ts.parse_verdicts(comment_bodies):
+            if not v.requestor:
+                continue
+            name = canon(v.requestor)
+            load = out.setdefault(name, ReviewLoad())
+            load.verdicts += 1
+            if name not in seen_this_pr:
+                load.prs_reviewed += 1
+                seen_this_pr.add(name)
+    return out
+
+
+def render_counts_line(loads: dict[str, ReviewLoad]) -> str:
+    """Pure: a compact one-line review-load summary, sorted by reviewer name.
+
+    e.g. ``review-load (verdicts): Ibrahim El-Amin 1 / Nia Rossi 2 / Paloma
+    Gupta 2 / Tariq Morales 1`` — the tracked number the wrapup records next to
+    concentration. Empty input yields an explicit ``(no reviewer verdicts)`` so
+    the line is never blank.
+    """
+    if not loads:
+        return "review-load (verdicts): (no reviewer verdicts)"
+    parts = [f"{name} {loads[name].verdicts}" for name in sorted(loads)]
+    return "review-load (verdicts): " + " / ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# I/O layer (live merged-PR set + verdict comments over gh). Reuses
+# trust_signals' gh-backed helpers so the merged-PR set is defined identically
+# to the scorer's. Everything above is reusable standalone.
+# ---------------------------------------------------------------------------
+
+
+def extract_review_load(
+    wave: str,
+    status_path: Path | None = None,
+    *,
+    label: str | None = None,
+    cfg=None,
+) -> dict[str, ReviewLoad]:
+    """Build ``{reviewer: ReviewLoad}`` for one wave from the live merged-PR set.
+
+    The merged-PR set and identity-folding are exactly ``trust_signals``' — this
+    reads its ``merged_prs`` / ``_pr_comment_bodies`` / ``_canonicalizer`` (never
+    writes). Reviewer identity is the verdict comment's ``Requestor:`` field,
+    canonicalized against the roster.
+    """
+    cfg = cfg or config()
+    prs = ts.merged_prs(wave, status_path, label=label, cfg=cfg)
+    canon = ts._canonicalizer(cfg)
+    rows = [
+        (pr["number"], ts._pr_comment_bodies(pr["repo"], pr["number"])) for pr in prs
+    ]
+    return review_load(rows, canon=canon)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _default_status() -> Path | None:
+    raw = config().get("paths.state_file")
+    return Path(raw) if raw else None
+
+
+def _cmd_counts(args: argparse.Namespace) -> int:
+    loads = extract_review_load(args.wave, args.status, label=args.label)
+    print(
+        json.dumps(
+            {name: asdict(load) for name, load in loads.items()},
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_counts = sub.add_parser(
+        "counts", help="emit per-reviewer review-load (verdicts, prs_reviewed) as JSON"
+    )
+    p_counts.add_argument("wave", help="iteration / wave id")
+    p_counts.add_argument(
+        "--label",
+        default=None,
+        help="optional issue/PR label to additionally filter the merged-PR set",
+    )
+    p_counts.add_argument(
+        "--status",
+        type=Path,
+        default=_default_status(),
+        help="path to the project state file (default: config paths.state_file)",
+    )
+    p_counts.set_defaults(func=_cmd_counts)
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    args = _build_parser().parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.claude/team/.charter-manifest.json
+++ b/.claude/team/.charter-manifest.json
@@ -7,7 +7,7 @@
     "commits.md": "c9d5e7349f0ead70cb37dd8cf20a7753fe3bea5c943ad56fe3f661dc4daaab67",
     "hooks.md": "77d72942082cf0dd1fb45da686376d8813d3e2b30ebe1ec4f99e432ef0fdb1d5",
     "issues.md": "18d7a6a6e31112abad5ae6f92635c268168cce750b3372aacfa9d875f3dfbc9d",
-    "pull-requests.md": "b22eb3ea593b0dde9d37d1387f04ab07c18f5eeffa8f9a54b20070c7178710ff",
+    "pull-requests.md": "6a38fed814bcdabb89bf63c78b68b241d23d0a923a7bef8034cdc341c61b783d",
     "skills.md": "dcc93b623b5f62cbac412634d4d3b04c3731c5a4a0892dd3227c70241703e81e"
   }
 }

--- a/.claude/team/charter/pull-requests.md
+++ b/.claude/team/charter/pull-requests.md
@@ -128,6 +128,31 @@ identities whose current verdict is clean (a `Replied` review with `Must-fix: No
 4. **Merge into the integration branch** — the team merges these PRs itself; no
    owner approval is needed below `main`.
 
+### Clearing a `Request`: amend in place (never post a new comment)
+
+When you re-review after the submitter has pushed a fix, **clear your blocking verdict by
+EDITING your original `Request` comment in place** to `Replied` / `Must-fix: None` — do
+**not** post a fresh `Replied` comment and leave the old `Request` standing:
+
+```bash
+gh api -X PATCH /repos/<owner>/<repo>/issues/comments/<comment-id> --field body=@resolved.md
+```
+
+**Why this is load-bearing, not stylistic.** The armed-gate oracle
+(`lib/pr_review_state`) counts **every current comment** that parses as a `Must-fix:` /
+`Request` as a still-open blocker, and a reviewer with any standing blocking comment is
+**not** counted as an approver even if they later add a separate clean one. A new `Replied`
+comment therefore leaves your old `Request` in force — the oracle stays `changes_requested`
+and the PR cannot reach `approved`. Editing the original comment is the only way to retract
+the block. (Learned the hard way in Phase 6 Wave 8, #231.)
+
+The scorer credits the catch regardless of the amendment: `trust_signals` records each
+changes-requested catch to a durable review-catch ledger **at issue time**, and (per S1,
+#229) also reconstructs catches from the comment **edit history** — so amending your
+`Request` away to `Replied` clears the oracle's block *without* erasing the
+`must_fix_caught` / `must_fix_received` credit for the review. Amend freely; the signal
+survives.
+
 ### Reviewer Assignment (distinct, author-exclusive)
 
 Reviewers are assigned by the lead at wave kickoff (spread the load). The reviewer runs
@@ -219,3 +244,31 @@ mirrored asset (or its live copy) without reinstalling fails that check.
 At the end of a wave/phase, the Manager creates a PR from the integration branch
 into `main`. The **project owner reviews and approves** this merge —
 do not proceed until they have (see [charter.md § Ground Rules](charter.md)).
+
+### Landing the rollup under a permanently-armed gate: the direct-push escape hatch
+
+A wave-rollup PR carries **no verdicts of its own** — its constituent story PRs each
+already cleared the gate with 2 clean reviews; re-reviewing the
+rollup is theater. But under a **permanently-armed** gate (`pr_review_gate_enabled=true`
+on `main`) the oracle still demands 2 clean approvals
+before `gh pr merge`, so a verdict-less rollup PR **cannot** clear the gate.
+
+The sanctioned way to land it is a **direct-push merge** — a direct push to
+`main` is not a gated verb (only `gh pr ready` / `gh pr merge` are), so it
+is ungated by construction:
+
+```bash
+git checkout main && git pull
+git merge --no-ff <integration-branch>          # e.g. deployments/phaseN/wave-M
+git -c user.name="<Manager>" -c user.email="<...>" commit   # only if the merge needs one
+git push origin main
+```
+
+GitHub auto-marks the rollup PR **MERGED** once its head commits reach
+`main`. This is the escape hatch for the rollup specifically — it does **not**
+lower the bar for the story PRs, which still go through the gate normally, and it is
+distinct from the § N-reviewer merge gate escape hatch (which *disarms* the gate via a
+config-only commit; this one leaves the gate armed and merges around it for the one
+verdict-less rollup). The same ungated-direct-push property is why wrapup / version-bump /
+memory / ontology commits also land as direct pushes. (Codified from Phase 6 Wave 7–8
+practice, #231.)

--- a/framework/assets/skills/wave-end/SKILL.md
+++ b/framework/assets/skills/wave-end/SKILL.md
@@ -51,6 +51,24 @@ and reads the counters recorded here.
    one round; count the PR once). This mirrors `trust_signals.py`'s `rework_cycles` signal
    ("PRs they authored that needed >=1 rework round") so the two counters never drift.
    `--concentration` = max(PRs by one author) × 100 / total.
+
+   **Emit review-load next to concentration** (#231): concentration tracks *authoring*
+   load; the companion number is *reviewing* load — per-reviewer verdict counts, so a
+   lopsided slate (one reviewer carrying most verdicts) is a tracked number rather than
+   something you balance by eye. Compute it with the skill's bundled `review_load.py`,
+   resolved the same dual-deploy way as `$LIB` (installed copy first, framework-source
+   fallback), and record the line alongside the counters — `/wave-retro` reads it into the
+   feedback log's review-load note:
+
+   ```bash
+   RL="$REPO_ROOT/.claude/skills/wave-end/review_load.py"
+   [ -f "$RL" ] || RL="$REPO_ROOT/framework/assets/skills/wave-end/review_load.py"
+   python3 "$RL" counts "$W"   # {reviewer: {verdicts, prs_reviewed}}, roster-canonicalized
+   ```
+
+   A "verdict" is one review turn by its `Requestor:` (both `Request` and the
+   amended-in-place `Replied` count once — the amendment convention edits the comment in
+   place, so it never inflates the count; see [pull-requests.md](../../team/charter/pull-requests.md)).
 4. Run `git worktree prune`
 5. Scan docs/ and diagrams for staleness against changes
 6. If this is the final wave of the phase, create a PR to the default branch (User

--- a/framework/assets/skills/wave-end/review_load.py
+++ b/framework/assets/skills/wave-end/review_load.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Per-reviewer review-load counts for a wave (W11/W12/W13 proposal; #231).
+
+Backs the ``/wave-end`` skill's review-load step: emit how the wave's review
+verdicts were spread across reviewers, so lopsided load (one reviewer carrying
+most of the verdicts) is a *tracked number* recorded next to concentration —
+not something the orchestrator eyeballs by hand.
+
+Layering mirrors ``trust_signals.py`` (and ``promotion-audit/helpers.py``): a
+pure counting/render core, callable standalone on hand-built verdict data; a
+thin SCM/I-O layer that wires it to the live merged-PR set via ``gh``; a CLI.
+The pure core is what the tests mutation-prove — the arithmetic (one verdict
+comment per review turn, one distinct PR per reviewer) is the whole value.
+
+Reuse, not re-implementation: verdict parsing and roster identity-folding live
+in ``trust_signals`` and are imported here (read-only) so the two never drift on
+what a "verdict" is or how ``Nia.Rossi`` / ``Nia Rossi (Staff)`` fold to one
+identity. This module never mutates ``trust_signals`` state — it only reads.
+
+A "verdict" is any comment carrying the charter's ``RequestOrReplied:`` line
+(see ``team/charter/issues.md``); both ``Request`` and the amended-in-place
+``Replied`` forms count as one review turn by that ``Requestor:``. Because the
+count is over the *comment*, a reviewer who posts a ``Request`` and later amends
+it in place to ``Replied`` is still one verdict on that PR — the amendment
+convention (see ``pull-requests.md``) does not inflate the load count.
+
+CLI:
+  review_load.py counts <wave> [--label L] [--status PATH]
+      Emit per-reviewer review-load as JSON: ``{reviewer: {verdicts,
+      prs_reviewed}}``, roster-canonicalized, sorted by reviewer name. Reads the
+      live merged-PR set + their verdict comments over ``gh`` — read-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+# The skill dir (assets/skills/wave-end or .claude/skills/wave-end) is a sibling of
+# hooks/ and lib/ under a common parent (assets/ or .claude/) in BOTH the source tree
+# and an installed tree — the same lib->hooks bridge trust_signals.py / helpers.py use.
+_SKILL_DIR = Path(__file__).resolve().parent
+_ROOT_DIR = _SKILL_DIR.parent.parent
+_HOOKS_DIR = _ROOT_DIR / "hooks"
+_LIB_DIR = _ROOT_DIR / "lib"
+sys.path.insert(0, str(_HOOKS_DIR))
+sys.path.insert(0, str(_LIB_DIR))
+
+import trust_signals as ts  # noqa: E402
+from _framework_config import config  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Pure counting / rendering core (no I/O)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ReviewLoad:
+    """One reviewer's load over a wave.
+
+    ``verdicts`` = review turns they authored (each verdict comment counts once,
+    whether ``Request`` or the amended ``Replied``). ``prs_reviewed`` = distinct
+    PRs they posted at least one verdict on — the load-balance measure.
+    """
+
+    verdicts: int = 0
+    prs_reviewed: int = 0
+
+
+def review_load(prs, *, canon=None) -> dict[str, ReviewLoad]:
+    """Pure: fold a wave's verdict comments into ``{reviewer: ReviewLoad}``.
+
+    ``prs`` is an iterable of ``(pr_key, comment_bodies)`` — ``pr_key`` any
+    hashable PR identity, ``comment_bodies`` the list of that PR's issue-comment
+    body strings. ``canon`` is an optional ``name -> canonical_name`` mapper
+    (default identity); pass ``trust_signals._canonicalizer(cfg)`` to fold name
+    variants to their roster identity exactly as the scorer does.
+
+    Verdicts with no ``Requestor:`` are skipped (nobody to attribute the load
+    to). Ordering of ``prs`` never affects the counts — the result is a pure
+    function of the multiset of (reviewer, pr) pairs.
+    """
+    canon = canon or (lambda n: n)
+    out: dict[str, ReviewLoad] = {}
+    for pr_key, comment_bodies in prs:
+        seen_this_pr: set[str] = set()
+        for v in ts.parse_verdicts(comment_bodies):
+            if not v.requestor:
+                continue
+            name = canon(v.requestor)
+            load = out.setdefault(name, ReviewLoad())
+            load.verdicts += 1
+            if name not in seen_this_pr:
+                load.prs_reviewed += 1
+                seen_this_pr.add(name)
+    return out
+
+
+def render_counts_line(loads: dict[str, ReviewLoad]) -> str:
+    """Pure: a compact one-line review-load summary, sorted by reviewer name.
+
+    e.g. ``review-load (verdicts): Ibrahim El-Amin 1 / Nia Rossi 2 / Paloma
+    Gupta 2 / Tariq Morales 1`` — the tracked number the wrapup records next to
+    concentration. Empty input yields an explicit ``(no reviewer verdicts)`` so
+    the line is never blank.
+    """
+    if not loads:
+        return "review-load (verdicts): (no reviewer verdicts)"
+    parts = [f"{name} {loads[name].verdicts}" for name in sorted(loads)]
+    return "review-load (verdicts): " + " / ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# I/O layer (live merged-PR set + verdict comments over gh). Reuses
+# trust_signals' gh-backed helpers so the merged-PR set is defined identically
+# to the scorer's. Everything above is reusable standalone.
+# ---------------------------------------------------------------------------
+
+
+def extract_review_load(
+    wave: str,
+    status_path: Path | None = None,
+    *,
+    label: str | None = None,
+    cfg=None,
+) -> dict[str, ReviewLoad]:
+    """Build ``{reviewer: ReviewLoad}`` for one wave from the live merged-PR set.
+
+    The merged-PR set and identity-folding are exactly ``trust_signals``' — this
+    reads its ``merged_prs`` / ``_pr_comment_bodies`` / ``_canonicalizer`` (never
+    writes). Reviewer identity is the verdict comment's ``Requestor:`` field,
+    canonicalized against the roster.
+    """
+    cfg = cfg or config()
+    prs = ts.merged_prs(wave, status_path, label=label, cfg=cfg)
+    canon = ts._canonicalizer(cfg)
+    rows = [
+        (pr["number"], ts._pr_comment_bodies(pr["repo"], pr["number"])) for pr in prs
+    ]
+    return review_load(rows, canon=canon)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _default_status() -> Path | None:
+    raw = config().get("paths.state_file")
+    return Path(raw) if raw else None
+
+
+def _cmd_counts(args: argparse.Namespace) -> int:
+    loads = extract_review_load(args.wave, args.status, label=args.label)
+    print(
+        json.dumps(
+            {name: asdict(load) for name, load in loads.items()},
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_counts = sub.add_parser(
+        "counts", help="emit per-reviewer review-load (verdicts, prs_reviewed) as JSON"
+    )
+    p_counts.add_argument("wave", help="iteration / wave id")
+    p_counts.add_argument(
+        "--label",
+        default=None,
+        help="optional issue/PR label to additionally filter the merged-PR set",
+    )
+    p_counts.add_argument(
+        "--status",
+        type=Path,
+        default=_default_status(),
+        help="path to the project state file (default: config paths.state_file)",
+    )
+    p_counts.set_defaults(func=_cmd_counts)
+    return parser
+
+
+def main(argv: list[str]) -> int:
+    args = _build_parser().parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/framework/assets/team/charter/pull-requests.md
+++ b/framework/assets/team/charter/pull-requests.md
@@ -128,6 +128,31 @@ identities whose current verdict is clean (a `Replied` review with `Must-fix: No
 4. **Merge into the integration branch** — the team merges these PRs itself; no
    owner approval is needed below `{{default_branch}}`.
 
+### Clearing a `Request`: amend in place (never post a new comment)
+
+When you re-review after the submitter has pushed a fix, **clear your blocking verdict by
+EDITING your original `Request` comment in place** to `Replied` / `Must-fix: None` — do
+**not** post a fresh `Replied` comment and leave the old `Request` standing:
+
+```bash
+gh api -X PATCH /repos/<owner>/<repo>/issues/comments/<comment-id> --field body=@resolved.md
+```
+
+**Why this is load-bearing, not stylistic.** The armed-gate oracle
+(`lib/pr_review_state`) counts **every current comment** that parses as a `Must-fix:` /
+`Request` as a still-open blocker, and a reviewer with any standing blocking comment is
+**not** counted as an approver even if they later add a separate clean one. A new `Replied`
+comment therefore leaves your old `Request` in force — the oracle stays `changes_requested`
+and the PR cannot reach `approved`. Editing the original comment is the only way to retract
+the block. (Learned the hard way in Phase 6 Wave 8, #231.)
+
+The scorer credits the catch regardless of the amendment: `trust_signals` records each
+changes-requested catch to a durable review-catch ledger **at issue time**, and (per S1,
+#229) also reconstructs catches from the comment **edit history** — so amending your
+`Request` away to `Replied` clears the oracle's block *without* erasing the
+`must_fix_caught` / `must_fix_received` credit for the review. Amend freely; the signal
+survives.
+
 ### Reviewer Assignment (distinct, author-exclusive)
 
 Reviewers are assigned by the lead at wave kickoff (spread the load). The reviewer runs
@@ -219,3 +244,31 @@ mirrored asset (or its live copy) without reinstalling fails that check.
 At the end of a wave/phase, the Manager creates a PR from the integration branch
 into `{{default_branch}}`. The **project owner reviews and approves** this merge —
 do not proceed until they have (see [charter.md § Ground Rules](charter.md)).
+
+### Landing the rollup under a permanently-armed gate: the direct-push escape hatch
+
+A wave-rollup PR carries **no verdicts of its own** — its constituent story PRs each
+already cleared the gate with {{reviewers_required}} clean reviews; re-reviewing the
+rollup is theater. But under a **permanently-armed** gate (`pr_review_gate_enabled=true`
+on `{{default_branch}}`) the oracle still demands {{reviewers_required}} clean approvals
+before `gh pr merge`, so a verdict-less rollup PR **cannot** clear the gate.
+
+The sanctioned way to land it is a **direct-push merge** — a direct push to
+`{{default_branch}}` is not a gated verb (only `gh pr ready` / `gh pr merge` are), so it
+is ungated by construction:
+
+```bash
+git checkout {{default_branch}} && git pull
+git merge --no-ff <integration-branch>          # e.g. deployments/phaseN/wave-M
+git -c user.name="<Manager>" -c user.email="<...>" commit   # only if the merge needs one
+git push origin {{default_branch}}
+```
+
+GitHub auto-marks the rollup PR **MERGED** once its head commits reach
+`{{default_branch}}`. This is the escape hatch for the rollup specifically — it does **not**
+lower the bar for the story PRs, which still go through the gate normally, and it is
+distinct from the § N-reviewer merge gate escape hatch (which *disarms* the gate via a
+config-only commit; this one leaves the gate armed and merges around it for the one
+verdict-less rollup). The same ungated-direct-push property is why wrapup / version-bump /
+memory / ontology commits also land as direct pushes. (Codified from Phase 6 Wave 7–8
+practice, #231.)

--- a/framework/install/golden-manifest.json
+++ b/framework/install/golden-manifest.json
@@ -71,6 +71,7 @@
     ".claude/skills/team-reset/SKILL.md",
     ".claude/skills/wave-audit/SKILL.md",
     ".claude/skills/wave-end/SKILL.md",
+    ".claude/skills/wave-end/review_load.py",
     ".claude/skills/wave-lifecycle/SKILL.md",
     ".claude/skills/wave-retro/SKILL.md",
     ".claude/skills/wave-start/SKILL.md",

--- a/framework/tests/test_wave_end_review_load.py
+++ b/framework/tests/test_wave_end_review_load.py
@@ -1,0 +1,124 @@
+"""Tests for the wave-end skill's review_load.py — per-reviewer review-load
+counts recorded next to concentration in the wrapup (#231; W11/W12/W13 proposal).
+
+Stdlib + pytest only; no network — the pure counting/render core is exercised on
+hand-built verdict-comment data (the same verdict grammar trust_signals parses).
+Covers verdict attribution to the Requestor, the per-PR distinct-review count,
+roster canonicalization of name variants, amend-in-place NOT inflating the count,
+and the compact render line.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+_SKILL_DIR = _FRAMEWORK_ROOT / "assets" / "skills" / "wave-end"
+sys.path.insert(0, str(_FRAMEWORK_ROOT / "assets" / "hooks"))
+sys.path.insert(0, str(_FRAMEWORK_ROOT / "assets" / "lib"))
+sys.path.insert(0, str(_SKILL_DIR))
+
+import review_load as rl  # noqa: E402
+
+
+def _verdict(requestor: str, requestee: str, must_fix: str = "None") -> str:
+    """A charter-shaped verdict comment body (see team/charter/issues.md)."""
+    replied = "Request" if must_fix != "None" else "Replied"
+    return (
+        f"Requestor: {requestor}\n"
+        f"Requestee: {requestee}\n"
+        f"RequestOrReplied: {replied}\n\n"
+        f"Must-fix: {must_fix}\n"
+    )
+
+
+# --------------------------------------------------------------- review_load (core)
+
+
+def test_counts_one_verdict_per_reviewer_per_pr() -> None:
+    prs = [
+        (1, [_verdict("Nia.Rossi", "Paloma.Gupta"), _verdict("Tariq.Morales", "Paloma.Gupta")]),
+        (2, [_verdict("Nia.Rossi", "Ibrahim.El-Amin"), _verdict("Paloma.Gupta", "Ibrahim.El-Amin")]),
+    ]
+    loads = rl.review_load(prs)
+    assert loads["Nia.Rossi"].verdicts == 2
+    assert loads["Nia.Rossi"].prs_reviewed == 2
+    assert loads["Tariq.Morales"].verdicts == 1
+    assert loads["Paloma.Gupta"].verdicts == 1
+
+
+def test_two_verdicts_same_pr_counts_two_verdicts_one_pr() -> None:
+    """A reviewer posting two verdict comments on ONE PR is 2 verdicts but 1 PR."""
+    prs = [
+        (7, [_verdict("Nia.Rossi", "Paloma.Gupta", must_fix="- fix X"), _verdict("Nia.Rossi", "Paloma.Gupta")]),
+    ]
+    loads = rl.review_load(prs)
+    assert loads["Nia.Rossi"].verdicts == 2
+    assert loads["Nia.Rossi"].prs_reviewed == 1
+
+
+def test_amend_in_place_does_not_inflate_count() -> None:
+    """The amendment convention edits the SAME comment — the count is over the
+    final comment set, so an amended Request→Replied is still one verdict."""
+    posted_then_amended = [_verdict("Tariq.Morales", "Paloma.Gupta")]  # ends as one Replied
+    loads = rl.review_load([(9, posted_then_amended)])
+    assert loads["Tariq.Morales"].verdicts == 1
+    assert loads["Tariq.Morales"].prs_reviewed == 1
+
+
+def test_verdict_without_requestor_is_skipped() -> None:
+    no_requestor = "RequestOrReplied: Replied\n\nMust-fix: None\n"
+    loads = rl.review_load([(3, [no_requestor, _verdict("Nia.Rossi", "Paloma.Gupta")])])
+    assert set(loads) == {"Nia.Rossi"}
+    assert loads["Nia.Rossi"].verdicts == 1
+
+
+def test_non_verdict_comments_ignored() -> None:
+    chatter = "LGTM, nice work!\n"
+    loads = rl.review_load([(4, [chatter, _verdict("Paloma.Gupta", "Nia.Rossi")])])
+    assert set(loads) == {"Paloma.Gupta"}
+
+
+def test_order_independent() -> None:
+    a = [(1, [_verdict("Nia.Rossi", "X")]), (2, [_verdict("Tariq.Morales", "X")])]
+    b = list(reversed(a))
+    assert rl.review_load(a) == rl.review_load(b)
+
+
+def test_empty_prs_yields_empty() -> None:
+    assert rl.review_load([]) == {}
+
+
+def test_canon_folds_name_variants() -> None:
+    """A canon mapper folds Requestor variants to one identity (roster-fold parity
+    with trust_signals): Nia.Rossi / 'Nia Rossi (Staff)' are one reviewer."""
+
+    def canon(name: str) -> str:
+        key = name.replace(".", " ").split(" (")[0].strip().lower()
+        return {"nia rossi": "Nia Rossi"}.get(key, name)
+
+    prs = [
+        (1, [_verdict("Nia.Rossi", "X")]),
+        (2, [_verdict("Nia Rossi (Staff)", "Y")]),
+    ]
+    loads = rl.review_load(prs, canon=canon)
+    assert set(loads) == {"Nia Rossi"}
+    assert loads["Nia Rossi"].verdicts == 2
+    assert loads["Nia Rossi"].prs_reviewed == 2
+
+
+# --------------------------------------------------------------- render_counts_line
+
+
+def test_render_counts_line_sorted_and_labeled() -> None:
+    loads = {
+        "Tariq Morales": rl.ReviewLoad(verdicts=1, prs_reviewed=1),
+        "Nia Rossi": rl.ReviewLoad(verdicts=2, prs_reviewed=2),
+    }
+    line = rl.render_counts_line(loads)
+    assert line == "review-load (verdicts): Nia Rossi 2 / Tariq Morales 1"
+
+
+def test_render_counts_line_empty_is_explicit() -> None:
+    assert rl.render_counts_line({}) == "review-load (verdicts): (no reviewer verdicts)"


### PR DESCRIPTION
## Summary
Turn two hard-won operational conventions into named, documented charter steps, and mechanize review-load in the wave-end wrapup.

- **`pull-requests.md` — amend-in-place step:** to clear a blocking verdict the reviewer **edits their original `Request` comment in place** to `Replied`/`Must-fix: None` (never a new comment), or the armed-gate oracle stays `changes_requested`. Explains the why: the oracle counts every *current* `Must-fix:` as an open blocker and won't count a reviewer with any standing block as an approver; the scorer credits the catch from the durable ledger + comment **edit-history** (per S1 #229), so amending never erases `must_fix_caught`/`must_fix_received`.
- **`pull-requests.md` — rollup direct-push escape hatch step:** a verdict-less rollup PR cannot clear a permanently-armed gate, so land it via `git merge --no-ff` + `git push origin main` (a direct push is ungated). Named, distinct from the gate-disarm escape hatch.
- **`wave-end` skill — review-load counts:** bundled `review_load.py` computes per-reviewer verdict counts (`verdicts` + distinct `prs_reviewed`) from the wave's merged-PR set, reusing `trust_signals`' verdict parse + roster identity-fold (read-only — never mutates or edits `trust_signals`). SKILL step 3 now emits review-load next to concentration so review-load balance is a tracked number (carried W11/W12/W13 proposal).

## Acceptance (#231)
- [x] Amend-in-place named step in `pull-requests.md` with the why (oracle counts current Must-fix; scorer credits from edit-history per S1)
- [x] Rollup direct-push escape-hatch named step in `pull-requests.md`
- [x] `wave-end` emits per-reviewer verdict counts next to concentration
- [x] Dual-deploy (#116): canonical `framework/assets/**` **and** reinstalled `.claude/**`; charter re-rendered; golden manifest regenerated
- [x] Tests/mutation for the wave-end counts (code); doc/charter changes verified by drift + manifest checks

## Dual-deploy proof (all three exit 0)
- `charter_drift.py --check` → **0**
- `reinstall.py --check` → **0**
- `manifest.py --check` → **0**

## Mutation evidence (the review-load counts core)
Four mutations to `review_load.py`, each caught by `test_wave_end_review_load.py`, restored green after:
- `load.verdicts += 1` → `+= 2` → **FAIL** (5 tests)
- drop the `seen_this_pr` distinct-PR guard → **FAIL** (`test_two_verdicts_same_pr...`)
- flip the `if not v.requestor` skip → **FAIL** (`test_verdict_without_requestor_is_skipped`)
- remove `sorted()` in render → **FAIL** (`test_render_counts_line_sorted_and_labeled`)

## Test suite
`ENVIRONMENT=test pytest framework/tests/ -q` → **756 passed** (+10 new). `ruff check framework/` clean.

## Files changed
Canonical + runtime mirrored copies:
- `framework/assets/team/charter/pull-requests.md` + `.claude/team/charter/pull-requests.md` (+ `.claude/team/.charter-manifest.json`)
- `framework/assets/skills/wave-end/SKILL.md` + `.claude/skills/wave-end/SKILL.md`
- `framework/assets/skills/wave-end/review_load.py` + `.claude/skills/wave-end/review_load.py` (new)
- `framework/tests/test_wave_end_review_load.py` (new)
- `framework/install/golden-manifest.json` (regenerated for the new skill file)

Reviewers: Paloma Gupta, Tariq Morales

Closes #231
