### PR TITLE
S1: trust scorer reads reality — edit-history catch crediting + difficulty weight (closes #229)

### DIFF
--- a/framework/assets/lib/trust_signals.py
+++ b/framework/assets/lib/trust_signals.py
@@ -55,6 +55,39 @@ CLI: ``trust_signals.py record-catch <wave> --repo O/N --pr P --requestor R
 --requestee E`` — meant to be invoked immediately after posting a blocking
 verdict comment (see the module CLI section below).
 
+Edit-history catch crediting + difficulty weight (#229)
+-------------------------------------------------------
+The #164 ledger only credits a catch that someone *remembered* to record at
+issue time. Wave 13 exposed the gap: the merge-gate oracle (``pr_review_state``)
+REQUIRES a reviewer to resolve a blocking ``Request`` by editing it in place to
+``Replied`` / ``Must-fix: None`` (any *current* comment parsing as a Must-fix
+blocks the merge), but the scorer read that same current state — so once the
+reviewer amended their comment the catch scored ``must_fix_caught=0`` (reviewer)
+and ``must_fix_received=0`` (author). The wave's single most valuable review — a
+real data-loss catch — scored mechanically zero.
+
+Fix (design option (a), complementary to the #164 ledger): source the catch from
+GitHub's comment **edit history**. :func:`_pr_comment_histories` fetches, per
+comment, its current body plus every prior revision (``userContentEdits.diff``,
+the full body at each revision). :func:`verdicts_from_histories` /
+:func:`_collapse_history` collapse each comment to one Verdict that credits a
+changes-requested catch if ANY revision was blocking — so an amended-away
+``Request`` still counts. FAIL-OPEN: an unavailable history degrades to the live
+comment bodies; the scorer never crashes. This is deliberately NOT wired into
+:func:`parse_verdicts` (the oracle depends on that reading current state so an
+amended-clean Request clears the gate) — only the scorer's extraction path uses
+it. The ledger and edit-history paths are belts-and-braces: the ledger survives a
+comment *deleted outright*; the edit-history path recovers a catch nobody
+recorded.
+
+The same wave also could not mechanically justify the reserved-5:
+:func:`difficulty_weight` derives a coarse per-PR tier (1-3) from diff magnitude
+(changed lines / files), summed per engineer into ``difficulty_points`` and fed
+into the distribution-discipline composite (:func:`apply_distribution_discipline`)
+so a flagship correctness fix outranks a one-liner without a narrative argument.
+Difficulty feeds ONLY the reserved-5 tiebreak, never :func:`score_delta`, so a
+clean no-diffstat wave scores exactly as before.
+
 Signals per engineer (all integers, all countable from the merged-PR set):
 
   ===========================  ============================================
@@ -75,6 +108,9 @@ Signals per engineer (all integers, all countable from the merged-PR set):
   review_false_positives       must-fix items they raised that were later
                                marked withdrawn/false-positive (negative —
                                review-quality signal).
+  difficulty_points            summed coarse difficulty weight (1-3 per PR,
+                               :func:`difficulty_weight`) over authored PRs;
+                               feeds the reserved-5 tiebreak, not score_delta.
   ===========================  ============================================
 
 CLI:
@@ -192,6 +228,14 @@ class Signals:
     ci_red_merges: int = 0
     rework_cycles: int = 0
     review_false_positives: int = 0
+    # Summed coarse per-PR difficulty weight over the engineer's authored PRs
+    # (:func:`difficulty_weight`, #229). A flagship correctness fix accrues 3, a
+    # one-line config change 1, so a wave of hard work outranks a wave of trivial
+    # churn even at equal PR *count*. Feeds the distribution-discipline composite
+    # (reserved-5 tiebreak) — NOT :func:`score_delta`, which stays purely
+    # negative/positive-signal driven, so a clean no-diffstat wave scores exactly
+    # as before (difficulty defaults to 0).
+    difficulty_points: int = 0
     # PR numbers the engineer authored (for the evidence citation in the line).
     authored_prs: list[int] = field(default_factory=list)
 
@@ -575,6 +619,195 @@ def _pr_comment_bodies(repo: str, number: int) -> list[str]:
     return [str(b) for b in parsed]
 
 
+# GraphQL query fetching every issue-comment on a PR together with its full
+# edit history. GitHub exposes each prior revision's *entire body* (not a unified
+# diff) as ``userContentEdits.diff`` — so the union of a comment's current body
+# and every ``diff`` is every body that comment has ever carried. ``{repo}`` /
+# ``{owner}`` / ``{number}`` are substituted by :func:`_pr_comment_histories`.
+_COMMENT_HISTORY_QUERY = """
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      comments(first: 100) {
+        nodes {
+          body
+          userContentEdits(first: 100) {
+            nodes { diff }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def _pr_comment_histories(repo: str, number: int) -> list[list[str]] | None:
+    """Per-comment body revisions on a PR — current body + every prior revision.
+
+    Returns one list per issue-comment: ``[current_body, *historical_bodies]``,
+    where the historical bodies come from GitHub's comment edit API
+    (``userContentEdits.diff`` — the full body at each prior revision, not a
+    unified diff). A comment never edited yields a single-element list. This is
+    the durable signal #229 needs: a blocking ``Request`` / ``Must-fix:`` later
+    amended in place to ``Replied`` / ``Must-fix: None`` (the charter Reply
+    Protocol the oracle requires) still leaves its original changes-requested
+    body in the edit history, so the catch survives the amendment.
+
+    FAIL-OPEN: any error — a ``gh`` failure/timeout, malformed JSON, or an
+    unexpected shape — returns ``None`` (not ``[]``), the sentinel telling
+    :func:`extract_signals` "edit history is unavailable, fall back to the live
+    comment bodies". Never raises; the scorer must never crash on a history
+    fetch. (``[]`` is a legitimate value — a PR with zero comments — and is
+    therefore distinct from the unavailable sentinel.)
+    """
+    if "/" not in repo:
+        return None
+    owner, name = repo.split("/", 1)
+    try:
+        raw = _run_gh(
+            [
+                "api",
+                "graphql",
+                "-f",
+                f"query={_COMMENT_HISTORY_QUERY}",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                f"name={name}",
+                "-F",
+                f"number={int(number)}",
+            ]
+        )
+        data = json.loads(raw or "{}")
+        nodes = (
+            data["data"]["repository"]["pullRequest"]["comments"]["nodes"]
+        )
+    except (
+        subprocess.SubprocessError,
+        OSError,
+        json.JSONDecodeError,
+        KeyError,
+        TypeError,
+        ValueError,
+    ):
+        return None
+    histories: list[list[str]] = []
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        revisions = [str(node.get("body") or "")]
+        edits = ((node.get("userContentEdits") or {}).get("nodes")) or []
+        for edit in edits:
+            if isinstance(edit, dict) and edit.get("diff") is not None:
+                revisions.append(str(edit["diff"]))
+        histories.append(revisions)
+    return histories
+
+
+def _pr_diffstat(pr: dict) -> tuple[int, int, int]:
+    """Extract ``(additions, deletions, changed_files)`` from a merged-PR record.
+
+    The diffstat travels on the ``pr list --json`` record :func:`merged_prs`
+    builds, so no extra network call is needed. Fail-open: any missing/non-int
+    field degrades to 0 (→ the minimum difficulty tier), never raises.
+    """
+
+    def _int(key: str) -> int:
+        try:
+            return int(pr.get(key) or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    return _int("additions"), _int("deletions"), _int("changedFiles")
+
+
+def difficulty_weight(additions: int, deletions: int, changed_files: int) -> int:
+    """Coarse per-PR difficulty tier in ``{1, 2, 3}`` from diff magnitude. Pure.
+
+    Deliberately three buckets, not a continuous score — the point (#229) is to
+    tell a flagship correctness fix apart from a one-line config change so the
+    reserved-5 rotation is mechanical, NOT to pretend line count measures value
+    precisely. The thresholds are intentionally generous and defensible:
+
+      * **3 (substantial / flagship):** >= 200 changed lines OR >= 8 files —
+        a cross-cutting change (e.g. #227 was 1101 additions across 6 files).
+      * **2 (moderate):** >= 40 changed lines OR >= 3 files.
+      * **1 (trivial):** anything smaller — a one-liner, a config bump, a doc
+        typo.
+
+    "Changed lines" is additions + deletions (a large deletion is still work).
+    Negative/garbage inputs are clamped to 0, so the worst case is tier 1 — it
+    never raises and never returns outside ``{1, 2, 3}``.
+    """
+    lines = max(0, additions) + max(0, deletions)
+    files = max(0, changed_files)
+    if lines >= 200 or files >= 8:
+        return 3
+    if lines >= 40 or files >= 3:
+        return 2
+    return 1
+
+
+def _collapse_history(revisions: list[str]) -> "Verdict | None":
+    """Collapse one comment's body revisions to a single durable-credit Verdict.
+
+    *revisions* is ``[current_body, *historical_bodies]`` (see
+    :func:`_pr_comment_histories`). The rule (#229): if ANY revision was a real
+    changes-requested verdict (a ``Request`` + enumerated ``Must-fix:``), the
+    returned Verdict carries ``changes_requested=True`` attributed to that
+    revision's ``Requestor:`` / ``Requestee:`` — **even if the current body was
+    amended clean**. Otherwise the current revision's verdict is returned
+    unchanged. A comment no revision of which parses as a verdict → ``None``.
+
+    ``false_positive`` is always taken from the CURRENT body: a retraction
+    ("withdrawn" / "false-positive") is only ever expressed in the live comment,
+    never recovered from history. Pure — no I/O.
+
+    Backward-compatible by construction: a comment never edited has a
+    single-element *revisions* list, so this returns exactly
+    ``parse_verdicts([body])[0]`` (or ``None``) — a clean no-amend wave is
+    scored identically to the legacy live-comment path.
+    """
+    parsed = [
+        (vs[0] if (vs := parse_verdicts([rev])) else None) for rev in revisions
+    ]
+    current = parsed[0] if parsed else None
+    catch = next((v for v in parsed if v is not None and v.changes_requested), None)
+    if catch is None:
+        return current
+    return Verdict(
+        requestor=catch.requestor,
+        requestee=catch.requestee,
+        verdict=catch.verdict,
+        false_positive=current.false_positive if current is not None else False,
+        changes_requested=True,
+    )
+
+
+def verdicts_from_histories(comment_histories: list[list[str]]) -> list[Verdict]:
+    """History-aware analogue of :func:`parse_verdicts`, one Verdict per comment.
+
+    Maps each comment's revision list through :func:`_collapse_history` and drops
+    the non-verdict comments. The result is the same ``list[Verdict]`` shape
+    :func:`parse_verdicts` returns, so :func:`_account_pr` consumes it unchanged
+    — but a catch that was amended away in the live comment body is preserved
+    here from the edit history. Pure — no I/O.
+
+    NOTE: this is intentionally NOT wired into :func:`parse_verdicts` itself,
+    because ``pr_review_state`` (the merge-gate oracle) depends on
+    ``parse_verdicts`` reading the CURRENT state — an amended-clean Request must
+    parse clean there so the gate clears. The scorer wants the opposite (durable
+    credit), so only the scorer's extraction path uses this function.
+    """
+    out: list[Verdict] = []
+    for revisions in comment_histories:
+        v = _collapse_history(revisions)
+        if v is not None:
+            out.append(v)
+    return out
+
+
 def _pr_ci_is_red(repo: str, number: int) -> bool:
     """True if the PR's latest status rollup carries a failing required check.
 
@@ -642,7 +875,7 @@ def merged_prs(
             "--base",
             base,
             "--json",
-            "number,headRefOid,mergedAt,author",
+            "number,headRefOid,mergedAt,author,additions,deletions,changedFiles",
         ]
         if label:
             list_args += ["--label", label]
@@ -668,6 +901,9 @@ def merged_prs(
                     "headRefOid": sha,
                     "author": (pr.get("author") or {}).get("login"),
                     "commit_author_name": commit_author,
+                    "additions": pr.get("additions"),
+                    "deletions": pr.get("deletions"),
+                    "changedFiles": pr.get("changedFiles"),
                 }
             )
     return out
@@ -738,8 +974,10 @@ def _account_pr(
     author: str,
     repo: str,
     number: int,
-    comment_bodies: list[str],
+    comment_bodies: list[str] | None = None,
+    comment_histories: list[list[str]] | None = None,
     ci_red: bool,
+    difficulty: int = 0,
     review_catches: list[dict] | None = None,
 ) -> None:
     """Fold one merged PR's contribution into *signals* (mutates in place).
@@ -748,17 +986,32 @@ def _account_pr(
     :func:`extract_signals` (live gh-backed) and tests (hand-built PR data), so
     the two never drift.
 
+    Verdicts are derived from ``comment_histories`` when supplied
+    (edit-history-aware, #229 — see :func:`verdicts_from_histories`) so a catch
+    amended away in the live comment body is still credited; otherwise from
+    ``comment_bodies`` via the legacy :func:`parse_verdicts` path. Exactly one of
+    the two should be supplied (histories preferred); an empty/absent pair yields
+    no verdicts.
+
     ``review_catches`` is the full wave-scoped durable ledger (#164,
     :func:`_review_catches_for_wave`); entries are filtered here to this
     ``(repo, number)``. When that filtered set is non-empty it is
     **authoritative** for this PR's changes-requested accounting
     (``must_fix_received`` / ``must_fix_caught`` / ``rework_cycles``) — it
-    supersedes re-deriving those from ``comment_bodies``, so a verdict comment
-    later amended in place (the charter's amendment convention) cannot erase a
-    catch that was durably recorded at issue time. A PR with no ledger entries
-    falls back to the legacy live-comment-parsing path unchanged. False-positive
-    detection is untouched by the ledger — it is always read from the live
-    comment body (a retraction is itself only ever expressed there).
+    supersedes re-deriving those from the comments, so a verdict comment later
+    amended in place (the charter's amendment convention) cannot erase a catch
+    that was durably recorded at issue time. The ledger and the #229 edit-history
+    path are complementary belts-and-braces: the ledger credits a catch recorded
+    at issue time even if the comment is later deleted outright; the edit-history
+    path recovers a catch nobody remembered to record, straight from GitHub. A PR
+    covered by neither falls back to the legacy live-comment-parsing path
+    unchanged. False-positive detection is untouched by the ledger — it is always
+    read from the (current) comment body (a retraction is itself only ever
+    expressed there).
+
+    ``difficulty`` is the PR's coarse difficulty weight (:func:`difficulty_weight`,
+    #229); it accrues to the author's ``difficulty_points`` and feeds only the
+    distribution-discipline reserved-5 tiebreak, never :func:`score_delta`.
     """
 
     def bucket(name: str) -> Signals:
@@ -767,11 +1020,15 @@ def _account_pr(
     author_sig = bucket(author)
     author_sig.prs_merged += 1
     author_sig.authored_prs.append(number)
+    author_sig.difficulty_points += difficulty
 
     if ci_red:
         author_sig.ci_red_merges += 1
 
-    verdicts = parse_verdicts(comment_bodies)
+    if comment_histories is not None:
+        verdicts = verdicts_from_histories(comment_histories)
+    else:
+        verdicts = parse_verdicts(comment_bodies or [])
     catches = [
         c
         for c in (review_catches or [])
@@ -836,15 +1093,24 @@ def extract_signals(
         author = pr.get("commit_author_name") or "(unknown)"
         repo = pr["repo"]
         number = pr["number"]
+        # Prefer the edit-history-aware path (#229): a catch amended away in the
+        # live comment body is recovered from GitHub's comment edit history. On
+        # any history-fetch failure (returns None) fall back to the live comment
+        # bodies — never crash, never lose the legacy behaviour.
+        histories = _pr_comment_histories(repo, number)
+        kwargs: dict = {"comment_histories": histories}
+        if histories is None:
+            kwargs = {"comment_bodies": _pr_comment_bodies(repo, number)}
         _account_pr(
             signals,
             canon,
             author=author,
             repo=repo,
             number=number,
-            comment_bodies=_pr_comment_bodies(repo, number),
             ci_red=_pr_ci_is_red(repo, number),
+            difficulty=difficulty_weight(*_pr_diffstat(pr)),
             review_catches=review_catches,
+            **kwargs,
         )
 
     return signals
@@ -918,11 +1184,17 @@ def apply_distribution_discipline(
     """
 
     def composite(s: Signals) -> int:
-        # Reward output + good reviewing; penalise the negatives. Pure ranking
-        # key, not a trust score.
+        # Reward output + good reviewing + difficulty of the work shipped;
+        # penalise the negatives. Pure ranking key, not a trust score. Adding
+        # ``difficulty_points`` (#229) is what makes the reserved-5 mechanical: a
+        # flagship correctness fix (weight 3) outranks a one-liner (weight 1) at
+        # equal PR count, so the top slot is not a narrative argument. Waves with
+        # no diffstat plumbed (``difficulty_points == 0`` for everyone — e.g. a
+        # hand-built Signals dict) rank exactly as before.
         return (
             s.prs_merged
             + s.must_fix_caught
+            + s.difficulty_points
             - s.must_fix_received
             - 2 * s.ci_red_merges
             - 2 * s.review_false_positives

--- a/framework/tests/test_trust_signals.py
+++ b/framework/tests/test_trust_signals.py
@@ -1230,3 +1230,294 @@ def test_cli_record_catch_appends_to_state_file(tmp_path) -> None:
             "recorded_at": "2026-07-06T00:00:00Z",
         }
     ]
+
+
+# ===========================================================================
+# #229 — trust scorer reads reality: edit-history catch crediting + difficulty
+# weight. The gate oracle (pr_review_state) REQUIRES a reviewer to resolve a
+# blocking Request by editing it in place to Replied; the scorer read that same
+# current state, so an amended catch scored must_fix_caught=0 / must_fix_received
+# =0 (W13: Tariq's real data-loss catch scored mechanically zero). These credit
+# the catch from GitHub's comment edit history instead, and add a coarse per-PR
+# difficulty weight so the reserved-5 rotation is mechanical.
+# ===========================================================================
+
+
+# ----------------------------------------------------------- difficulty_weight
+
+
+def test_difficulty_weight_trivial_is_tier_1() -> None:
+    # A one-line config change / doc typo.
+    assert ts.difficulty_weight(1, 0, 1) == 1
+    assert ts.difficulty_weight(0, 0, 0) == 1
+    assert ts.difficulty_weight(39, 0, 2) == 1  # just under both tier-2 bars
+
+
+def test_difficulty_weight_moderate_is_tier_2() -> None:
+    assert ts.difficulty_weight(40, 0, 1) == 2  # lines bar
+    assert ts.difficulty_weight(0, 0, 3) == 2  # files bar
+    assert ts.difficulty_weight(199, 0, 7) == 2  # just under both tier-3 bars
+
+
+def test_difficulty_weight_flagship_is_tier_3() -> None:
+    assert ts.difficulty_weight(200, 0, 1) == 3  # lines bar
+    assert ts.difficulty_weight(0, 0, 8) == 3  # files bar
+    # #227 (the W13 flagship): 1101 additions across 6 files → tier 3.
+    assert ts.difficulty_weight(1101, 0, 6) == 3
+
+
+def test_difficulty_weight_counts_deletions_and_clamps_garbage() -> None:
+    # A large deletion is still work; negatives clamp to 0 (never < tier 1).
+    assert ts.difficulty_weight(0, 250, 1) == 3
+    assert ts.difficulty_weight(-500, -9, -3) == 1
+
+
+def test_pr_diffstat_reads_record_fail_open() -> None:
+    assert ts._pr_diffstat({"additions": 200, "deletions": 5, "changedFiles": 6}) == (
+        200,
+        5,
+        6,
+    )
+    # Missing / non-int fields degrade to 0, never raise.
+    assert ts._pr_diffstat({}) == (0, 0, 0)
+    assert ts._pr_diffstat({"additions": "x", "deletions": None}) == (0, 0, 0)
+
+
+# ------------------------------------------------- _collapse_history / verdicts
+
+
+def test_collapse_history_credits_amended_away_catch() -> None:
+    """The core #229 case: a blocking Request amended in place to a clean Replied
+    still yields a changes_requested Verdict attributed to the original reviewer."""
+    current = _verdict_body("Tariq.Morales", "Replied", None)  # amended clean
+    original = _verdict_body("Tariq.Morales", "Request", "Data-loss in the amend path.")
+    v = ts._collapse_history([current, original])
+    assert v is not None
+    assert v.changes_requested is True
+    assert v.requestor == "Tariq.Morales"
+    assert v.requestee == "Paloma.Gupta"
+
+
+def test_collapse_history_no_edits_matches_parse_verdicts() -> None:
+    """Backward-compat: a never-edited comment (single revision) collapses to
+    exactly parse_verdicts([body])[0] — a clean no-amend wave is unchanged."""
+    for body in (
+        _verdict_body("Nia.Rossi", "Replied", None),
+        _verdict_body("Tariq.Morales", "Request", "Fix this."),
+    ):
+        collapsed = ts._collapse_history([body])
+        (expected,) = ts.parse_verdicts([body])
+        assert collapsed == expected
+
+
+def test_collapse_history_non_verdict_comment_is_none() -> None:
+    assert ts._collapse_history(["just a plain chat comment, no verdict header"]) is None
+
+
+def test_collapse_history_false_positive_taken_from_current_body() -> None:
+    """A retraction lives only in the live comment — false_positive comes from the
+    CURRENT revision, not resurrected from a historical blocking revision."""
+    current = (
+        "Requestor: Nia.Rossi\nRequestee: Paloma.Gupta\nRequestOrReplied: Replied\n\n"
+        "**Review**\nMust-fix:\n1. Withdrawn — this was a false-positive on my part.\n"
+    )
+    original = _verdict_body("Nia.Rossi", "Request", "Original blocking finding.")
+    v = ts._collapse_history([current, original])
+    assert v is not None
+    assert v.changes_requested is True  # credited from history
+    assert v.false_positive is True  # detected from the current retraction body
+
+
+def test_verdicts_from_histories_drops_non_verdicts_and_keeps_one_per_comment() -> None:
+    histories = [
+        [_verdict_body("Tariq.Morales", "Replied", None),
+         _verdict_body("Tariq.Morales", "Request", "Blocking.")],
+        ["plain non-verdict comment"],
+        [_verdict_body("Nia.Rossi", "Replied", None)],
+    ]
+    vs = ts.verdicts_from_histories(histories)
+    assert len(vs) == 2  # the plain comment is dropped
+    assert vs[0].changes_requested is True
+    assert vs[1].changes_requested is False
+
+
+# --------------------------------------- _account_pr with comment_histories
+
+
+def test_account_pr_credits_amended_catch_from_history(tmp_path) -> None:
+    """The mutation bar for #229: reading histories, an amended-away catch still
+    credits the reviewer (must_fix_caught) and author (must_fix_received).
+
+    Mutation bar: reverting _account_pr to parse the CURRENT bodies only (the
+    W13 bug) makes must_fix_caught == 0 and must_fix_received == 0 → this fails.
+    """
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Paloma Gupta",
+        repo="o/r",
+        number=600,
+        comment_histories=[
+            # Tariq's blocking Request, later amended in place to a clean Replied.
+            [_verdict_body("Tariq.Morales", "Replied", None),
+             _verdict_body("Tariq.Morales", "Request", "Data-loss in amend path.")],
+        ],
+        ci_red=False,
+        difficulty=3,
+    )
+    assert sigs["Tariq Morales"].must_fix_caught == 1  # survived the amendment
+    assert sigs["Paloma Gupta"].must_fix_received == 1
+    assert sigs["Paloma Gupta"].rework_cycles == 1
+    assert sigs["Paloma Gupta"].difficulty_points == 3
+
+
+def test_account_pr_history_clean_wave_scores_no_catch(tmp_path) -> None:
+    """Backward-compat via the history path: a clean review (no revision ever
+    blocking) yields no catch — identical to the legacy live-comment path."""
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Paloma Gupta",
+        repo="o/r",
+        number=601,
+        comment_histories=[[_verdict_body("Tariq.Morales", "Replied", None)]],
+        ci_red=False,
+        difficulty=1,
+    )
+    assert sigs["Paloma Gupta"].must_fix_received == 0
+    assert sigs["Paloma Gupta"].rework_cycles == 0
+    assert "Tariq Morales" not in sigs
+    assert sigs["Paloma Gupta"].difficulty_points == 1
+
+
+def test_account_pr_ledger_still_authoritative_over_history(tmp_path) -> None:
+    """The #164 ledger takes precedence over the #229 history path when present —
+    belts-and-braces, never double-counting."""
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Paloma Gupta",
+        repo="o/r",
+        number=602,
+        # History ALSO shows the catch; the ledger must not add a second one.
+        comment_histories=[
+            [_verdict_body("Tariq.Morales", "Replied", None),
+             _verdict_body("Tariq.Morales", "Request", "Blocking.")],
+        ],
+        ci_red=False,
+        review_catches=[
+            {"repo": "o/r", "pr": 602, "requestor": "Tariq.Morales",
+             "requestee": "Paloma.Gupta"},
+        ],
+    )
+    assert sigs["Tariq Morales"].must_fix_caught == 1  # once, not twice
+    assert sigs["Paloma Gupta"].must_fix_received == 1
+    assert sigs["Paloma Gupta"].rework_cycles == 1
+
+
+# ------------------------------------------- wave-13 re-score (the AC anchor)
+
+
+def test_wave13_rescore_credits_tariq_catch_and_paloma_received(tmp_path) -> None:
+    """Re-scoring W13's flagship PR #227 with the fix credits Tariq's real
+    data-loss catch and Paloma's received must-fix — reconstructed from the real
+    comment edit history (Tariq's Request amended in place to Replied; three
+    other clean reviews never edited). Before #229 both scored zero (finding #1).
+    """
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    # Real #227 history shape: Tariq's blocking comment (id 4904379564) was edited
+    # in place from Request+Must-fix to Replied+Must-fix:None; the other three
+    # comments (two of Nia's, one Tariq follow-up) were clean and never edited.
+    tariq_current = _verdict_body("Tariq.Morales", "Replied", None)
+    tariq_original = _verdict_body(
+        "Tariq.Morales", "Request",
+        "Amend-disposition surgical removal deletes pre-existing user files — "
+        "unrecoverable data loss.",
+    )
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Paloma Gupta",
+        repo="parametrization/2real-team-framework",
+        number=227,
+        comment_histories=[
+            [tariq_current, tariq_original],                       # the catch
+            [_verdict_body("Nia.Rossi", "Replied", None)],         # clean
+            [_verdict_body("Tariq.Morales", "Replied", None)],     # clean follow-up
+            [_verdict_body("Nia.Rossi", "Replied", None)],         # clean re-review
+        ],
+        ci_red=False,
+        difficulty=ts.difficulty_weight(1101, 0, 6),  # the real diffstat → tier 3
+    )
+    assert sigs["Tariq Morales"].must_fix_caught == 1  # was 0 pre-#229
+    assert sigs["Paloma Gupta"].must_fix_received == 1  # was 0 pre-#229
+    assert sigs["Paloma Gupta"].rework_cycles == 1
+    assert sigs["Paloma Gupta"].difficulty_points == 3  # flagship, not a one-liner
+
+
+# ------------------------------------------- difficulty in distribution
+
+
+def test_difficulty_breaks_reserved_5_toward_flagship_author() -> None:
+    """The reserved-5 goes to the flagship author mechanically: two engineers with
+    identical PR counts and clean records, but one shipped a tier-3 flagship and
+    the other a tier-1 one-liner — only the flagship author keeps the proposed 5.
+    """
+    flagship = ts.Signals(prs_merged=1, difficulty_points=3)
+    trivial = ts.Signals(prs_merged=1, difficulty_points=1)
+    out = ts.apply_distribution_discipline(
+        {
+            "Flagship": (ts.MAX_SCORE, flagship),
+            "Trivial": (ts.MAX_SCORE, trivial),
+        }
+    )
+    assert out["Flagship"] == ts.MAX_SCORE  # top composite keeps the 5
+    assert out["Trivial"] == ts.MAX_SCORE - 1  # capped to 4
+
+
+def test_distribution_unchanged_without_difficulty() -> None:
+    """Backward-compat: with difficulty_points == 0 for everyone the composite
+    ranking is exactly as before (difficulty is purely additive from 0)."""
+    a = ts.Signals(prs_merged=2, must_fix_caught=2)
+    b = ts.Signals(prs_merged=1)
+    out = ts.apply_distribution_discipline(
+        {"A": (ts.MAX_SCORE, a), "B": (ts.MAX_SCORE, b)}
+    )
+    assert out["A"] == ts.MAX_SCORE
+    assert out["B"] == ts.MAX_SCORE - 1
+
+
+# ------------------------------------------- _pr_comment_histories (I/O, mocked)
+
+
+def test_pr_comment_histories_parses_graphql(monkeypatch) -> None:
+    canned = json.dumps(
+        {"data": {"repository": {"pullRequest": {"comments": {"nodes": [
+            {"body": "CURRENT",
+             "userContentEdits": {"nodes": [{"diff": "NEWEST"}, {"diff": "ORIGINAL"}]}},
+            {"body": "CLEAN", "userContentEdits": {"nodes": []}},
+        ]}}}}}
+    )
+    monkeypatch.setattr(ts, "_run_gh", lambda args: canned)
+    got = ts._pr_comment_histories("o/r", 700)
+    assert got == [["CURRENT", "NEWEST", "ORIGINAL"], ["CLEAN"]]
+
+
+def test_pr_comment_histories_fail_open_on_error(monkeypatch) -> None:
+    def boom(args):
+        raise ts.subprocess.CalledProcessError(1, ["gh"])
+
+    monkeypatch.setattr(ts, "_run_gh", boom)
+    # Fail-open sentinel is None (distinct from [] = a PR with zero comments).
+    assert ts._pr_comment_histories("o/r", 701) is None
+
+
+def test_pr_comment_histories_bad_repo_is_none() -> None:
+    assert ts._pr_comment_histories("no-slash-repo", 702) is None


### PR DESCRIPTION
## Summary
Make `trust_signals.py` score the review cycle from **durable evidence**, not the mutable current comment state. W13 exposed that the merge-gate oracle (`pr_review_state`) REQUIRES a reviewer to resolve a blocking `Request` by editing it **in place** to `Replied`/`Must-fix: None` — but the scorer read that same current state, so an amended-away catch scored `must_fix_caught=0` (reviewer) and `must_fix_received=0` (author). The wave's single most valuable review — Tariq's real data-loss catch on flagship #227 — scored mechanically **zero**.

Two changes, both in `framework/assets/lib/trust_signals.py` + its tests (file-disjoint from S2/S3):

### 1. Edit-history catch crediting (design option (a), complementary to the #164 issue-time ledger)
- `_pr_comment_histories(repo, number)` fetches, per comment, its current body **plus every prior revision** via GitHub's comment edit API (GraphQL `userContentEdits.diff` — the full body at each revision, not a unified diff). **FAIL-OPEN:** any error returns a `None` sentinel and extraction falls back to live comment bodies; the scorer never crashes and never needs live GitHub in tests.
- `_collapse_history` / `verdicts_from_histories` collapse each comment to one `Verdict` that credits a changes-requested catch if **any** revision was blocking, attributed to that revision's `Requestor:` — so an amended-away `Request` still counts. Deliberately **NOT** wired into `parse_verdicts` (the oracle depends on that reading current state so an amended-clean Request clears the gate); only the scorer's extraction path uses it.
- Backward-compatible by construction: a never-edited comment (single revision) collapses to exactly `parse_verdicts([body])[0]`, so a clean no-amend wave scores unchanged.

### 2. Difficulty/impact weight (makes reserved-5 rotation mechanical)
- `difficulty_weight(additions, deletions, changed_files)` → coarse per-PR tier **1–3** from diff magnitude (`>=200` lines or `>=8` files = 3; `>=40` lines or `>=3` files = 2; else 1). Summed per engineer into a new `difficulty_points` signal, fed into the distribution-discipline composite so a flagship correctness fix outranks a one-liner **without a narrative argument**. Feeds ONLY the reserved-5 tiebreak, never `score_delta`, so a clean no-diffstat wave scores exactly as before (`difficulty_points` defaults to 0). Diffstat travels on the existing `merged_prs` pr-list json — no extra network call.

## Acceptance
- [x] **Credit resolved catches from comment edit-history** — amended-away `Request`/`Must-fix` still counts `must_fix_caught` + `must_fix_received`; sourced from GitHub's comment edit API; fail-open (`None` sentinel → live-body fallback, never crashes).
- [x] **Difficulty/impact weight** — coarse 1–3 tier from diff size; documented rationale; feeds reserved-5 tiebreak.
- [x] **Re-scoring W13 credits Tariq's S1 catch + Paloma's received must-fix** — verified against the **real live #227 edit history** (see below).
- [x] **Backward-compatible** — 72 pre-existing tests unchanged; `score` stays pure/total + fail-open; difficulty is purely additive from 0.
- [x] **Mutation-proved; all three `--check` gates exit 0; dual-deploy (#116)**.

## Wave-13 re-score check (real #227 history, live)
```
comments fetched: 4   revisions per comment: [3, 1, 1, 1]
changes_requested BEFORE #229 (current state only): 0   <- the W13 bug
changes_requested AFTER  #229 (edit-history aware):  1   <- Tariq.Morales
re-scored #227:  Tariq.Morales caught=1  |  Paloma received=1 rework=1 difficulty=3(flagship)
```

## Mutation evidence (4 mutations, each kills a targeted test)
1. `_collapse_history` ignores history (return current only) → `test_collapse_history_credits_amended_away_catch`, `test_account_pr_credits_amended_catch_from_history`, `test_wave13_rescore_*` FAIL.
2. `difficulty_weight` tier-3 threshold `200 → 201` → `test_difficulty_weight_flagship_is_tier_3` FAIL.
3. composite drops `difficulty_points` → `test_difficulty_breaks_reserved_5_toward_flagship_author` FAIL.
4. `_account_pr` accrues no difficulty → three difficulty-accrual tests FAIL.

## `--check` gates
- `manifest.py --check` → exit **0** (golden manifest in sync)
- `charter_drift.py --check` → exit **0**
- `reinstall.py --check` (#116 dual-deploy) → exit **0** (`.claude/` in sync with canonical; lib deploys to `.claude/lib/` on targets via the install set — this framework-source repo runs the canonical `framework/assets/lib` copy directly, so no runtime copy to drift)

## Test suite
`765 passed` full suite (746 baseline + 19 new); `91 passed` on `test_trust_signals.py`; `ruff check framework/` clean.

Reviewers: **Paloma Gupta, Tariq Morales**
