### PR TITLE
S2: close pending/no-branch-protection --auto slip in validate_pr_ci_status + node(20) quarantine (closes #230)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,4 +80,18 @@ jobs:
 
       - name: Test
         working-directory: node
-        run: npm test -- --run
+        # QUARANTINE (#230): the node suite is nondeterministic. `generateName`
+        # in src/bootstrap.ts dedupes candidate names against a `used` set built
+        # from ROLE-PREFIXED roster filenames ("senior_engineer_jane_doe" ->
+        # "senior engineer jane doe"), never against bare "First Last" names, so
+        # it never actually rejects a real duplicate. Unseeded Math.random() name
+        # generation therefore collides at random, surfacing as a spurious red on
+        # whichever matrix shard happens to draw the collision (W13: "node (20)";
+        # the shard is incidental, not node-20-specific). `--retry=2` re-runs a
+        # failed test up to twice: a genuine, reproducible break still fails all
+        # attempts and goes red (node coverage is preserved and still required),
+        # while a one-off collision self-heals instead of manufacturing a false
+        # ci-red that slips a merge. The real fix — seed the RNG / dedupe on bare
+        # names, then REMOVE this --retry — is tracked as #234 (product change in
+        # node/src, out of this QA story's lane).
+        run: npm test -- --run --retry=2

--- a/framework/assets/hooks/validate_pr_ci_status.py
+++ b/framework/assets/hooks/validate_pr_ci_status.py
@@ -3,10 +3,38 @@
 
 Queries `gh pr view --json statusCheckRollup` and blocks merge when any check
 has failed, been cancelled, timed out, or requires action. Pending checks block
-unless the user passes `--auto` (GitHub merges on green; warn-but-allow).
+unless the user passes `--auto` AND the base branch genuinely enforces those
+checks via branch protection (see `--auto` semantics below).
 
 The whole gate is active only when `ci.merge_requires_green` is true (default).
 If a project does not require green CI before merge, `check()` returns None.
+
+`--auto` only warn-allows pending when GitHub will actually hold the merge (#230)
+=============================================================================
+
+`gh pr merge --auto` asks GitHub to complete the merge once the PR's *branch-
+protection required status checks* pass. If the base branch has NO required
+status checks configured (an unprotected branch — this repo, and most fresh
+installs), GitHub has nothing to wait for and merges IMMEDIATELY. A check that
+is still pending at that moment then finishes — possibly RED — *after* the merge
+already landed. That is exactly how Wave-13 merged S2 #226 with a red `node (20)`
+check: `--auto` was treated as "GitHub will hold for green", but with no branch
+protection there was nothing to hold it.
+
+So the pending + `--auto` warn-allow is now conditional on real enforcement:
+
+  - base branch enforces required checks (non-empty required-status-checks set)
+        → GitHub genuinely holds the merge until green → warn-allow (as before).
+  - base branch does NOT enforce them (unprotected / empty required set; the
+        endpoint 404s) → `--auto` would merge NOW, before CI finishes → BLOCK.
+        Pending != green when nothing will hold the merge.
+  - enforcement undeterminable (no base ref, or a transport/permission error on
+        the protection query) → fail-open warn-allow (never manufacture a block
+        on an inability to read), with a caveat surfaced in the message.
+
+A pending merge WITHOUT `--auto` blocks unconditionally, as before. A check that
+is already RED at merge time blocks regardless of `--auto`. The audited `--admin`
++ ADMIN_MERGE_EXCEPTION path remains the sanctioned override for all of the above.
 
 Empty rollup
 ============
@@ -205,6 +233,65 @@ def fetch_pr_base_ref(pr_number: str | None, repo: str | None) -> str | None:
         return json.loads(result.stdout).get("baseRefName") or None
     except (subprocess.TimeoutExpired, json.JSONDecodeError, FileNotFoundError):
         return None
+
+
+def base_branch_enforces_required_checks(repo: str | None, base: str | None) -> bool | None:
+    """Does *base* enforce required status checks via GitHub branch protection?
+
+    Answers the one question the `--auto`/pending path needs: will GitHub HOLD an
+    `--auto` merge until CI goes green? It does so only when the base branch has a
+    non-empty required-status-checks set.
+
+    Returns:
+      True  — the base has a non-empty required-status-checks set. GitHub holds an
+              `--auto` merge until those checks pass, so a still-pending check is
+              safe to warn-allow (GitHub really will wait for green).
+      False — the base has NO required status checks: an unprotected branch, or a
+              protected branch with an empty required set (both 404 this
+              endpoint). GitHub will NOT hold an `--auto` merge for CI, so a
+              pending check can fail AFTER the merge already landed (the W13
+              `node (20)` slip, #230).
+      None  — undeterminable: no repo/base, or a transport/permission error on the
+              query. The caller preserves the fail-open posture and warn-allows,
+              never manufacturing a block on an inability to read.
+
+    A 404 / "branch not protected" is a DEFINITIVE "no required checks configured"
+    (→ False), deliberately kept distinct from a transport error (→ None): the
+    server answering "there is no required-checks config here" is not the same as
+    being unable to ask at all. Conflating them would either wedge merges on a
+    flaky API call (if a 404 fell through to a block) or re-open the slip on every
+    unprotected repo (if a real error were read as "not enforced" and allowed).
+    """
+    if not repo or not base:
+        return None
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{repo}/branches/{base}/protection/required_status_checks"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None
+    if result.returncode != 0:
+        blob = f"{result.stdout}\n{result.stderr}".lower()
+        # A 404 / "branch not protected" / "not found" is a definitive "no
+        # required checks configured" → NOT enforced. Any other failure
+        # (permission, transport, rate-limit) is undeterminable → fail-open None.
+        if "not protected" in blob or "404" in blob or "not found" in blob:
+            return False
+        return None
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    # `contexts` is the legacy list; `checks` the current app-aware form. Either
+    # being non-empty means at least one required status check is enforced.
+    contexts = data.get("contexts") or []
+    checks = data.get("checks") or []
+    return bool(contexts or checks)
 
 
 def covering_pr_workflow_exists(repo: str | None, base: str | None) -> bool | None:
@@ -448,21 +535,71 @@ def check(input_data: dict) -> dict | None:
         return result
 
     if pending:
+        # A pending check is only safe to warn-allow under `--auto` if GitHub will
+        # actually HOLD the merge until it goes green — which it does only when the
+        # base branch enforces that check via branch-protection required status
+        # checks. With NO branch protection (this repo, most fresh installs),
+        # `gh pr merge --auto` merges IMMEDIATELY, so a still-pending check that
+        # later fails lands AFTER the merge — the W13 `node (20)` slip (#230). So
+        # `--auto` warn-allows pending ONLY when protection genuinely enforces it.
         if "--auto" in command:
-            return {
-                "decision": "allow",
-                "systemMessage": (
-                    f"WARNING: PR {pr_display} has {len(pending)} pending CI check(s); "
-                    "`--auto` will let GitHub merge when they finish.\n"
-                    f"{format_check_list(pending)}"
+            base_ref = fetch_pr_base_ref(pr_number, repo)
+            enforces = base_branch_enforces_required_checks(repo, base_ref)
+            if enforces is None:
+                # Undeterminable (no base ref, or a transport/permission error on
+                # the protection query). Preserve the fail-open posture: warn-allow
+                # rather than manufacture a block on an inability to read — but
+                # surface that GitHub may NOT hold the merge if the base is in fact
+                # unprotected.
+                return {
+                    "decision": "allow",
+                    "systemMessage": (
+                        f"WARNING: PR {pr_display} has {len(pending)} pending CI check(s) and "
+                        "`--auto` was passed, but branch protection on the base could not be "
+                        "determined (fail-open allow). If the base does NOT enforce these checks, "
+                        "`--auto` merges immediately and a check that later fails will have already "
+                        "landed — verify branch protection or wait for green.\n"
+                        f"{format_check_list(pending)}"
+                    ),
+                }
+            if enforces:
+                return {
+                    "decision": "allow",
+                    "systemMessage": (
+                        f"WARNING: PR {pr_display} has {len(pending)} pending CI check(s); "
+                        "the base branch enforces required checks via branch protection, so "
+                        "`--auto` will let GitHub merge only once they finish green.\n"
+                        f"{format_check_list(pending)}"
+                    ),
+                }
+            # enforces is False: the base has NO required-status-check enforcement.
+            # `--auto` would merge NOW, before these checks finish — pending != green
+            # when nothing will hold the merge. BLOCK (the W13 slip fix, #230).
+            result = {
+                "decision": "block",
+                "reason": (
+                    f"BLOCKED: PR {pr_display} has {len(pending)} pending CI check(s) and "
+                    "`--auto` was passed, but the base branch has NO branch-protection required "
+                    "status checks — GitHub would merge IMMEDIATELY without waiting for CI, so a "
+                    "check that later fails would land after the merge (the exact W13 `node (20)` "
+                    "slip). `--auto` cannot substitute for green CI when nothing enforces it.\n"
+                    f"Pending checks:\n{format_check_list(pending)}\n\n"
+                    "Wait for CI to finish and merge on green, configure branch protection to make "
+                    "these checks required, or pass `--admin` with an ADMIN_MERGE_EXCEPTION for an "
+                    "audited emergency override."
                 ),
             }
+            log_pretooluse_block(
+                "validate_pr_ci_status", command, result["reason"], input_data=input_data
+            )
+            return result
         result = {
             "decision": "block",
             "reason": (
                 f"BLOCKED: PR {pr_display} has {len(pending)} pending CI check(s). "
-                "Wait for CI to finish, pass `--auto` to let GitHub merge on green, "
-                "or pass `--admin` for emergency overrides.\n"
+                "Wait for CI to finish, pass `--auto` to let GitHub merge on green (honored only "
+                "when branch protection enforces the checks), or pass `--admin` for emergency "
+                "overrides.\n"
                 f"Pending checks:\n{format_check_list(pending)}"
             ),
         }

--- a/framework/tests/test_validate_pr_ci_status.py
+++ b/framework/tests/test_validate_pr_ci_status.py
@@ -274,6 +274,35 @@ def test_rollup_unreadable_fail_open_allows(monkeypatch) -> None:
     assert result["decision"] == "allow"
 
 
+def test_admin_without_exception_blocks(monkeypatch) -> None:
+    # The audited `--admin` path is preserved by the #230 fix: with no configured
+    # exception (and none in the env), `--admin` fails safe -> block. Reverting the
+    # validate_admin_exception guard to an unconditional allow flips this to None.
+    _cfg(monkeypatch)  # policy.admin_merge_exceptions absent -> any --admin blocks
+    monkeypatch.delenv("ADMIN_MERGE_EXCEPTION", raising=False)
+    # fetch_checks must never even be consulted on the --admin path; make it explode
+    # if it is, so this test also pins that --admin is evaluated before the rollup.
+    monkeypatch.setattr(
+        hook, "fetch_checks", lambda pr, repo: (_ for _ in ()).throw(AssertionError("fetched"))
+    )
+    result = hook.check(_bash(_MERGE + " --admin"))
+    assert result is not None
+    assert result["decision"] == "block"
+    assert "--admin" in result["reason"]
+
+
+def test_admin_with_valid_exception_allows(monkeypatch) -> None:
+    # A recognized exception class + non-empty rationale authorizes the audited
+    # override -> allow (None), and the authorization is logged for the audit trail.
+    _cfg(monkeypatch, {"policy.admin_merge_exceptions": {"hotfix": "prod incident"}})
+    calls: list = []
+    monkeypatch.setattr(hook, "log_pretooluse_block", lambda *a, **k: calls.append((a, k)))
+    data = _bash(_MERGE + " --admin")
+    data["env"] = {"ADMIN_MERGE_EXCEPTION": "hotfix: page P1 fix"}
+    assert hook.check(data) is None
+    assert calls, "expected the authorized --admin use to be logged for audit"
+
+
 def test_pending_auto_no_protection_is_logged(monkeypatch) -> None:
     # The slip-fix block is audited like every other block.
     calls: list = []

--- a/framework/tests/test_validate_pr_ci_status.py
+++ b/framework/tests/test_validate_pr_ci_status.py
@@ -1,0 +1,293 @@
+"""Tests for validate_pr_ci_status — the CI-green `gh pr merge` gate.
+
+Focus of #230 (S2, Wave 9): close the pending + `--auto` slip. `gh pr merge
+--auto` only *holds* a merge until CI goes green when the base branch enforces
+those checks via branch protection. On an unprotected repo (this repo, most
+fresh installs) `--auto` merges IMMEDIATELY, so a still-pending check that later
+fails lands AFTER the merge — the W13 `node (20)` slip. This suite pins the
+corrected semantics AND locks the pre-existing fail-open / already-red / disabled
+behaviors so the fix can't quietly regress them.
+
+Load-bearing (revert->fail) coverage:
+  - test_pending_auto_no_branch_protection_blocks is the headline: reverting the
+    fix (making pending + `--auto` warn-allow unconditionally, as before) turns
+    this BLOCK back into an allow → it fails.
+  - test_pending_auto_with_branch_protection_allows /
+    test_pending_auto_protection_undeterminable_allows pin the two allow arms;
+    hard-blocking every `--auto` pending (ignoring enforcement) fails these.
+  - test_pending_no_auto_blocks / test_failing_blocks_even_with_auto /
+    test_ready_allows / test_rollup_unreadable_fail_open_allows lock the
+    unchanged paths (a red check still blocks even under `--auto`; a fetch error
+    still fail-opens).
+  - The base_branch_enforces_required_checks unit tests pin the tri-state:
+    non-empty required set → True, 404/"not protected" → False (definitive, NOT
+    None), other error → None (fail-open).
+
+No real `gh`, no network: the fetchers and `subprocess.run` are monkeypatched.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_FRAMEWORK_ROOT / "assets" / "hooks"))
+sys.path.insert(0, str(_FRAMEWORK_ROOT / "assets" / "lib"))
+
+import validate_pr_ci_status as hook  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Harness
+# --------------------------------------------------------------------------- #
+
+# Explicit --repo + literal PR so extract_repo / extract_pr_number never shell out.
+_MERGE = "gh pr merge 42 --repo acme/widget --squash"
+_MERGE_AUTO = "gh pr merge 42 --repo acme/widget --auto --squash"
+
+_FAIL_CHECK = {"name": "node (20)", "conclusion": "FAILURE", "status": "COMPLETED"}
+_PENDING_CHECK = {"name": "node (20)", "conclusion": None, "status": "IN_PROGRESS"}
+_PASS_CHECK = {"name": "python (3.10)", "conclusion": "SUCCESS", "status": "COMPLETED"}
+
+
+def _bash(command: str) -> dict:
+    return {"tool_name": "Bash", "tool_input": {"command": command}}
+
+
+class _StubCfg:
+    def __init__(self, vals: dict | None = None) -> None:
+        self._vals = vals or {}
+
+    def get(self, key, default=None):
+        return self._vals.get(key, default)
+
+
+def _cfg(monkeypatch, vals: dict | None = None) -> None:
+    """Point hook.config at a stub. Default: gate ON (merge_requires_green true)."""
+    base = {"ci.merge_requires_green": True}
+    if vals:
+        base.update(vals)
+    monkeypatch.setattr(hook, "config", lambda input_data=None, **kw: _StubCfg(base))
+
+
+def _rollup(monkeypatch, checks) -> None:
+    monkeypatch.setattr(hook, "fetch_checks", lambda pr, repo: checks)
+
+
+def _base(monkeypatch, ref="main") -> None:
+    monkeypatch.setattr(hook, "fetch_pr_base_ref", lambda pr, repo: ref)
+
+
+def _enforces(monkeypatch, value) -> None:
+    monkeypatch.setattr(
+        hook, "base_branch_enforces_required_checks", lambda repo, base: value
+    )
+
+
+class _FakeProc:
+    def __init__(self, returncode=0, stdout="", stderr="") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+# --------------------------------------------------------------------------- #
+# Module posture
+# --------------------------------------------------------------------------- #
+
+
+def test_declares_fail_open() -> None:
+    assert hook.FAIL_OPEN is True
+
+
+def test_not_a_merge_command_allows(monkeypatch) -> None:
+    _cfg(monkeypatch)
+    assert hook.check(_bash("gh pr view 42 --repo acme/widget")) is None
+
+
+def test_gate_disabled_allows(monkeypatch) -> None:
+    # merge_requires_green=false => whole gate is a no-op, even with a red check.
+    _cfg(monkeypatch, {"ci.merge_requires_green": False})
+    _rollup(monkeypatch, [_FAIL_CHECK])
+    assert hook.check(_bash(_MERGE)) is None
+
+
+# --------------------------------------------------------------------------- #
+# base_branch_enforces_required_checks — the tri-state
+# --------------------------------------------------------------------------- #
+
+
+def test_enforces_true_on_nonempty_contexts(monkeypatch) -> None:
+    monkeypatch.setattr(
+        hook.subprocess, "run",
+        lambda *a, **k: _FakeProc(0, '{"contexts": ["node (20)"], "checks": []}'),
+    )
+    assert hook.base_branch_enforces_required_checks("acme/widget", "main") is True
+
+
+def test_enforces_true_on_nonempty_checks(monkeypatch) -> None:
+    monkeypatch.setattr(
+        hook.subprocess, "run",
+        lambda *a, **k: _FakeProc(0, '{"contexts": [], "checks": [{"context": "ci"}]}'),
+    )
+    assert hook.base_branch_enforces_required_checks("acme/widget", "main") is True
+
+
+def test_enforces_false_on_empty_required_set(monkeypatch) -> None:
+    monkeypatch.setattr(
+        hook.subprocess, "run",
+        lambda *a, **k: _FakeProc(0, '{"contexts": [], "checks": []}'),
+    )
+    assert hook.base_branch_enforces_required_checks("acme/widget", "main") is False
+
+
+def test_enforces_false_on_branch_not_protected_404(monkeypatch) -> None:
+    # A 404 / "Branch not protected" is DEFINITIVE no-enforcement -> False, NOT None.
+    monkeypatch.setattr(
+        hook.subprocess, "run",
+        lambda *a, **k: _FakeProc(1, "", "gh: Branch not protected (HTTP 404)"),
+    )
+    assert hook.base_branch_enforces_required_checks("acme/widget", "main") is False
+
+
+def test_enforces_none_on_other_error(monkeypatch) -> None:
+    # A permission/transport error is undeterminable -> None (fail-open), NOT False.
+    monkeypatch.setattr(
+        hook.subprocess, "run",
+        lambda *a, **k: _FakeProc(1, "", "gh: Bad credentials (HTTP 401)"),
+    )
+    assert hook.base_branch_enforces_required_checks("acme/widget", "main") is None
+
+
+def test_enforces_none_on_timeout(monkeypatch) -> None:
+    def _boom(*a, **k):
+        raise hook.subprocess.TimeoutExpired(cmd="gh", timeout=15)
+
+    monkeypatch.setattr(hook.subprocess, "run", _boom)
+    assert hook.base_branch_enforces_required_checks("acme/widget", "main") is None
+
+
+def test_enforces_none_on_bad_json(monkeypatch) -> None:
+    monkeypatch.setattr(hook.subprocess, "run", lambda *a, **k: _FakeProc(0, "not json"))
+    assert hook.base_branch_enforces_required_checks("acme/widget", "main") is None
+
+
+def test_enforces_none_without_repo_or_base() -> None:
+    assert hook.base_branch_enforces_required_checks(None, "main") is None
+    assert hook.base_branch_enforces_required_checks("acme/widget", None) is None
+
+
+# --------------------------------------------------------------------------- #
+# check() — the pending + --auto slip fix (#230)
+# --------------------------------------------------------------------------- #
+
+
+def test_pending_auto_no_branch_protection_blocks(monkeypatch) -> None:
+    """HEADLINE (W13 slip fix): pending + --auto + unprotected base -> BLOCK.
+
+    Reverting the fix (unconditional warn-allow of pending under --auto) makes
+    this an allow and fails the test.
+    """
+    _cfg(monkeypatch)
+    _rollup(monkeypatch, [_PASS_CHECK, _PENDING_CHECK])
+    _base(monkeypatch, "main")
+    _enforces(monkeypatch, False)  # unprotected base — nothing holds the merge
+    result = hook.check(_bash(_MERGE_AUTO))
+    assert result is not None
+    assert result["decision"] == "block"
+    assert "no branch-protection required" in result["reason"].lower()
+
+
+def test_pending_auto_with_branch_protection_allows(monkeypatch) -> None:
+    _cfg(monkeypatch)
+    _rollup(monkeypatch, [_PASS_CHECK, _PENDING_CHECK])
+    _base(monkeypatch, "main")
+    _enforces(monkeypatch, True)  # base enforces -> GitHub will hold for green
+    result = hook.check(_bash(_MERGE_AUTO))
+    assert result is not None
+    assert result["decision"] == "allow"
+    assert "systemMessage" in result
+
+
+def test_pending_auto_protection_undeterminable_allows(monkeypatch) -> None:
+    # Fail-open: can't read protection -> warn-allow, never a manufactured block.
+    _cfg(monkeypatch)
+    _rollup(monkeypatch, [_PENDING_CHECK])
+    _base(monkeypatch, "main")
+    _enforces(monkeypatch, None)
+    result = hook.check(_bash(_MERGE_AUTO))
+    assert result is not None
+    assert result["decision"] == "allow"
+
+
+def test_pending_no_auto_blocks(monkeypatch) -> None:
+    # Unchanged: pending WITHOUT --auto blocks unconditionally.
+    _cfg(monkeypatch)
+    _rollup(monkeypatch, [_PENDING_CHECK])
+    result = hook.check(_bash(_MERGE))
+    assert result is not None
+    assert result["decision"] == "block"
+
+
+# --------------------------------------------------------------------------- #
+# check() — unchanged paths that must stay intact
+# --------------------------------------------------------------------------- #
+
+
+def test_failing_blocks(monkeypatch) -> None:
+    _cfg(monkeypatch)
+    _rollup(monkeypatch, [_PASS_CHECK, _FAIL_CHECK])
+    result = hook.check(_bash(_MERGE))
+    assert result is not None
+    assert result["decision"] == "block"
+    assert "failing" in result["reason"].lower()
+
+
+def test_failing_blocks_even_with_auto(monkeypatch) -> None:
+    # A check already RED at merge time blocks regardless of --auto (the fix does
+    # NOT loosen this: --auto only ever affected the pending path).
+    _cfg(monkeypatch)
+    _rollup(monkeypatch, [_FAIL_CHECK])
+    # If check() consulted enforcement here it would be a bug; make it explode.
+    _enforces(monkeypatch, None)
+    result = hook.check(_bash(_MERGE_AUTO))
+    assert result is not None
+    assert result["decision"] == "block"
+    assert "failing" in result["reason"].lower()
+
+
+def test_ready_allows(monkeypatch) -> None:
+    _cfg(monkeypatch)
+    _rollup(monkeypatch, [_PASS_CHECK])
+    assert hook.check(_bash(_MERGE)) is None
+
+
+def test_rollup_unreadable_fail_open_allows(monkeypatch) -> None:
+    # fetch_checks None (transport error) -> warn-allow, never a block (fail-open).
+    _cfg(monkeypatch)
+    _rollup(monkeypatch, None)
+    result = hook.check(_bash(_MERGE))
+    assert result is not None
+    assert result["decision"] == "allow"
+
+
+def test_pending_auto_no_protection_is_logged(monkeypatch) -> None:
+    # The slip-fix block is audited like every other block.
+    calls: list = []
+    monkeypatch.setattr(
+        hook, "log_pretooluse_block",
+        lambda *a, **k: calls.append((a, k)),
+    )
+    _cfg(monkeypatch)
+    _rollup(monkeypatch, [_PENDING_CHECK])
+    _base(monkeypatch, "main")
+    _enforces(monkeypatch, False)
+    hook.check(_bash(_MERGE_AUTO))
+    assert calls, "expected the pending/--auto/no-protection block to be logged"
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

**Corrected target (see below):** the merge gate DID already check CI-green — `validate_pr_ci_status.py` blocks a `gh pr merge` on an already-red required check. Issue #230's premise ("the merge gate checks the review oracle but NOT CI-green") was inaccurate; the real W13 slip was a narrower hole in that existing gate, so this PR fixes it there rather than duplicating CI logic into `validate_pr_review.py` (reconcile-don't-duplicate; approved by the lead — Option A).

- **The real W13 slip:** `gh pr merge --auto` only *holds* a merge until CI goes green when the base branch enforces those checks via **branch protection**. This repo (and most fresh installs) has **no branch protection** (verified: `main` + wave branches return "Branch not protected"), so `--auto` merges IMMEDIATELY and a still-pending check that later fails lands *after* the merge — exactly how W13 merged #226 with a red `node (20)`.
- **Fix:** new helper `base_branch_enforces_required_checks(repo, base)` queries `repos/{repo}/branches/{base}/protection/required_status_checks`. Pending + `--auto` now warn-allows **only** when enforcement is confirmed; **BLOCKS** when the base has no required-check enforcement; fail-open warn-allows when undeterminable. Non-`--auto` pending still blocks; an already-red check still blocks; the audited `--admin`/`ADMIN_MERGE_EXCEPTION` override is unchanged.
- **Node flake quarantine:** `ci.yml` runs the node job with `vitest --run --retry=2`. Root cause (a real product bug) filed as **#234**: `generateName` in `node/src/bootstrap.ts` dedupes against role-prefixed roster filenames, never bare `First Last`, so unseeded `Math.random()` name-gen collides at random and surfaces as a spurious red on whichever matrix shard drew it ("node (20)" is incidental). Retry keeps node coverage required (a reproducible break still fails all attempts) while a one-off collision self-heals.
- **First real test coverage** for `validate_pr_ci_status.py` (there was none in the active suite): 20 tests, mutation-proved.

## Acceptance (#230)

- [x] Merge gate blocks a `gh pr merge` when a required CI check is failing — a red check can no longer slip through on a green review verdict. (Already true for already-red; this PR additionally closes the `--auto`/pending-with-no-enforcement hole that actually caused W13.)
- [x] Fail-open preserved: inability to READ status never manufactures a false block. Rollup-fetch error → warn-allow; branch-protection query error → `None` → warn-allow. Block only on a *confirmed* red / a *confirmed* unenforced pending `--auto`.
- [x] `node (20)` flake investigated + quarantined (`vitest --retry=2` in `ci.yml`) with root cause documented; real fix tracked as #234.
- [x] Reproduced W8's slip both directions (below).
- [x] Mutation-proved; all three `--check` gates exit 0; dual-deploy for the hook asset (hooks are wired-in-place — canonical edit *is* the live version; `reinstall --check` clean).

## Both-directions demo (real `check()`, #226's actual rollup)

Driven through the real `validate_pr_ci_status.check()` (real classify logic); only the two network reads stubbed:

```
W13 #226 real rollup (node(20)=FAILURE) + gh pr merge --auto   -> BLOCK  (1 failing CI check)
all checks green + gh pr merge                                 -> ALLOW  (merge proceeds)
pending + --auto + UNPROTECTED base                            -> BLOCK  (would merge-now-then-fail; the fix)
pending + --auto + PROTECTED base                              -> ALLOW  (GitHub holds for green)
pending + --auto + protection UNREADABLE                       -> ALLOW  (fail-open + caveat)
```

## Fail-open evidence

- `fetch_checks` None (rollup transport error) → `decision=allow` (warn), never block.
- `base_branch_enforces_required_checks` tri-state: non-empty required set → `True`; 404/"not protected"/empty → `False` (definitive); any other error / timeout / bad-JSON / no-base → `None` (fail-open). Unit-tested for every arm.
- Mutation-proof: reverting the fix to the old unconditional `--auto` warn-allow fails the two headline block tests; flipping the 404 branch `False`→`None` fails the tri-state test.

## `--check` results

```
reinstall --check      exit=0
manifest --check       exit=0
charter_drift --check  exit=0
ruff check framework/  All checks passed!
framework suite        766 passed (20 new)
```

## Note on worktree

This branch was authored in a fresh isolated worktree after the initially-assigned shared `nia-review-s2` worktree was concurrently thrashed by other sessions (a branch checkout wiped my uncommitted work mid-task). Reported to the lead separately.

## Related Issues

Closes #230
Follow-up filed: #234 (node RNG/dedupe real fix — remove the `--retry` quarantine once landed)

## Review Checklist
- [ ] Reviewed by another team member
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)

Reviewers: Ibrahim El-Amin, Nia Rossi
