### PR TITLE
fix(install): reconcile config module lists on amend (#162)

### DIFF
--- a/framework/install/bootstrap.py
+++ b/framework/install/bootstrap.py
@@ -347,10 +347,66 @@ def install_assets(target_claude: Path, *, force: bool, dry_run: bool) -> dict[s
     return report
 
 
+#: Framework hook module-lists the amend/upgrade write reconciles onto the shipped
+#: canonical set (drop stale, converge — a RECONCILE, not a union). ``pre_push_commands``
+#: is deliberately EXCLUDED: it carries user-authored push checks, not framework modules,
+#: so an amend preserves it verbatim. Mirrors the lists the harness oracle
+#: (``m_config_module_lists_complete``) pins: pre_bash ⊇ required, agent == [],
+#: stop == ["session_handoff"].
+_RECONCILED_HOOK_LISTS = ("pre_bash", "post_bash", "post_file", "session_start", "agent", "stop")
+
+
+def reconcile_module_lists(existing: dict, canonical: dict) -> tuple[dict, bool]:
+    """Converge an existing runtime config's framework hook module-lists onto the
+    shipped ``canonical`` set — dropping stale/extra entries and restoring the
+    canonical order — WITHOUT disturbing any other user field.
+
+    This is the #162/#238 amend fix: a re-install over a *diverged* live config must
+    RECONCILE (not union) its ``hooks.pre_bash`` / ``hooks.agent`` / ``hooks.stop``
+    (etc.) so stale entries are removed instead of accumulated. Idempotent — a config
+    already at the canonical set reports no change. Never raises on a partial config:
+    a missing/malformed ``hooks`` block is rebuilt from the canonical lists, and any
+    hook key the canonical set does not carry is left untouched.
+
+    Returns ``(reconciled_config, changed)``.
+    """
+    canon_hooks = canonical.get("hooks") if isinstance(canonical, dict) else None
+    if not isinstance(canon_hooks, dict):
+        return existing, False
+    merged = dict(existing)  # shallow: only the 'hooks' block is rebound below
+    cur_hooks = merged.get("hooks")
+    hooks = dict(cur_hooks) if isinstance(cur_hooks, dict) else {}
+    for key in _RECONCILED_HOOK_LISTS:
+        want = canon_hooks.get(key)
+        if isinstance(want, list):
+            hooks[key] = list(want)
+    merged["hooks"] = hooks
+    return merged, merged != existing
+
+
 def write_config(target_claude: Path, cfg: dict, *, force: bool, dry_run: bool) -> str:
     dest = target_claude / "framework.config.json"
     if dest.exists() and not force:
-        return "skipped (exists; use --force to overwrite)"
+        # Amend / upgrade-over-live-install path (#162, #238): do NOT blanket-skip.
+        # An existing (possibly diverged) live config must have its framework hook
+        # module-lists RECONCILED onto the shipped canonical set — stale entries
+        # dropped, canonical order restored — while every other user field is kept
+        # verbatim. Fail-open: an unreadable / non-object config never crashes the
+        # installer; it is left untouched.
+        try:
+            existing = json.loads(dest.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return "skipped (existing config unreadable; left untouched)"
+        if not isinstance(existing, dict):
+            return "skipped (existing config not a JSON object; left untouched)"
+        reconciled, changed = reconcile_module_lists(existing, cfg)
+        if not changed:
+            return "skipped (exists; hook module lists already canonical)"
+        if dry_run:
+            return "would reconcile hook module lists"
+        target_claude.mkdir(parents=True, exist_ok=True)
+        dest.write_text(json.dumps(reconciled, indent=2) + "\n", encoding="utf-8")
+        return "amended (reconciled hook module lists)"
     if dry_run:
         return "would write"
     target_claude.mkdir(parents=True, exist_ok=True)

--- a/framework/tests/test_bootstrap.py
+++ b/framework/tests/test_bootstrap.py
@@ -17,13 +17,18 @@ assertion on the written-defaults source. Stdlib + pytest only.
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
 _FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+_REPO_ROOT = _FRAMEWORK_ROOT.parent
+sys.path.insert(0, str(_REPO_ROOT))  # make `framework.harness` importable (namespace package)
 sys.path.insert(0, str(_FRAMEWORK_ROOT / "install"))
 
 import bootstrap  # noqa: E402
+
+from framework.harness import metrics  # noqa: E402  (read-only ORACLE — never mutated here)
 
 
 def _written_pre_bash() -> list[str]:
@@ -67,3 +72,135 @@ def test_ensure_gitignore_entries_dedupes_and_orders_deterministically(tmp_path:
     assert lines.count(".claude-backups/") == 1
     # sorted(...) output is deterministic regardless of call-site argument order.
     assert lines.index(".claude-backups/") < lines.index(".claude/x.json")
+
+
+# --------------------------------------------------------------------------
+# Amend / upgrade-over-diverged-install: write_config() must RECONCILE (not
+# union) the framework hook module-lists so a re-install over a diverged live
+# config DROPS stale entries and converges on the shipped canonical set
+# (#162, closed by #238). The harness metric `config_module_lists_complete`
+# is the ORACLE — this test drives the real amend write and evaluates that
+# metric read-only, proving the fix from the installer's own side.
+
+
+def _canonical_cfg() -> dict:
+    """The RUNTIME config an amend writes: schema defaults with the identity gate
+    prepended (what the team-enabled standalone/amend path builds at line ~1524)."""
+    cfg = bootstrap._schema_defaults()
+    pre = cfg["hooks"]["pre_bash"]
+    if "validate_commit_identity" not in pre:
+        pre.insert(0, "validate_commit_identity")
+    return cfg
+
+
+def _diverged_live_config() -> dict:
+    """A live install that has DRIFTED: pre_bash carries a stale extra module and
+    has lost required entries + canonical order; agent is non-empty; stop is wrong.
+    Also carries a user-owned field (`scm.owner`) and a custom `pre_push_commands`
+    that the amend MUST preserve untouched."""
+    return {
+        "version": 1,
+        "scm": {"owner": "acme-user-set"},  # user field — must survive the amend
+        "hooks": {
+            "pre_bash": ["validate_commit_identity", "stale_removed_module", "validate_labels"],
+            "post_bash": ["warn_pipe_mask_rc"],
+            "agent": ["legacy_agent_hook"],          # must reconcile -> []
+            "stop": ["some_old_stop", "session_handoff"],  # must reconcile -> [session_handoff]
+            "pre_push_commands": ["pytest -q"],      # user data — must be preserved verbatim
+        },
+    }
+
+
+def _metric_passes(workdir: Path) -> metrics.Measurement:
+    ctx = metrics.CellContext(workdir=workdir, installer="bootstrap", permutation={})
+    return metrics.m_config_module_lists_complete(ctx)
+
+
+def test_amend_reconciles_diverged_config_module_lists(tmp_path: Path) -> None:
+    """Load-bearing (revert -> fail): amending over a diverged config converges the
+    hook module-lists onto the canonical set — stale entries gone, required order
+    restored, agent->[] and stop->[session_handoff] — and the ORACLE metric passes.
+    Reverting the reconcile in `write_config` (back to blanket skip-if-exists) makes
+    both the stale-entry assertion and the metric assertion fail."""
+    claude = tmp_path / ".claude"
+    claude.mkdir()
+    (claude / "framework.config.json").write_text(
+        json.dumps(_diverged_live_config()) + "\n", encoding="utf-8"
+    )
+
+    # Pre-condition: the diverged config FAILS the oracle before the amend.
+    assert _metric_passes(tmp_path).passed is False
+
+    status = bootstrap.write_config(claude, _canonical_cfg(), force=False, dry_run=False)
+    assert "reconciled" in status
+
+    written = json.loads((claude / "framework.config.json").read_text(encoding="utf-8"))
+    hooks = written["hooks"]
+    # Stale accumulation is GONE (reconcile, not union).
+    assert "stale_removed_module" not in hooks["pre_bash"]
+    assert hooks["agent"] == []
+    assert hooks["stop"] == ["session_handoff"]
+    # pre_bash converged to the canonical shipped list, in canonical order.
+    assert hooks["pre_bash"] == _canonical_cfg()["hooks"]["pre_bash"]
+    assert metrics._REQUIRED_PRE_BASH <= set(hooks["pre_bash"])
+    # User-owned fields are preserved verbatim across the amend.
+    assert written["scm"]["owner"] == "acme-user-set"
+    assert hooks["pre_push_commands"] == ["pytest -q"]
+    # The ORACLE now passes post-amend.
+    assert _metric_passes(tmp_path).passed is True
+
+
+def test_amend_reconcile_is_idempotent(tmp_path: Path) -> None:
+    """Amending twice == amending once: no drift, no duplication. The 2nd amend
+    is a no-op (config already canonical) and the file stays byte-identical."""
+    claude = tmp_path / ".claude"
+    claude.mkdir()
+    (claude / "framework.config.json").write_text(
+        json.dumps(_diverged_live_config()) + "\n", encoding="utf-8"
+    )
+    bootstrap.write_config(claude, _canonical_cfg(), force=False, dry_run=False)
+    after_first = (claude / "framework.config.json").read_text(encoding="utf-8")
+
+    status2 = bootstrap.write_config(claude, _canonical_cfg(), force=False, dry_run=False)
+    assert "already canonical" in status2
+    assert (claude / "framework.config.json").read_text(encoding="utf-8") == after_first
+    assert _metric_passes(tmp_path).passed is True
+
+
+def test_amend_fail_open_on_malformed_live_config(tmp_path: Path) -> None:
+    """Fail-open (AC #3): a malformed/partial live config never crashes the amend —
+    it degrades gracefully and leaves the file untouched rather than throwing."""
+    claude = tmp_path / ".claude"
+    claude.mkdir()
+    dest = claude / "framework.config.json"
+    dest.write_text("{not valid json", encoding="utf-8")
+    status = bootstrap.write_config(claude, _canonical_cfg(), force=False, dry_run=False)
+    assert "unreadable" in status
+    assert dest.read_text(encoding="utf-8") == "{not valid json"  # left untouched
+
+
+def test_reconcile_module_lists_drops_stale_without_union() -> None:
+    """Unit: reconcile REPLACES a diverged list with the canonical one (drops the
+    stale entry) rather than unioning the two — and reports `changed`."""
+    existing = {"hooks": {"pre_bash": ["stale", "validate_labels"], "agent": ["x"], "stop": []}}
+    canonical = {"hooks": {"pre_bash": ["validate_labels", "block_squash_wave_merge"],
+                           "agent": [], "stop": ["session_handoff"]}}
+    merged, changed = bootstrap.reconcile_module_lists(existing, canonical)
+    assert changed is True
+    assert merged["hooks"]["pre_bash"] == ["validate_labels", "block_squash_wave_merge"]
+    assert "stale" not in merged["hooks"]["pre_bash"]
+    assert merged["hooks"]["agent"] == [] and merged["hooks"]["stop"] == ["session_handoff"]
+    # Idempotent: reconciling the result again reports no change.
+    _, changed2 = bootstrap.reconcile_module_lists(merged, canonical)
+    assert changed2 is False
+
+
+def test_reconcile_module_lists_rebuilds_partial_hooks() -> None:
+    """Unit / fail-open: a config MISSING the hooks block gets it rebuilt from the
+    canonical lists without raising."""
+    merged, changed = bootstrap.reconcile_module_lists(
+        {"version": 1}, {"hooks": {"agent": [], "stop": ["session_handoff"]}}
+    )
+    assert changed is True
+    assert merged["hooks"]["agent"] == [] and merged["hooks"]["stop"] == ["session_handoff"]
+    assert merged["version"] == 1  # untouched


### PR DESCRIPTION
## Summary

Fixes the install **amend** path (keep-&-amend, the non-destructive default) leaving **stale config module lists** behind on an upgrade-over-diverged-live-install (#162, closed by #238).

`write_config` previously **blanket-skipped** `framework.config.json` whenever it already existed, so a re-install over a diverged live config left its stale hook module-lists untouched — and the harness oracle `m_config_module_lists_complete` FAILED (`pre_bash` missing required modules, `hooks.agent` non-empty, or `hooks.stop` != `["session_handoff"]`).

The amend write now **RECONCILES (not unions)** the framework hook module-lists onto the shipped canonical set:
- `hooks.pre_bash` converges to the canonical shipped list (stale entries dropped, required order restored) — **reconcile, not union**.
- `hooks.agent` → `[]`, `hooks.stop` → `["session_handoff"]`.
- Every other user field (`scm.owner`, `policy`, the user-owned `pre_push_commands`) is **preserved verbatim**.

Scope is entirely within `framework/install/` (bootstrap.py). These are installer **product** files, not runtime `.claude/` assets — no reinstall/dual-deploy copy needed. The harness metric is the untouched **ORACLE**.

## Acceptance criteria

- [x] **AC1** Amend over stale/extra `pre_bash` converges to the canonical set (no stale accumulation); required order preserved; `hooks.agent`→`[]`, `hooks.stop`→`["session_handoff"]` reconciled.
- [x] **AC2** Idempotent: amending twice == amending once (2nd run is a no-op, byte-identical).
- [x] **AC3** Fail-open: a malformed / non-object live config never crashes the installer — left untouched.
- [x] **AC4** Regression test builds a diverged install config, runs the amend/reconcile, asserts `config_module_lists_complete` passes post-amend and stale entries are gone (`framework/tests/test_bootstrap.py`).
- [x] **AC5** Full suite green.
- [x] **AC6** `reinstall.py --check`, `manifest.py --check`, `charter_drift.py --check` all exit 0.

## Files changed
- `framework/install/bootstrap.py` — new `reconcile_module_lists()` + `_RECONCILED_HOOK_LISTS`; `write_config()` reconciles-on-amend instead of blanket skip.
- `framework/tests/test_bootstrap.py` — 5 regression tests (oracle-anchored amend, idempotency, fail-open, reconcile-not-union unit, partial-hooks rebuild).

## Test evidence

```
$ python3 -m pytest framework/tests/test_bootstrap.py -v
8 passed

$ python3 -m pytest framework/tests/  (full suite)
802 passed in 42.94s

$ ruff check framework/install/bootstrap.py framework/tests/test_bootstrap.py
All checks passed!

$ python3 framework/install/reinstall.py --check      -> exit 0 (in sync)
$ python3 framework/install/manifest.py --check       -> exit 0 (in sync)
$ python3 framework/install/charter_drift.py --check  -> exit 0 (matches canonical)
```

End-to-end (real bootstrap `--expect existing` over a diverged live install):
```
framework.config:  amended (reconciled hook module lists)
STALE_MODULE dropped: True
agent: [] | stop: ['session_handoff']
pre_bash canonical: True
owner preserved: acme-live | pre_push preserved: ['pytest -q']
ORACLE m_config_module_lists_complete passed: True
```

**Reviewers: Nia Rossi (TL) + Tariq Morales (QA)**
