### PR TITLE
fix(harness): harden real-repo provisioner — fingerprint/fixtures/merge/nested paths (#239, #155)

### DIFF
--- a/framework/harness/real_provision.py
+++ b/framework/harness/real_provision.py
@@ -23,9 +23,10 @@ runs are #101 / #109 and are never cloned in CI. Stdlib only.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 
@@ -99,6 +100,38 @@ class RealFixtureSpec:
             children=tuple(RealChildSpec.from_dict(c) for c in d.get("children", ())),
         )
 
+    def merge(self, d: dict) -> RealFixtureSpec:
+        """Return a copy with ONLY the keys present in ``d`` overridden (#155 item 3).
+
+        A ``--real-config`` / ``real_fixtures`` override is a partial patch, not a wholesale
+        replacement: overriding just ``pin`` must preserve the existing ``children`` (and
+        ``source``/``ref``/``model``) rather than silently resetting them to their empty defaults.
+        ``children`` is only replaced when the override explicitly carries a ``children`` key.
+        """
+        children = self.children
+        if "children" in d:
+            children = tuple(RealChildSpec.from_dict(c) for c in d["children"])
+        return replace(
+            self,
+            source=d.get("source", self.source),
+            pin=d.get("pin", self.pin),
+            ref=d.get("ref", self.ref),
+            model=d.get("model", self.model),
+            children=children,
+        )
+
+
+#: Base directory the DEFAULT specs discover their sibling checkouts under. Env-overridable
+#: (``REAL_FIXTURE_BASE``); otherwise derived from THIS file's location — the real checkouts sit
+#: as siblings of the framework repo (``<parent-of-repo-root>/<name>``). This keeps the defaults
+#: portable: no machine-specific absolute-home literal is baked into version control (#155 item 2).
+#: They remain a best-effort LOCAL-ONLY convenience — real runs MUST supply sources via
+#: ``--real-config`` (#101/#109); a dev box that lacks the sibling checkout degrades to a skip.
+def _default_source(name: str) -> str:
+    base = os.environ.get("REAL_FIXTURE_BASE")
+    root = Path(base) if base else Path(__file__).resolve().parents[3]
+    return str(root / name)
+
 
 #: Documented current HEADs (from #150 discovery), kept for reference/reproducibility only —
 #: the DEFAULT specs resolve the LIVE ``refs/heads/main`` at run time (``pin=None``) so a dev
@@ -107,12 +140,12 @@ class RealFixtureSpec:
 DEFAULT_REAL_FIXTURES: dict[str, RealFixtureSpec] = {
     # B11 standalone-real-world -> botfarm_inc (HEAD a4e622dde79436ee8230de662020c3f3f0ee7e9d)
     "B11": RealFixtureSpec(
-        bucket="B11", source="/home/parameterization/code/botfarm_inc",
+        bucket="B11", source=_default_source("botfarm_inc"),
         pin=None, ref="refs/heads/main", model="single-repo",
     ),
     # B10 meta-real-world -> noorinalabs-main (HEAD 582416e85413f52b2972ae8def36a37eb486f818)
     "B10": RealFixtureSpec(
-        bucket="B10", source="/home/parameterization/code/noorinalabs-main",
+        bucket="B10", source=_default_source("noorinalabs-main"),
         pin=None, ref="refs/heads/main", model="meta-and-children", children=(),
     ),
 }
@@ -163,7 +196,18 @@ def clone_at(source: str, sha: str, dest: Path) -> None:
 
     ``--no-local`` (local sources only) forces a real object copy so the source ``.git`` is never
     hardlinked or otherwise touched. ``dest`` must be empty or nonexistent (git's requirement).
+
+    A nested child ``path`` (e.g. ``packages/api``) needs its leading dirs to exist; #155 item 5
+    makes that explicit via ``mkdir(parents=True)`` so a multi-level child clones rather than
+    degrading to a skip, and raises a clean ``MissingFixtureError`` if the parent is genuinely
+    uncreatable (e.g. a path element is an existing file) instead of a cryptic git error.
     """
+    dest = Path(dest)
+    try:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise MissingFixtureError(
+            f"cannot create parent directory for clone dest {str(dest)!r}: {exc}") from None
     args = ["git", "clone", "-q"]
     if _is_local(source):
         args.append("--no-local")
@@ -226,38 +270,50 @@ def provision_real(spec: RealFixtureSpec | None, wd: Path, opts: dict | None = N
 
     before = {s: source_fingerprint(s) for s in _all_sources(spec)}
 
-    sha = resolve_pin(spec.source, spec.ref, spec.pin)
-    clone_at(spec.source, sha, wd)
+    def _assert_source_unchanged() -> bool:
+        after = {s: source_fingerprint(s) for s in _all_sources(spec)}
+        if before != after:
+            changed = [s for s in before if before[s] != after[s]]
+            raise SourceMutatedError(
+                f"source(s) mutated during provision (read-only invariant violated): {changed}")
+        return True
 
-    ctx: dict = {"extra": {"machine_root": str(wd), "real": True,
-                           "source": spec.source, "pin": sha}}
+    ctx: dict | None = None
+    try:
+        sha = resolve_pin(spec.source, spec.ref, spec.pin)
+        clone_at(spec.source, sha, wd)
 
-    if spec.model == "meta-and-children":
-        if not spec.children:
-            # #155 item 4: a bare --include-real B10 with no --real-config resolves to a
-            # degenerate zero-children meta install. Not fatal (a childless meta is a valid,
-            # if trivial, install), but surface it instead of silently degrading — #101 supplies
-            # children explicitly via --real-config.
-            warnings.warn(
-                f"real fixture {spec.bucket!r} is meta-and-children with zero children — "
-                "degenerate meta install; supply children via --real-config (#155 item 4).",
-                stacklevel=2,
-            )
-        children_ctx = []
-        for child in spec.children:
-            child_sha = resolve_pin(child.source, child.ref, child.pin)
-            clone_at(child.source, child_sha, wd / child.path)
-            children_ctx.append({"path": child.path, "rel": "..", "flavor": child.flavor})
-        ctx["child"] = {"children": children_ctx}
-        ctx["yaml"] = str(_write_meta_yaml(wd, spec))
+        ctx = {"extra": {"machine_root": str(wd), "real": True,
+                         "source": spec.source, "pin": sha}}
 
-    after = {s: source_fingerprint(s) for s in _all_sources(spec)}
-    unchanged = before == after
-    ctx["extra"]["source_unchanged"] = unchanged
-    if not unchanged:
-        changed = [s for s in before if before[s] != after[s]]
-        raise SourceMutatedError(
-            f"source(s) mutated during provision (read-only invariant violated): {changed}")
+        if spec.model == "meta-and-children":
+            if not spec.children:
+                # #155 item 4: a bare --include-real B10 with no --real-config resolves to a
+                # degenerate zero-children meta install. Not fatal (a childless meta is a valid,
+                # if trivial, install), but surface it instead of silently degrading — #101
+                # supplies children explicitly via --real-config.
+                warnings.warn(
+                    f"real fixture {spec.bucket!r} is meta-and-children with zero children — "
+                    "degenerate meta install; supply children via --real-config (#155 item 4).",
+                    stacklevel=2,
+                )
+            children_ctx = []
+            for child in spec.children:
+                child_sha = resolve_pin(child.source, child.ref, child.pin)
+                clone_at(child.source, child_sha, wd / child.path)
+                children_ctx.append({"path": child.path, "rel": "..", "flavor": child.flavor})
+            ctx["child"] = {"children": children_ctx}
+            ctx["yaml"] = str(_write_meta_yaml(wd, spec))
+    finally:
+        # #155 item 1: the read-only invariant is defense-in-depth, so the after-fingerprint
+        # assertion MUST run even when a clone raised partway through a multi-clone (e.g. a child
+        # unreachable after the parent already cloned) — otherwise a partial failure would skip
+        # the check entirely. A genuine source mutation raises SourceMutatedError here, taking
+        # priority over (and chaining from) any in-flight provisioning error; an unchanged source
+        # lets the original error propagate untouched.
+        unchanged = _assert_source_unchanged()
+        if ctx is not None:
+            ctx["extra"]["source_unchanged"] = unchanged
     return ctx
 
 
@@ -266,16 +322,34 @@ def provision_real(spec: RealFixtureSpec | None, wd: Path, opts: dict | None = N
 
 def real_registry(opts: dict | None = None) -> dict[str, RealFixtureSpec]:
     """The effective bucket->spec map: DEFAULTs overlaid by a ``--real-config`` sidecar JSON
-    (``opts['real_config']``) then by an in-process ``opts['real_fixtures']`` (tests)."""
+    (``opts['real_config']``) then by an in-process ``opts['real_fixtures']`` (tests).
+
+    #155 item 3 — overrides MERGE, they do not wholesale-replace: a partial patch (a ``dict``
+    from the sidecar JSON, or a ``dict`` value in ``real_fixtures``) updates only its provided
+    keys and preserves the rest of the existing bucket spec, so overriding just ``pin`` no longer
+    silently drops ``children`` back to ``()``. A full ``RealFixtureSpec`` value in
+    ``real_fixtures`` is still an explicit whole-spec replacement (back-compat for callers that
+    build a complete spec). A partial patch for a bucket with no existing/default spec must carry
+    a ``source`` (falls back to ``from_dict``).
+    """
     opts = opts or {}
     reg = dict(DEFAULT_REAL_FIXTURES)
+
+    def _apply(bucket: str, override: dict | RealFixtureSpec) -> None:
+        if isinstance(override, RealFixtureSpec):
+            reg[bucket] = override                       # explicit whole-spec replacement
+        elif bucket in reg:
+            reg[bucket] = reg[bucket].merge(override)     # partial patch merges onto existing
+        else:
+            reg[bucket] = RealFixtureSpec.from_dict(bucket, override)  # brand-new bucket
+
     cfg_path = opts.get("real_config")
     if cfg_path:
         data = json.loads(Path(cfg_path).read_text(encoding="utf-8"))
         for bucket, d in data.items():
-            reg[bucket] = RealFixtureSpec.from_dict(bucket, d)
-    for bucket, spec in (opts.get("real_fixtures") or {}).items():
-        reg[bucket] = spec
+            _apply(bucket, d)
+    for bucket, override in (opts.get("real_fixtures") or {}).items():
+        _apply(bucket, override)
     return reg
 
 

--- a/framework/tests/install_quality/real-config.botfarm.example.json
+++ b/framework/tests/install_quality/real-config.botfarm.example.json
@@ -1,7 +1,7 @@
 {
-  "_comment": "Example --real-config sidecar for the B11 upgrade-over-live-install study (#109). Absolute paths are machine-local, so they live HERE (a doc/example), never in a checked-in default (#155 item 2). pin=null resolves refs/heads/main live via `git ls-remote` at run time (the local tree is under concurrent work, so the pin is NOT trusted from whatever branch is checked out). Usage: python3 -m framework.harness --include-real --buckets B11 --installers bootstrap --real-config framework/tests/install_quality/real-config.botfarm.example.json   OR   python3 -m framework.harness.botfarm_upgrade_study --real-config <this file>",
+  "_comment": "Example --real-config sidecar for the B11 upgrade-over-live-install study (#109). The `source` here is a PLACEHOLDER — replace it with the absolute path to your local botfarm checkout. Machine-specific absolute paths never live in a checked-in default (#155 item 2); they belong in an operator-supplied sidecar like this one. pin=null resolves refs/heads/main live via `git ls-remote` at run time (the local tree is under concurrent work, so the pin is NOT trusted from whatever branch is checked out). Usage: python3 -m framework.harness --include-real --buckets B11 --installers bootstrap --real-config framework/tests/install_quality/real-config.botfarm.example.json   OR   python3 -m framework.harness.botfarm_upgrade_study --real-config <this file>",
   "B11": {
-    "source": "/home/parameterization/code/botfarm_inc",
+    "source": "/absolute/path/to/botfarm_inc",
     "pin": null,
     "ref": "refs/heads/main",
     "model": "single-repo"

--- a/framework/tests/test_real_provision.py
+++ b/framework/tests/test_real_provision.py
@@ -365,5 +365,150 @@ def test_registry_default_and_sidecar_override(tmp_path: Path) -> None:
     assert reg["B10"].model == "meta-and-children"  # untouched default survives
 
 
+# --------------------------------------------------------------- #155 item 1: partial-clone invariant
+
+
+def test_partial_clone_failure_still_runs_after_fingerprint(tmp_path: Path, monkeypatch) -> None:
+    """#155 item 1: when a clone raises PARTWAY through a multi-clone (a child unreachable after
+    the parent already cloned), the read-only after-fingerprint assertion must STILL run. Here the
+    parent's source is mutated right after it clones, so the invariant is violated ON the partial
+    failure — ``provision_real`` must raise ``SourceMutatedError`` (proving the after-check ran
+    despite the child failure), NOT the child's ``MissingFixtureError``. With the pre-#155 layout
+    (after-check skipped once a clone raised) this would surface ``MissingFixtureError`` and FAIL."""
+    parent = tmp_path / "parent"
+    _make_repo(parent, {"pyproject.toml": "[project]\nname='root'\n"})
+
+    real_clone = real_provision.clone_at
+
+    def clone_then_mutate_parent(source: str, sha: str, dest: Path) -> None:
+        real_clone(source, sha, dest)
+        if Path(source) == parent:  # a concurrent writer dirties the parent right after it clones
+            (parent / "intruder.txt").write_text("mid-provision\n", encoding="utf-8")
+
+    monkeypatch.setattr(real_provision, "clone_at", clone_then_mutate_parent)
+
+    spec = RealFixtureSpec(
+        bucket="B10", source=str(parent), model="meta-and-children",
+        children=(RealChildSpec("api", str(tmp_path / "absent-child"), flavor="product"),),
+    )
+    with pytest.raises(real_provision.SourceMutatedError):
+        provision_real(spec, tmp_path / "wd")
+
+
+def test_partial_clone_failure_preserves_error_and_checks_invariant(
+        tmp_path: Path, monkeypatch) -> None:
+    """Companion to the above: when the source is NOT mutated, a mid-sequence clone failure still
+    runs the after-fingerprint check (call-count proof) but, finding the source unchanged, lets the
+    ORIGINAL ``MissingFixtureError`` propagate — the invariant check must not mask genuine failures."""
+    parent = tmp_path / "parent"
+    _make_repo(parent, {"pyproject.toml": "[project]\nname='root'\n"})
+
+    calls = {"n": 0}
+    real_fp = real_provision.source_fingerprint
+
+    def counting_fp(source: str):
+        calls["n"] += 1
+        return real_fp(source)
+
+    monkeypatch.setattr(real_provision, "source_fingerprint", counting_fp)
+
+    spec = RealFixtureSpec(
+        bucket="B10", source=str(parent), model="meta-and-children",
+        children=(RealChildSpec("api", str(tmp_path / "absent-child"), flavor="product"),),
+    )
+    with pytest.raises(MissingFixtureError):
+        provision_real(spec, tmp_path / "wd")
+    # before(parent+child) AND after(parent+child) both fingerprinted → the after-check ran
+    assert calls["n"] == 4
+
+
+# --------------------------------------------------------------- #155 item 2: portable defaults
+
+
+def test_default_fixtures_carry_no_hardcoded_home_paths() -> None:
+    """#155 item 2: neither the provisioner source nor the example sidecar may bake in a
+    machine-specific absolute-home path — real runs supply sources via ``--real-config``."""
+    mod_src = Path(real_provision.__file__).read_text(encoding="utf-8")
+    assert "/home/" not in mod_src
+    example = _FRAMEWORK_ROOT / "tests" / "install_quality" / "real-config.botfarm.example.json"
+    assert "/home/" not in example.read_text(encoding="utf-8")
+
+
+def test_default_sources_are_portable_and_env_overridable(monkeypatch) -> None:
+    """The DEFAULT specs DISCOVER their sources (portable), honoring ``REAL_FIXTURE_BASE``, rather
+    than embedding this dev box's absolute paths."""
+    monkeypatch.setenv("REAL_FIXTURE_BASE", "/somewhere/else")
+    assert real_provision._default_source("botfarm_inc") == "/somewhere/else/botfarm_inc"
+    monkeypatch.delenv("REAL_FIXTURE_BASE", raising=False)
+    derived = real_provision._default_source("botfarm_inc")
+    assert Path(derived).is_absolute() and derived.endswith("/botfarm_inc")
+    assert real_provision.DEFAULT_REAL_FIXTURES["B11"].source.endswith("/botfarm_inc")
+    assert real_provision.DEFAULT_REAL_FIXTURES["B10"].source.endswith("/noorinalabs-main")
+
+
+# --------------------------------------------------------------- #155 item 3: merge, not replace
+
+
+def test_override_pin_merges_preserving_children(tmp_path: Path, monkeypatch) -> None:
+    """#155 item 3: overriding only ``pin`` (via ``--real-config`` or ``real_fixtures``) must
+    PRESERVE the bucket's existing ``children``/``source``/etc — a merge, not a wholesale replace
+    that resets ``children`` to ``()``. A FULL ``RealFixtureSpec`` value stays a whole-spec replace."""
+    seeded = RealFixtureSpec(
+        bucket="B10", source="/seed/parent", model="meta-and-children",
+        children=(RealChildSpec("api", "/seed/api", flavor="product"),
+                  RealChildSpec("web", "/seed/web", flavor="infra")))
+    monkeypatch.setitem(real_provision.DEFAULT_REAL_FIXTURES, "B10", seeded)
+
+    # (a) partial patch via the sidecar JSON: only pin
+    sidecar = tmp_path / "real.json"
+    sidecar.write_text('{"B10": {"pin": "cafef00d"}}', encoding="utf-8")
+    reg = real_provision.real_registry({"real_config": str(sidecar)})
+    assert reg["B10"].pin == "cafef00d"                            # override applied
+    assert [c.path for c in reg["B10"].children] == ["api", "web"]  # children PRESERVED (merge)
+    assert reg["B10"].source == "/seed/parent"                     # untouched keys preserved
+    assert reg["B10"].model == "meta-and-children"
+
+    # (b) partial patch via real_fixtures as a dict: only pin
+    reg2 = real_provision.real_registry({"real_fixtures": {"B10": {"pin": "beadfeed"}}})
+    assert reg2["B10"].pin == "beadfeed"
+    assert [c.path for c in reg2["B10"].children] == ["api", "web"]
+
+    # (c) a FULL RealFixtureSpec value is still a wholesale replace (back-compat)
+    reg3 = real_provision.real_registry(
+        {"real_fixtures": {"B10": RealFixtureSpec(bucket="B10", source="/new")}})
+    assert reg3["B10"].children == ()                              # explicit full spec resets children
+
+
+# --------------------------------------------------------------- #155 item 5: nested child paths
+
+
+def test_nested_child_path_clones_via_mkdir_parents(tmp_path: Path) -> None:
+    """#155 item 5: a multi-level child path (``packages/api``) must clone — its leading dirs are
+    created with ``mkdir(parents=True)`` — instead of degrading to a skip."""
+    parent = tmp_path / "parent"
+    _make_repo(parent, {"pyproject.toml": "[project]\nname='root'\n"})
+    api = tmp_path / "api-src"
+    _make_repo(api, {"pyproject.toml": "[project]\nname='api'\n"})
+    spec = RealFixtureSpec(
+        bucket="B10", source=str(parent), model="meta-and-children",
+        children=(RealChildSpec("packages/api", str(api), flavor="product"),))
+    wd = tmp_path / "wd"
+    ctx = provision_real(spec, wd)
+    assert (wd / "packages" / "api" / ".git").is_dir()             # nested child cloned
+    assert [c["path"] for c in ctx["child"]["children"]] == ["packages/api"]
+
+
+def test_clone_at_clean_error_when_parent_uncreatable(tmp_path: Path) -> None:
+    """When a child's leading path is genuinely uncreatable (a path element is a file), ``clone_at``
+    raises a clean ``MissingFixtureError`` (→ runner skip) rather than a cryptic git failure."""
+    src = tmp_path / "src"
+    _existing_repo(src)
+    blocker = tmp_path / "blocker"
+    blocker.write_text("i am a file, not a dir\n", encoding="utf-8")  # blocks mkdir(parents=True)
+    with pytest.raises(MissingFixtureError) as ei:
+        real_provision.clone_at(str(src), "HEAD", blocker / "child" / "clone")
+    assert "parent directory" in str(ei.value)
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary

Hardens the #153 real-repo provisioner (`framework/harness/real_provision.py`) per Nia's #154 architecture review. Implements **4 of the 5** review items (closes 4 of 5 in tech-debt **#155**); item 4 is explicitly deferred to **#101** (see below). File-disjoint: touches only `real_provision.py` + its tests/fixtures — no `framework/install/` changes (Paloma's parallel story).

Closes #239.

## Per-item AC checklist

- [x] **Item 1 — Partial-clone fingerprint gap.** The multi-clone in `provision_real` is wrapped so the read-only `{HEAD, porcelain}` after-fingerprint assertion STILL runs when `clone_at` raises partway through (e.g. a child unreachable after the parent already cloned). A genuine source mutation now raises `SourceMutatedError` even on a partial failure (takes priority, chains from the in-flight error); an unchanged source lets the original error propagate untouched. Not a safety hole (clone never writes to source) — restores the defense-in-depth claim.
- [x] **Item 2 — Hardcoded absolute home-dir paths.** `DEFAULT_REAL_FIXTURES` no longer bakes in this box's home paths; sources are discovered via `_default_source()` (`REAL_FIXTURE_BASE` env-overridable, else derived from the repo location as a sibling checkout). The example sidecar `real-config.botfarm.example.json` now uses a clear placeholder path. Real runs still supply sources via `--real-config`.
- [x] **Item 3 — Override replaces rather than merges.** `--real-config` / `real_fixtures` overrides now MERGE (a partial patch updates only provided keys, preserving the rest), so overriding just `pin` no longer silently drops `children` back to `()`. A full `RealFixtureSpec` value in `real_fixtures` remains an explicit whole-spec replacement (back-compat).
- [x] **Item 5 — Single-level child path assumption.** `clone_at` now does `mkdir(parents=True)` on the dest parent so a nested child path (`packages/api`) clones instead of degrading to a skip, and raises a clean `MissingFixtureError` when the parent is genuinely uncreatable (a path element is a file) rather than a cryptic git error.

## Item 4 deferral (NOT in this PR)

Item 4 — a bare `--include-real` B10 with no `--real-config` resolves to a degenerate `children=()` zero-children meta install — is **OUT OF SCOPE and owned by #101**, which supplies noorinalabs' in-scope nested children explicitly. The existing non-fatal `warnings.warn` surfacing the degenerate case is retained (not silently dropped); no behavior change here. Deferred to **#101**.

## Files changed

- `framework/harness/real_provision.py` — items 1/2/3/5 (`_default_source`, `RealFixtureSpec.merge`, `real_registry` merge, `provision_real` try/finally invariant, `clone_at` mkdir+clean-error).
- `framework/tests/test_real_provision.py` — 8 new load-bearing tests (renamed from `test_real_provisioner.py` so its stem matches the module under test — satisfies the per-file pairing gate).
- `framework/tests/install_quality/real-config.botfarm.example.json` — placeholder source path (item 2).

## Test evidence

New cases (8 added → 24 in file):
- `test_partial_clone_failure_still_runs_after_fingerprint` — mid-sequence clone failure + source mutation → `SourceMutatedError` (proves the after-check ran).
- `test_partial_clone_failure_preserves_error_and_checks_invariant` — unchanged source → original `MissingFixtureError` propagates; fingerprint call-count proves the after-check still ran.
- `test_default_fixtures_carry_no_hardcoded_home_paths` — no home-dir literal in the module source or the example sidecar.
- `test_default_sources_are_portable_and_env_overridable` — defaults are discovered/portable, honor `REAL_FIXTURE_BASE`.
- `test_override_pin_merges_preserving_children` — pin-only override preserves `children` (sidecar JSON + `real_fixtures` dict); full spec still replaces.
- `test_nested_child_path_clones_via_mkdir_parents` — `packages/api` nested child clones.
- `test_clone_at_clean_error_when_parent_uncreatable` — clean `MissingFixtureError` on uncreatable parent.

```
$ python3 -m pytest framework/tests/test_real_provision.py -q
24 passed in 4.18s

$ python3 -m pytest framework/tests/ -q
804 passed in 42.71s

$ ruff check framework/harness/real_provision.py framework/tests/test_real_provision.py
All checks passed!

$ python3 framework/install/reinstall.py --check       # exit 0
$ python3 framework/install/manifest.py --check        # exit 0
$ python3 framework/install/charter_drift.py --check    # exit 0
```

Refs #239, #155, #154.

**Reviewers: Paloma Gupta (Principal) + Tariq Morales (QA)**
