### PR TITLE
docs(charter): per-agent scratch namespacing + e2e cd/mkdir hygiene

### DIFF
--- a/.claude/team/.charter-manifest.json
+++ b/.claude/team/.charter-manifest.json
@@ -1,8 +1,8 @@
 {
   "version": 1,
   "files": {
-    "agents.md": "8a53b9a7bf6b97e473bc5387b84609a83fe8c0524374d66dc2330e5d7ed450ce",
-    "branching.md": "3e51782810787065403bbd7203610e7be247788cb60278960859e1ffb922b5af",
+    "agents.md": "8920741cc025a4587499e18f8e58d896fa67c27fd2ea3a3fa43bebb8bafc7618",
+    "branching.md": "59c9091e039cc5b97c021f7969adb036ad5396ab73dfa0e046ef33481900f4e0",
     "charter.md": "b2d200f1de236bc1ba6d997917be5e186504a05c12015e392b1ecf7291564dfb",
     "commits.md": "c9d5e7349f0ead70cb37dd8cf20a7753fe3bea5c943ad56fe3f661dc4daaab67",
     "hooks.md": "77d72942082cf0dd1fb45da686376d8813d3e2b30ebe1ec4f99e432ef0fdb1d5",

--- a/.claude/team/charter/agents.md
+++ b/.claude/team/charter/agents.md
@@ -12,6 +12,17 @@ No anonymous functional agents.
 - **Violations:** functional-only names (e.g., `ci-fixer`, `issue-closer`) are not
   allowed.
 
+## Per-Agent Scratch-File Namespacing
+
+**Every spawned agent MUST prefix its scratch files with its own name** — commit
+messages, PR bodies, and any temporary working file (`paloma_prbody.md`,
+`ibrahim_commitmsg.txt`), never a bare shared name (`prbody.md`, `commitmsg.txt`).
+The job's temp directory is **shared across concurrently-running agents**, so two
+agents writing the same bare filename clobber each other mid-run (Phase 6 Wave 10:
+two parallel authors overwrote each other's `commitmsg.txt`/`prbody.md`; no work was
+lost only because it was caught in progress). The orchestrator carries this instruction
+in the author/reviewer spawn-prompt boilerplate, and each agent enforces it on itself.
+
 ## How to Instantiate the Team
 
 When starting any work session, the orchestrating agent should:

--- a/.claude/team/charter/branching.md
+++ b/.claude/team/charter/branching.md
@@ -55,6 +55,24 @@ git -C <main-repo> worktree add <path> -b <branch> origin/<base>
 - An agent never removes the worktree it is standing in (enforced — see
   [hooks.md](hooks.md)).
 
+## Ad-hoc / e2e Check Hygiene
+
+Ad-hoc end-to-end checks (bootstrap runs, install dry-runs, throwaway scripts) MUST
+execute in an **explicit, pre-created scratch dir**. Chain the directory creation and
+the `cd` with `&&` so the `cd` cannot run unless the `mkdir` succeeded:
+
+```bash
+mkdir -p <scratch> && cd <scratch> && <command>
+```
+
+Never split `mkdir` and `cd` across a `;`-separated chain (or leave the `cd` on its
+own line) where an earlier command can be blocked or fail: a hook-blocked or failed
+`mkdir` leaves the following `cd` pointing at a directory that was never created, the
+`cd` fails silently, and every later command runs in the **worktree root** instead —
+where an ad-hoc `bootstrap`/install can clobber tracked files (Phase 6 Wave 10
+incident #1). Chaining with `&&` aborts the whole sequence on the first failure, so a
+silently-redirected cwd can never happen.
+
 ## Worktree Cleanup
 
 **After every wave completes** (all PRs merged into the integration branch), clean

--- a/framework/assets/team/charter/agents.md
+++ b/framework/assets/team/charter/agents.md
@@ -12,6 +12,17 @@ No anonymous functional agents.
 - **Violations:** functional-only names (e.g., `ci-fixer`, `issue-closer`) are not
   allowed.
 
+## Per-Agent Scratch-File Namespacing
+
+**Every spawned agent MUST prefix its scratch files with its own name** — commit
+messages, PR bodies, and any temporary working file (`paloma_prbody.md`,
+`ibrahim_commitmsg.txt`), never a bare shared name (`prbody.md`, `commitmsg.txt`).
+The job's temp directory is **shared across concurrently-running agents**, so two
+agents writing the same bare filename clobber each other mid-run (Phase 6 Wave 10:
+two parallel authors overwrote each other's `commitmsg.txt`/`prbody.md`; no work was
+lost only because it was caught in progress). The orchestrator carries this instruction
+in the author/reviewer spawn-prompt boilerplate, and each agent enforces it on itself.
+
 ## How to Instantiate the Team
 
 When starting any work session, the orchestrating agent should:

--- a/framework/assets/team/charter/branching.md
+++ b/framework/assets/team/charter/branching.md
@@ -55,6 +55,24 @@ git -C <main-repo> worktree add <path> -b <branch> origin/<base>
 - An agent never removes the worktree it is standing in (enforced — see
   [hooks.md](hooks.md)).
 
+## Ad-hoc / e2e Check Hygiene
+
+Ad-hoc end-to-end checks (bootstrap runs, install dry-runs, throwaway scripts) MUST
+execute in an **explicit, pre-created scratch dir**. Chain the directory creation and
+the `cd` with `&&` so the `cd` cannot run unless the `mkdir` succeeded:
+
+```bash
+mkdir -p <scratch> && cd <scratch> && <command>
+```
+
+Never split `mkdir` and `cd` across a `;`-separated chain (or leave the `cd` on its
+own line) where an earlier command can be blocked or fail: a hook-blocked or failed
+`mkdir` leaves the following `cd` pointing at a directory that was never created, the
+`cd` fails silently, and every later command runs in the **worktree root** instead —
+where an ad-hoc `bootstrap`/install can clobber tracked files (Phase 6 Wave 10
+incident #1). Chaining with `&&` aborts the whole sequence on the first failure, so a
+silently-redirected cwd can never happen.
+
 ## Worktree Cleanup
 
 **After every wave completes** (all PRs merged into the integration branch), clean


### PR DESCRIPTION
## Summary
Promote the two Wave 14/15 retro orchestration-hygiene proposals from the feedback log into the team charter, so future waves inherit them automatically. Docs-only — no code behavior change.

- **AC1 — Per-agent temp-file namespacing** (`agents.md`, new "Per-Agent Scratch-File Namespacing" section): every spawned agent MUST prefix its scratch/commit-message/PR-body files with its own name (`paloma_prbody.md`, `ibrahim_commitmsg.txt`), never a bare shared name — the job temp dir is shared across concurrent agents (W10 incident #2: two authors clobbered each other's `commitmsg.txt`/`prbody.md`).
- **AC2 — Guard e2e `cd` on `mkdir` success** (`branching.md`, new "Ad-hoc / e2e Check Hygiene" section): ad-hoc end-to-end checks run in an explicit pre-created scratch dir, chaining `mkdir -p X && cd X && …` so a hook-blocked/failed `mkdir` can't silently redirect later commands into the worktree root (W10 incident #1).
- **AC3 — Dual-deploy parity:** identical prose applied to canonical `framework/assets/team/charter/` and installed `.claude/team/charter/`. Inserted blocks verified byte-identical across both trees; the only remaining canonical↔installed differences are pre-existing `{{token}}` substitutions outside my edits.

Out of scope (per issue #245): reserved-5 rotation / `trust_signals` scoring — owner carried that over as a standalone decision. No scoring touched.

## Related Issues
Closes #245

## Review Checklist
- [ ] Reviewed by another team member
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)
