### PR TITLE
harness: provisioner error-hardening + doc note (#243/#244/#242)

### DIFF
--- a/framework/config/README.md
+++ b/framework/config/README.md
@@ -36,6 +36,13 @@ capability but do not error.
 | `hooks.stop` | Stop-event checks (advisory, never block). Ships with `session_handoff` (auto handoff note; defers to a manual `/handoff`). |
 | `hooks.pre_push_commands` | Checks the enforce-mode pre-push git hook runs (read at push time; empty = pass). |
 
+> **Re-install RESETS the framework-owned hook lists to canonical.** Re-installing over an
+> existing config (the amend/upgrade path) reconciles the framework-owned hook module-lists
+> (`hooks.pre_bash`/`post_bash`/`post_file`/`session_start`/`agent`/`stop`) back to the shipped
+> canonical set — stale/extra entries you added there are **dropped**, not merged. Put your own
+> push-time checks in `hooks.pre_push_commands`, which is deliberately excluded from this reconcile
+> and preserved verbatim — it is the user escape hatch for custom checks.
+
 ## How reads work
 
 Hooks call `_framework_config.config(input_data).get("dotted.key", default)`.

--- a/framework/harness/real_provision.py
+++ b/framework/harness/real_provision.py
@@ -259,12 +259,38 @@ def _write_meta_yaml(wd: Path, spec: RealFixtureSpec) -> Path:
     return yaml
 
 
+def _guard_zero_children(spec: RealFixtureSpec, opts: dict) -> None:
+    """#155 item 4 / #244: handle a ``meta-and-children`` spec provisioned with no children.
+
+    A bare ``--include-real`` B10 with no ``--real-config`` resolves to a degenerate
+    zero-children meta install. By DEFAULT this is surfaced with a ``warnings.warn`` and the
+    trivial install proceeds — a childless meta is a valid (if trivial) install, and a smoke-test
+    ``--include-real`` run should degrade rather than crash. A real provisioning run that MUST have
+    children (``#101``/``#109``) can opt into a HARD guard with ``opts['real_require_children']``:
+    the harness then raises ``MissingFixtureError`` (degraded to a *skip* by the runner) instead of
+    shipping the degenerate zero-children install, so a misconfigured real run fails visibly rather
+    than silently provisioning an empty meta.
+    """
+    if opts.get("real_require_children"):
+        raise MissingFixtureError(
+            f"real fixture {spec.bucket!r} is meta-and-children with zero children and "
+            "real_require_children is set — refusing the degenerate zero-children meta install; "
+            "supply children via --real-config (#155 item 4 / #244)."
+        )
+    warnings.warn(
+        f"real fixture {spec.bucket!r} is meta-and-children with zero children — "
+        "degenerate meta install; supply children via --real-config (#155 item 4 / #244).",
+        stacklevel=3,
+    )
+
+
 def provision_real(spec: RealFixtureSpec | None, wd: Path, opts: dict | None = None) -> dict:
     """Clone ``spec``'s source (+ children for meta) at its pin into ``wd``; return fixture ctx.
 
     Read-only w.r.t. the source and asserted so: every local source's ``{head, porcelain}`` is
     fingerprinted before and after and must be byte-identical (``SourceMutatedError`` otherwise).
     """
+    opts = opts or {}
     if spec is None:
         raise MissingFixtureError("no real-fixture spec registered for this bucket")
 
@@ -288,15 +314,10 @@ def provision_real(spec: RealFixtureSpec | None, wd: Path, opts: dict | None = N
 
         if spec.model == "meta-and-children":
             if not spec.children:
-                # #155 item 4: a bare --include-real B10 with no --real-config resolves to a
-                # degenerate zero-children meta install. Not fatal (a childless meta is a valid,
-                # if trivial, install), but surface it instead of silently degrading — #101
-                # supplies children explicitly via --real-config.
-                warnings.warn(
-                    f"real fixture {spec.bucket!r} is meta-and-children with zero children — "
-                    "degenerate meta install; supply children via --real-config (#155 item 4).",
-                    stacklevel=2,
-                )
+                # #155 item 4 / #244: a bare --include-real B10 with no --real-config resolves to
+                # a degenerate zero-children meta install. Default = warn-and-proceed; opt into a
+                # hard MissingFixtureError guard via opts['real_require_children'] (see helper).
+                _guard_zero_children(spec, opts)
             children_ctx = []
             for child in spec.children:
                 child_sha = resolve_pin(child.source, child.ref, child.pin)
@@ -329,8 +350,9 @@ def real_registry(opts: dict | None = None) -> dict[str, RealFixtureSpec]:
     keys and preserves the rest of the existing bucket spec, so overriding just ``pin`` no longer
     silently drops ``children`` back to ``()``. A full ``RealFixtureSpec`` value in
     ``real_fixtures`` is still an explicit whole-spec replacement (back-compat for callers that
-    build a complete spec). A partial patch for a bucket with no existing/default spec must carry
-    a ``source`` (falls back to ``from_dict``).
+    build a complete spec). A partial patch for a bucket with no existing/default spec creates a
+    brand-new bucket and therefore MUST carry a ``source`` — a source-less new-bucket patch raises
+    a friendly ``MissingFixtureError`` naming the bucket (#243) rather than a bare ``KeyError``.
     """
     opts = opts or {}
     reg = dict(DEFAULT_REAL_FIXTURES)
@@ -340,6 +362,15 @@ def real_registry(opts: dict | None = None) -> dict[str, RealFixtureSpec]:
             reg[bucket] = override                       # explicit whole-spec replacement
         elif bucket in reg:
             reg[bucket] = reg[bucket].merge(override)     # partial patch merges onto existing
+        elif "source" not in override:
+            # #243: a partial patch that CREATES a new bucket must carry a 'source'. Without it,
+            # from_dict() would raise a bare KeyError('source'); surface a friendly, actionable
+            # message naming the bucket instead (MissingFixtureError -> runner degrades to a skip).
+            raise MissingFixtureError(
+                f"real fixture override for new bucket {bucket!r} is a partial patch with no "
+                "'source' key; creating a new bucket requires a 'source' (a local path or git "
+                "remote URL). Add a 'source', or patch an already-registered bucket."
+            )
         else:
             reg[bucket] = RealFixtureSpec.from_dict(bucket, override)  # brand-new bucket
 

--- a/framework/tests/test_real_provision.py
+++ b/framework/tests/test_real_provision.py
@@ -319,6 +319,33 @@ def test_meta_with_children_does_not_warn(tmp_path: Path) -> None:
     assert [c["path"] for c in ctx["child"]["children"]] == ["api"]
 
 
+def test_meta_zero_children_strict_guard_raises(tmp_path: Path) -> None:
+    """#244: the zero-children case has a STRONGER, opt-in guard. With
+    ``opts['real_require_children']`` set, a degenerate zero-children ``meta-and-children`` provision
+    must RAISE ``MissingFixtureError`` (runner degrades to a skip) instead of shipping the empty meta
+    install — a real run that must have children fails visibly rather than silently provisioning
+    nothing. Load-bearing: remove the ``real_require_children`` branch in ``_guard_zero_children`` and
+    this provision no longer raises (it only warns), so ``pytest.raises`` finds nothing and FAILS."""
+    parent = tmp_path / "parent"
+    _make_repo(parent, {"pyproject.toml": "[project]\nname='root'\n"})
+    spec = RealFixtureSpec(bucket="B10", source=str(parent), model="meta-and-children", children=())
+
+    with pytest.raises(MissingFixtureError, match=r"zero children"):
+        provision_real(spec, tmp_path / "wd", opts={"real_require_children": True})
+
+
+def test_meta_zero_children_strict_guard_default_off(tmp_path: Path) -> None:
+    """Control for #244: WITHOUT ``real_require_children`` the guard stays a warn-and-proceed (the
+    legitimate bare ``--include-real`` smoke-test flow), so the hard guard is genuinely opt-in and
+    does not change the default behavior."""
+    parent = tmp_path / "parent"
+    _make_repo(parent, {"pyproject.toml": "[project]\nname='root'\n"})
+    spec = RealFixtureSpec(bucket="B10", source=str(parent), model="meta-and-children", children=())
+    with pytest.warns(UserWarning, match=r"zero children"):
+        ctx = provision_real(spec, tmp_path / "wd", opts={"real_require_children": False})
+    assert ctx["child"]["children"] == []  # still a (trivial) degenerate install, not a raise
+
+
 def test_include_real_executes_b10_meta_path_all_green(tmp_path: Path) -> None:
     parent = tmp_path / "parent"
     _make_repo(parent, {"pyproject.toml": "[project]\nname='root'\n"})
@@ -363,6 +390,27 @@ def test_registry_default_and_sidecar_override(tmp_path: Path) -> None:
     assert reg["B11"].source == "/x" and reg["B11"].pin == "abc123"
     assert reg["B11"].ref == "refs/heads/release"
     assert reg["B10"].model == "meta-and-children"  # untouched default survives
+
+
+def test_new_bucket_partial_patch_without_source_friendly_error(tmp_path: Path) -> None:
+    """#243: a ``--real-config`` / ``real_fixtures`` partial patch that CREATES a new bucket (one not
+    in the defaults) with no ``source`` key must raise a friendly ``MissingFixtureError`` NAMING the
+    bucket and asking for a ``source`` — not the bare ``KeyError('source')`` the unconditional
+    ``from_dict`` used to raise. Load-bearing: drop the ``'source' not in override`` guard in
+    ``_apply`` and the call raises a bare ``KeyError`` (not ``MissingFixtureError``), so this fails."""
+    # (a) via the sidecar JSON
+    sidecar = tmp_path / "real.json"
+    sidecar.write_text('{"BZ9": {"pin": "cafef00d", "ref": "refs/heads/main"}}', encoding="utf-8")
+    with pytest.raises(MissingFixtureError, match=r"BZ9.*source"):
+        real_provision.real_registry({"real_config": str(sidecar)})
+
+    # (b) via real_fixtures as a dict
+    with pytest.raises(MissingFixtureError, match=r"BZ9.*source"):
+        real_provision.real_registry({"real_fixtures": {"BZ9": {"pin": "beadfeed"}}})
+
+    # a new bucket that DOES carry a source still works (guard is scoped to the missing-source case)
+    ok = real_provision.real_registry({"real_fixtures": {"BZ9": {"source": "/some/repo"}}})
+    assert ok["BZ9"].source == "/some/repo"
 
 
 # --------------------------------------------------------------- #155 item 1: partial-clone invariant


### PR DESCRIPTION
## Summary
- **#243** — a `--real-config` / `real_fixtures` partial patch that CREATES a new bucket (one not in the defaults) with no `source` now raises a friendly `MissingFixtureError` naming the bucket, instead of the bare `KeyError('source')` the unconditional `from_dict` raised (runner degrades it to a skip).
- **#244** — strengthen the degenerate zero-children `meta-and-children` guard. Default stays warn-and-proceed (the legitimate bare `--include-real` B10 smoke-test flow should degrade, not crash); a real run opts into a HARD guard via `opts['real_require_children']`, which raises `MissingFixtureError` (runner skip) rather than silently provisioning an empty meta install. Branch extracted into `_guard_zero_children`.
- **#242** — one-line note in `framework/config/README.md`: the amend/upgrade path's `reconcile_module_lists()` deliberately resets the framework-owned hook lists (`pre_bash`/`post_bash`/`post_file`/`session_start`/`agent`/`stop`) to canonical on re-install (user entries dropped); `hooks.pre_push_commands` is the escape hatch.

**#244 design decision (justification):** kept-and-strengthened rather than a blanket hard error. A bare `--include-real` B10 with no `--real-config` is a legitimate smoke-test flow — a childless meta is a valid-if-trivial install — so hard-erroring it by default would break that flow. The stronger guard is therefore opt-in: real provisioning runs that MUST have children (#101/#109) set `real_require_children` and get a visible `MissingFixtureError`; everyone else keeps the clearly-surfaced warning.

**Load-bearing tests** (both fail on revert, verified):
- `test_new_bucket_partial_patch_without_source_friendly_error` — revert the `'source' not in override` guard → bare `KeyError` (not `MissingFixtureError`) → fails.
- `test_meta_zero_children_strict_guard_raises` (+ `_default_off` control) — revert the `real_require_children` branch → warn-only, no raise → `pytest.raises` finds nothing → fails.

Docs-only file (`config/README.md`) is single-homed (framework source of truth, not a byte-mirrored tree); `reinstall.py --check` is green — no source↔runtime drift. Full suite: 812 passed; `ruff check framework/` clean.

## Related Issues
Closes #243
Closes #244
Closes #242

## Review Checklist
- [ ] Reviewed by another team member
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)
