### PR TITLE
fix(node): dedupe on bare names + seedable RNG, drop CI retry (#234)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,18 +80,8 @@ jobs:
 
       - name: Test
         working-directory: node
-        # QUARANTINE (#230): the node suite is nondeterministic. `generateName`
-        # in src/bootstrap.ts dedupes candidate names against a `used` set built
-        # from ROLE-PREFIXED roster filenames ("senior_engineer_jane_doe" ->
-        # "senior engineer jane doe"), never against bare "First Last" names, so
-        # it never actually rejects a real duplicate. Unseeded Math.random() name
-        # generation therefore collides at random, surfacing as a spurious red on
-        # whichever matrix shard happens to draw the collision (W13: "node (20)";
-        # the shard is incidental, not node-20-specific). `--retry=2` re-runs a
-        # failed test up to twice: a genuine, reproducible break still fails all
-        # attempts and goes red (node coverage is preserved and still required),
-        # while a one-off collision self-heals instead of manufacturing a false
-        # ci-red that slips a merge. The real fix — seed the RNG / dedupe on bare
-        # names, then REMOVE this --retry — is tracked as #234 (product change in
-        # node/src, out of this QA story's lane).
-        run: npm test -- --run --retry=2
+        # The #230 --retry=2 quarantine was removed in #234 once the root cause
+        # was fixed: generateName now dedupes candidates against bare "First Last"
+        # names parsed from each roster card (not role-prefixed filenames), and
+        # the RNG is seedable, so the suite is deterministic and needs no retry.
+        run: npm test -- --run

--- a/node/src/bootstrap.ts
+++ b/node/src/bootstrap.ts
@@ -117,18 +117,87 @@ export const COMMUNICATION_STYLES = [
   "Measured and diplomatic. Navigates disagreements with tact.",
 ];
 
-function randomChoice<T>(arr: T[]): T {
-  return arr[Math.floor(Math.random() * arr.length)];
+// ---------------------------------------------------------------------------
+// Seedable RNG
+//
+// The name/persona pickers used to call `Math.random()` directly, which made
+// the vitest suite nondeterministic (#234). The RNG is now a single injectable
+// generator: production keeps `Math.random`, while tests seed it via
+// `setRng(makeSeededRng(n))` for reproducible, flake-free runs.
+// ---------------------------------------------------------------------------
+
+/** A random generator: returns a float in [0, 1), like `Math.random`. */
+export type Rng = () => number;
+
+let _rng: Rng = Math.random;
+
+/** Override the module-level RNG (e.g. a seeded generator in tests). */
+export function setRng(rng: Rng): void {
+  _rng = rng;
 }
 
-export function generateName(used: Set<string>): [string, string] {
+/** Restore the default `Math.random` RNG. */
+export function resetRng(): void {
+  _rng = Math.random;
+}
+
+/**
+ * Deterministic PRNG (mulberry32) — same seed always yields the same stream,
+ * so a seeded run of the name generator is fully reproducible.
+ */
+export function makeSeededRng(seed: number): Rng {
+  let a = seed >>> 0;
+  return function () {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function randomChoice<T>(arr: T[], rng: Rng = _rng): T {
+  return arr[Math.floor(rng() * arr.length)];
+}
+
+export function generateName(
+  used: Set<string>,
+  rng: Rng = _rng,
+): [string, string] {
   for (let i = 0; i < 100; i++) {
-    const first = randomChoice(FIRST_NAMES);
-    const last = randomChoice(LAST_NAMES);
+    const first = randomChoice(FIRST_NAMES, rng);
+    const last = randomChoice(LAST_NAMES, rng);
     const full = `${first} ${last}`;
     if (!used.has(full)) return [first, last];
   }
   throw new Error("Could not generate unique name");
+}
+
+/**
+ * Build the set of bare `First Last` names already on the roster, for
+ * `generateName` dedupe. Historically callers built this set from ROLE-PREFIXED
+ * roster FILENAMES (e.g. `senior_engineer_jane_doe.md` -> "senior engineer jane
+ * doe"), which never matched a bare "Jane Doe" candidate — so `generateName`
+ * could hand back a name already on the roster (#234). We now parse the actual
+ * `**Name:**` field out of each roster card so a generated duplicate is
+ * genuinely rejected. Departed cards are included so a departed member's name is
+ * not immediately recycled; a card whose name cannot be parsed falls back to the
+ * legacy filename-derived string (still better than dropping it entirely).
+ */
+export function usedNamesFromRoster(rosterDir: string): Set<string> {
+  const used = new Set<string>();
+  if (!existsSync(rosterDir)) return used;
+  for (const f of readdirSync(rosterDir).filter((f) => f.endsWith(".md"))) {
+    const stem = f.replace(/^_departed_/, "").replace(/\.md$/, "");
+    let name: string | null = null;
+    try {
+      name = extractField(readFileSync(join(rosterDir, f), "utf-8"), "Name");
+    } catch {
+      name = null;
+    }
+    used.add(name && name.trim() ? name.trim() : stem.replace(/_/g, " "));
+  }
+  return used;
 }
 
 export function makeEmail(first: string, last: string, prefix: string = ""): string {
@@ -611,11 +680,7 @@ export function addMember(opts: AddMemberOptions): void {
 
   let name = opts.name;
   if (!name) {
-    const used = new Set<string>();
-    for (const f of readdirSync(rosterDir).filter((f) => f.endsWith(".md"))) {
-      used.add(f.replace(/\.md$/, "").replace(/_/g, " "));
-    }
-    const [first, last] = generateName(used);
+    const [first, last] = generateName(usedNamesFromRoster(rosterDir));
     name = `${first} ${last}`;
   }
 
@@ -755,12 +820,8 @@ export function randomizeMember(opts: { name: string; target: string }): void {
   // Archive old
   renameSync(oldPath, join(rosterDir, `_departed_${files[0]}`));
 
-  // Generate new identity
-  const used = new Set<string>();
-  for (const f of readdirSync(rosterDir).filter((f) => f.endsWith(".md"))) {
-    used.add(f.replace(/\.md$/, "").replace(/_/g, " "));
-  }
-  const [first, last] = generateName(used);
+  // Generate new identity (dedupe against bare roster names, not filenames)
+  const [first, last] = generateName(usedNamesFromRoster(rosterDir));
   const newName = `${first} ${last}`;
   const email = makeEmail(first, last);
 

--- a/node/tests/cli.test.ts
+++ b/node/tests/cli.test.ts
@@ -57,6 +57,10 @@ import {
   FIRST_NAMES,
   LAST_NAMES,
   COMMUNICATION_STYLES,
+  usedNamesFromRoster,
+  setRng,
+  resetRng,
+  makeSeededRng,
 } from "../src/bootstrap.js";
 import { getPreset, listPresets as listPresetsFromModule } from "../src/presets.js";
 import {
@@ -269,6 +273,122 @@ describe("name generation", () => {
     expect(FIRST_NAMES.length).toBeGreaterThan(0);
     expect(LAST_NAMES.length).toBeGreaterThan(0);
     expect(COMMUNICATION_STYLES.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dedupe root-cause + seedable RNG (#234)
+//
+// These are the load-bearing regression tests: each FAILS if the fix is
+// reverted. `Aisha` is FIRST_NAMES[0] and `Rossi` is LAST_NAMES[18], so a
+// scripted RNG that emits [0, 0.37, ...] draws the pair "Aisha Rossi".
+// ---------------------------------------------------------------------------
+
+/** A deterministic RNG that replays `values` (cycling), for exact draws. */
+function scriptedRng(values: number[]): () => number {
+  let i = 0;
+  return () => values[i++ % values.length];
+}
+
+describe("generateName dedupe compares bare names (#234)", () => {
+  afterEach(() => resetRng());
+
+  it("usedNamesFromRoster parses bare `First Last`, not role-prefixed filenames", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "test-usednames-"));
+    const rosterDir = join(tmp, ".claude", "team", "roster");
+    mkdirSync(rosterDir, { recursive: true });
+    // Filename is ROLE-PREFIXED; the card body carries the bare name.
+    writeFileSync(
+      join(rosterDir, "senior_engineer_jane_doe.md"),
+      "## Identity\n- **Name:** Jane Doe\n- **Role:** Software Engineer\n",
+    );
+    const used = usedNamesFromRoster(rosterDir);
+    // The fix: the set holds the bare name a candidate is actually compared to.
+    expect(used.has("Jane Doe")).toBe(true);
+    // The bug: the pre-fix set held the role-prefixed filename string, which
+    // never matches a bare "First Last" candidate.
+    expect(used.has("senior engineer jane doe")).toBe(false);
+    rmSync(tmp, { recursive: true });
+  });
+
+  it("generateName rejects a candidate already on the roster", () => {
+    // used holds the BARE name, exactly as usedNamesFromRoster now produces it.
+    const used = new Set<string>(["Aisha Rossi"]);
+    // First draw = "Aisha Rossi" (collision -> must be rejected), second draw =
+    // "Amara Asante" (FIRST_NAMES[1]/LAST_NAMES[0]).
+    const rng = scriptedRng([0, 0.37, 0.02, 0]);
+    const [first, last] = generateName(used, rng);
+    expect(`${first} ${last}`).toBe("Amara Asante");
+    expect(`${first} ${last}`).not.toBe("Aisha Rossi");
+  });
+
+  it("addMember(random) does not recreate a name already on the roster", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "test-add-dedupe-"));
+    const rosterDir = join(tmp, ".claude", "team", "roster");
+    mkdirSync(rosterDir, { recursive: true });
+    // Existing member whose filename would collide iff the draw repeats it.
+    writeFileSync(
+      join(rosterDir, "qa_engineer_aisha_rossi.md"),
+      "## Identity\n- **Name:** Aisha Rossi\n- **Role:** QA Engineer\n",
+    );
+    // Force the first random draw to be the existing "Aisha Rossi".
+    setRng(scriptedRng([0, 0.37, 0.02, 0]));
+    addMember({ role: "QA Engineer", level: "Senior", target: tmp });
+
+    const active = readdirSync(rosterDir).filter(
+      (f) => f.endsWith(".md") && !f.startsWith("_departed_"),
+    );
+    // Pre-fix, the drawn duplicate "Aisha Rossi" would overwrite the existing
+    // card -> still 1 card. Post-fix, the collision is rejected and a distinct
+    // member is added -> 2 cards.
+    expect(active.length).toBe(2);
+    expect(active).toContain("qa_engineer_amara_asante.md");
+    rmSync(tmp, { recursive: true });
+  });
+});
+
+describe("seedable RNG is reproducible (#234)", () => {
+  afterEach(() => resetRng());
+
+  it("makeSeededRng: same seed yields the same generateName sequence", () => {
+    const draw = (seed: number): string[] => {
+      const rng = makeSeededRng(seed);
+      const used = new Set<string>();
+      const out: string[] = [];
+      for (let i = 0; i < 8; i++) {
+        const [f, l] = generateName(used, rng);
+        const full = `${f} ${l}`;
+        used.add(full);
+        out.push(full);
+      }
+      return out;
+    };
+    const a = draw(1234);
+    const b = draw(1234);
+    const c = draw(9999);
+    expect(a).toEqual(b); // reproducible under a fixed seed
+    expect(a).not.toEqual(c); // a different seed diverges
+  });
+
+  it("setRng makes a full team generation deterministic across runs", () => {
+    // The whole point of #234: no flake. With a fixed seed the generated roster
+    // is byte-for-byte identical run to run, and every name is unique.
+    const generate = (): string[] => {
+      setRng(makeSeededRng(42));
+      const used = new Set<string>();
+      const names: string[] = [];
+      for (let i = 0; i < 20; i++) {
+        const [f, l] = generateName(used);
+        const full = `${f} ${l}`;
+        used.add(full);
+        names.push(full);
+      }
+      return names;
+    };
+    const run1 = generate();
+    const run2 = generate();
+    expect(run1).toEqual(run2);
+    expect(new Set(run1).size).toBe(run1.length); // all unique — no collision
   });
 });
 


### PR DESCRIPTION
## Summary
- **Dedupe root cause (the real bug):** `addMember`/`randomizeMember` built `generateName`'s `used` set from ROLE-PREFIXED roster *filenames* (`senior_engineer_jane_doe.md` → `"senior engineer jane doe"`), so `used.has("First Last")` never matched a real member and a generated duplicate was silently accepted. New `usedNamesFromRoster` parses the bare `**Name:**` field out of each roster card; both callers now route through it.
- **Seedable RNG:** name/persona pickers called `Math.random()` directly → nondeterministic runs. Introduced a single injectable generator (`setRng` / `resetRng` / `makeSeededRng` — mulberry32); production still defaults to `Math.random`, tests seed for reproducibility.
- **Quarantine removed:** dropped the #230 `--retry=2` vitest quarantine from `.github/workflows/ci.yml` now that the root cause is fixed.

## Determinism evidence
- Suite run **15/15 clean** locally (`npx vitest --run`), zero flakes, before removing the retry.
- Revert-check: reverting the dedupe fix makes both load-bearing dedupe tests FAIL (2 failed / 135 passed); restored → 137 passed.

## Load-bearing tests (fail if the fix is reverted)
- `usedNamesFromRoster` parses bare `First Last`, not the role-prefixed filename.
- `generateName` rejects a candidate already on the roster (scripted RNG forces the collision).
- `addMember(random)` does not recreate a name already on the roster (2 cards post-fix vs 1 pre-fix).
- Seeded RNG: same seed yields the same `generateName` sequence; a full seeded team generation is identical run-to-run and collision-free.

## Related Issues
Closes #234

## Review Checklist
- [ ] Reviewed by another team member
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)
