### PR TITLE
S2: Rollup-hygiene runbook step — codify the W11 stale-local-branch slip (#255)

### DIFF
--- a/.claude/skills/wave-end/SKILL.md
+++ b/.claude/skills/wave-end/SKILL.md
@@ -72,7 +72,12 @@ and reads the counters recorded here.
 4. Run `git worktree prune`
 5. Scan docs/ and diagrams for staleness against changes
 6. If this is the final wave of the phase, create a PR to the default branch (User
-   approval gate applies — never merge without sign-off)
+   approval gate applies — never merge without sign-off). When that rollup is landed,
+   follow the **rollup pre-flight** in
+   [pull-requests.md](../../team/charter/pull-requests.md): `git fetch origin` and merge
+   `origin/<wave>` **explicitly** (never a stale local ref), then verify feature-code is on
+   the merge parent (`git show <default-branch>:<file> | grep -c <new-symbol>`) BEFORE
+   bump/release — a code-less rollup (state.json only) is a stop-and-investigate.
 7. Hand off to `/wave-retro` — trust deltas, the forced negative-signal pass, the
    feedback-log entry, process proposals, and the next-wave stub all live there, not here.
 

--- a/.claude/team/.charter-manifest.json
+++ b/.claude/team/.charter-manifest.json
@@ -7,7 +7,7 @@
     "commits.md": "c9d5e7349f0ead70cb37dd8cf20a7753fe3bea5c943ad56fe3f661dc4daaab67",
     "hooks.md": "77d72942082cf0dd1fb45da686376d8813d3e2b30ebe1ec4f99e432ef0fdb1d5",
     "issues.md": "18d7a6a6e31112abad5ae6f92635c268168cce750b3372aacfa9d875f3dfbc9d",
-    "pull-requests.md": "6a38fed814bcdabb89bf63c78b68b241d23d0a923a7bef8034cdc341c61b783d",
+    "pull-requests.md": "86eb6d9592c9e607e982d66cf9483391bb2319a5daaca1b82a6ea952f2baa99a",
     "skills.md": "dcc93b623b5f62cbac412634d4d3b04c3731c5a4a0892dd3227c70241703e81e"
   }
 }

--- a/.claude/team/charter/pull-requests.md
+++ b/.claude/team/charter/pull-requests.md
@@ -258,11 +258,39 @@ The sanctioned way to land it is a **direct-push merge** — a direct push to
 is ungated by construction:
 
 ```bash
+git fetch origin                                     # refresh the remote wave tip FIRST
 git checkout main && git pull
-git merge --no-ff <integration-branch>          # e.g. deployments/phaseN/wave-M
+git merge --no-ff origin/<integration-branch>        # the REMOTE ref (e.g. origin/deployments/phaseN/wave-M) — never a stale local ref
 git -c user.name="<Manager>" -c user.email="<...>" commit   # only if the merge needs one
 git push origin main
 ```
+
+### Rollup pre-flight: merge `origin/<wave>`, never a stale LOCAL ref, then verify code landed
+
+The story PRs merge into the wave branch **server-side** (`origin/…`); a local
+`deployments/phaseN/wave-M` ref that was never fast-forwarded is **stale**, and merging that
+bare local name gives `main` a **code-less** rollup (only `state.json` moves).
+Before the merge above:
+
+1. **`git fetch origin`** so the remote wave tip is local.
+2. Merge the **remote-tracking** ref explicitly — `git merge --no-ff origin/<integration-branch>`
+   — or fast-forward the local ref first
+   (`git branch -f <integration-branch> origin/<integration-branch>`); never merge the
+   possibly-stale bare local branch name.
+3. **Verify feature-code is on the merge parent BEFORE bump/release.** Grep a known new
+   symbol from this wave on `main`:
+
+   ```bash
+   git show main:<path/to/changed/file> | grep -c '<new-symbol>'
+   ```
+
+   A non-zero count confirms the feature code landed. A rollup that moved only `state.json`
+   (grep count `0`) is a **STOP-and-investigate**: you almost certainly merged a stale local
+   ref — re-run from step 1 against `origin/<wave>` before tagging or releasing.
+
+(Codified from the Phase 6 Wave 11 slip: the first rollup merged a stale local wave ref, so
+`main` got a code-less merge — caught only by a post-merge content probe and
+fixed by merging `origin/<wave>` before bump/release. #255.)
 
 GitHub auto-marks the rollup PR **MERGED** once its head commits reach
 `main`. This is the escape hatch for the rollup specifically — it does **not**

--- a/framework/assets/skills/wave-end/SKILL.md
+++ b/framework/assets/skills/wave-end/SKILL.md
@@ -72,7 +72,12 @@ and reads the counters recorded here.
 4. Run `git worktree prune`
 5. Scan docs/ and diagrams for staleness against changes
 6. If this is the final wave of the phase, create a PR to the default branch (User
-   approval gate applies — never merge without sign-off)
+   approval gate applies — never merge without sign-off). When that rollup is landed,
+   follow the **rollup pre-flight** in
+   [pull-requests.md](../../team/charter/pull-requests.md): `git fetch origin` and merge
+   `origin/<wave>` **explicitly** (never a stale local ref), then verify feature-code is on
+   the merge parent (`git show <default-branch>:<file> | grep -c <new-symbol>`) BEFORE
+   bump/release — a code-less rollup (state.json only) is a stop-and-investigate.
 7. Hand off to `/wave-retro` — trust deltas, the forced negative-signal pass, the
    feedback-log entry, process proposals, and the next-wave stub all live there, not here.
 

--- a/framework/assets/team/charter/pull-requests.md
+++ b/framework/assets/team/charter/pull-requests.md
@@ -258,11 +258,39 @@ The sanctioned way to land it is a **direct-push merge** — a direct push to
 is ungated by construction:
 
 ```bash
+git fetch origin                                     # refresh the remote wave tip FIRST
 git checkout {{default_branch}} && git pull
-git merge --no-ff <integration-branch>          # e.g. deployments/phaseN/wave-M
+git merge --no-ff origin/<integration-branch>        # the REMOTE ref (e.g. origin/deployments/phaseN/wave-M) — never a stale local ref
 git -c user.name="<Manager>" -c user.email="<...>" commit   # only if the merge needs one
 git push origin {{default_branch}}
 ```
+
+### Rollup pre-flight: merge `origin/<wave>`, never a stale LOCAL ref, then verify code landed
+
+The story PRs merge into the wave branch **server-side** (`origin/…`); a local
+`deployments/phaseN/wave-M` ref that was never fast-forwarded is **stale**, and merging that
+bare local name gives `{{default_branch}}` a **code-less** rollup (only `state.json` moves).
+Before the merge above:
+
+1. **`git fetch origin`** so the remote wave tip is local.
+2. Merge the **remote-tracking** ref explicitly — `git merge --no-ff origin/<integration-branch>`
+   — or fast-forward the local ref first
+   (`git branch -f <integration-branch> origin/<integration-branch>`); never merge the
+   possibly-stale bare local branch name.
+3. **Verify feature-code is on the merge parent BEFORE bump/release.** Grep a known new
+   symbol from this wave on `{{default_branch}}`:
+
+   ```bash
+   git show {{default_branch}}:<path/to/changed/file> | grep -c '<new-symbol>'
+   ```
+
+   A non-zero count confirms the feature code landed. A rollup that moved only `state.json`
+   (grep count `0`) is a **STOP-and-investigate**: you almost certainly merged a stale local
+   ref — re-run from step 1 against `origin/<wave>` before tagging or releasing.
+
+(Codified from the Phase 6 Wave 11 slip: the first rollup merged a stale local wave ref, so
+`{{default_branch}}` got a code-less merge — caught only by a post-merge content probe and
+fixed by merging `origin/<wave>` before bump/release. #255.)
 
 GitHub auto-marks the rollup PR **MERGED** once its head commits reach
 `{{default_branch}}`. This is the escape hatch for the rollup specifically — it does **not**


### PR DESCRIPTION
## Summary

Codifies the Phase 6 Wave 11 rollup slip as an explicit, mechanical **rollup pre-flight**
in the merge-to-main runbook so it can't recur.

**The slip this prevents:** Wave 11's first rollup merged a STALE LOCAL
`deployments/phase6/wave-11` ref. The story PRs had merged into `origin/…` server-side, but
the local ref was never fast-forwarded, so `main` got a **code-less** merge (only
`state.json`). It was caught by a post-merge content probe and fixed by merging
`origin/<wave>` before bump/release.

**The runbook step added** (charter `pull-requests.md`, rollup escape-hatch section):

1. `git fetch origin` BEFORE the rollup merge (now embedded in the escape-hatch command block).
2. Merge `origin/<integration-branch>` **explicitly** — `git merge --no-ff origin/<...>` (or
   `git branch -f <wave> origin/<wave>` first) — never the possibly-stale bare local ref.
3. **Verify feature-code is on the merge parent BEFORE bump/release:**
   `git show main:<path/to/changed/file> | grep -c '<new-symbol>'`. A non-zero count confirms
   the code landed; a rollup that moved only `state.json` (grep `0`) is a
   **STOP-and-investigate** — re-run from step 1 against `origin/<wave>`.

The authoritative step lives in the charter; `wave-end` SKILL.md step 6 carries a short
pointer/echo to it (matching the existing charter-link structure), so the operator hits the
guard where the rollup PR is actually created.

## Dual-tree byte-parity confirmation

The charter is template-rendered, so its two trees are intentionally NOT raw-byte-identical
(`framework/assets/` uses `{{default_branch}}`; `.claude/` renders `main`). The authoritative
parity check is `charter_drift.plan()`:

- **Charter** — canonical `framework/assets/team/charter/pull-requests.md` edited with
  `{{default_branch}}` placeholders; this repo's `.claude/` copy + `.charter-manifest.json`
  re-rendered via `install_charter(force=True)`.
  `python3 framework/install/charter_drift.py --check` → **rc 0** (`plan() == []`).
- **wave-end SKILL.md** — byte-mirrored tree:
  `diff .claude/skills/wave-end/SKILL.md framework/assets/skills/wave-end/SKILL.md` →
  **empty** (parity OK).

## Verification

- `python3 framework/install/reinstall.py --check` → in sync.
- Full suite: **812 passed** (`framework/tests/`), incl. `test_charter_drift.py`,
  `test_skill_parity.py`, `test_reinstall_parity.py`.
- `ruff check framework/` → all checks passed.

## Files changed

- `framework/assets/team/charter/pull-requests.md` (canonical, `{{default_branch}}`)
- `.claude/team/charter/pull-requests.md` (re-rendered runtime copy)
- `.claude/team/.charter-manifest.json` (pull-requests.md checksum only)
- `framework/assets/skills/wave-end/SKILL.md` + `.claude/skills/wave-end/SKILL.md` (byte-identical)

## Related Issues

Closes #255

## Review Checklist
- [ ] Reviewed by another team member
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)
