### PR TITLE
S1: Symmetric trust scoring — verified_reviews + rework/must-fix downward signals (#254)

### DIFF
--- a/.claude/skills/wave-retro/SKILL.md
+++ b/.claude/skills/wave-retro/SKILL.md
@@ -165,9 +165,11 @@ PR as the feedback log — never as a separate direct-to-default commit.
 Every row applies the mechanical policy from `trust_signals.py` and cites its numbers:
 
 - **Delta:** `new = clamp(old + delta, 1, 5)` — bidirectional, already clamped to ±2 per
-  wave by `score_delta`. Each CI-red merge / review false-positive is −1; 3+ must-fix
-  received is −1; a clean wave with 2+ PRs merged or 2+ must-fix caught as reviewer is +1
-  each. A single clean PR is **not** a bump.
+  wave by `score_delta`. Each CI-red merge / review false-positive is −1; 2+ must-fix
+  received is −1; 2+ rework cycles is −1; a clean wave with 2+ PRs merged, 2+ must-fix
+  caught as reviewer, or 2+ verified reviews (reviewer verdicts carrying a concrete
+  `Verified:` block) is +1 each — so QA rigor isn't zero-credit when there are no
+  must-fixes. A single clean PR is **not** a bump.
 - **Decay toward neutral:** an engineer with no signal for 3 consecutive waves drifts one
   step toward 3 (`trust_signals.decay(old, waves_since_signal)`). A stale 4 or 2 is no
   longer earned; decay is one step per retro, never a reset.

--- a/framework/assets/lib/trust_signals.py
+++ b/framework/assets/lib/trust_signals.py
@@ -108,6 +108,11 @@ Signals per engineer (all integers, all countable from the merged-PR set):
   review_false_positives       must-fix items they raised that were later
                                marked withdrawn/false-positive (negative —
                                review-quality signal).
+  verified_reviews             clean verdicts they issued as Requestor whose
+                               body carried a concrete ``Verified:`` block
+                               (>=1 real check, e.g. revert→red / Nx
+                               determinism / byte-parity) (positive —
+                               QA-rigor review signal).
   difficulty_points            summed coarse difficulty weight (1-3 per PR,
                                :func:`difficulty_weight`) over authored PRs;
                                feeds the reserved-5 tiebreak, not score_delta.
@@ -196,6 +201,28 @@ _MUST_FIX_LABEL_RE = re.compile(r"^\s*\**must[\s-]?fix\**:\s*(.*?)\s*$", re.IGNO
 _LIST_ITEM_RE = re.compile(r"^\s*(?:\d+[.)]|[-*+])\s+\S")
 _EMPTY_MUST_FIX_RE = re.compile(r"^(none|n/?a|-+|0)(?:\W|$)", re.IGNORECASE)
 
+# A reviewer's clean verdict may carry a ``Verified:`` block enumerating the
+# concrete checks they actually ran (the QA-rigor receipt). ``_VERIFIED_LABEL_RE``
+# matches that label line and captures any same-line remainder; the block runs
+# until a blank line or the next charter section label (``_SECTION_LABEL_RE``).
+# ``_VERIFIED_CHECK_RE`` recognizes >=1 CONCRETE verification token inside that
+# block — a boilerplate / empty ``Verified:`` with no such token does not count
+# (anti-gaming).
+_VERIFIED_LABEL_RE = re.compile(r"^\s*\**verified\**:\s*(.*?)\s*$", re.IGNORECASE)
+_SECTION_LABEL_RE = re.compile(
+    r"^\s*\**(?:requestor|requestee|requestorreplied|must[\s-]?fix|tech[\s-]?debt|review)\b",
+    re.IGNORECASE,
+)
+_VERIFIED_CHECK_RE = re.compile(
+    r"revert\s*(?:→|-+|to)?\s*red"  # revert→red / revert to red / revert-red
+    r"|byte[\s-]?parity"  # byte-parity
+    r"|\d+\s*[x×]\s*determinism|determinism"  # Nx / N× determinism
+    r"|ci[\s-]?rollup"  # CI-rollup ...
+    r"|(?:ci|rollup)\b[^\n]*\bsuccess"  # CI/rollup ... SUCCESS
+    r"|green\s+ci|ci\s+green",  # green CI
+    re.IGNORECASE,
+)
+
 
 def _strip_code_markup(text: str) -> str:
     """Remove fenced code blocks and inline code spans from *text*.
@@ -228,6 +255,15 @@ class Signals:
     ci_red_merges: int = 0
     rework_cycles: int = 0
     review_false_positives: int = 0
+    # Clean reviewer verdicts (as Requestor) whose comment body carried a
+    # parseable ``Verified:`` block enumerating >=1 concrete check
+    # (:func:`_has_verified_checks`, e.g. ``revert→red`` / ``Nx determinism`` /
+    # ``byte-parity`` / ``CI-rollup SUCCESS``). Positive — the QA-rigor review
+    # signal that credits demonstrated verification when there were no must-fixes
+    # to catch. An empty / boilerplate ``Verified:`` line does NOT count
+    # (anti-gaming). Feeds :func:`score_delta` (clean +1 at >=2) and the
+    # reserved-5 composite; never counted as a negative.
+    verified_reviews: int = 0
     # Summed coarse per-PR difficulty weight over the engineer's authored PRs
     # (:func:`difficulty_weight`, #229). A flagship correctness fix accrues 3, a
     # one-line config change 1, so a wave of hard work outranks a wave of trivial
@@ -249,12 +285,16 @@ class Signals:
                 self.ci_red_merges,
                 self.rework_cycles,
                 self.review_false_positives,
+                self.verified_reviews,
             )
         )
 
     def has_negative(self) -> bool:
         return bool(
-            self.must_fix_received or self.ci_red_merges or self.review_false_positives
+            self.must_fix_received
+            or self.ci_red_merges
+            or self.review_false_positives
+            or self.rework_cycles
         )
 
 
@@ -273,6 +313,11 @@ class Verdict:
     verdict: str | None
     false_positive: bool
     changes_requested: bool = False
+    # True when the comment body carried a parseable ``Verified:`` block
+    # enumerating >=1 concrete check (:func:`_has_verified_checks`). Credited as
+    # a ``verified_reviews`` signal to the Requestor only on a CLEAN verdict
+    # (``changes_requested`` is False).
+    verified: bool = False
 
 
 def _has_must_fix_items(body: str) -> bool:
@@ -303,6 +348,37 @@ def _has_must_fix_items(body: str) -> bool:
         while j < len(lines) and not lines[j].strip():
             j += 1
         if j < len(lines) and _LIST_ITEM_RE.match(lines[j]):
+            return True
+    return False
+
+
+def _has_verified_checks(body: str) -> bool:
+    """True when *body* carries a ``Verified:`` block enumerating >=1 concrete check.
+
+    The charter's QA-rigor convention writes the checks a reviewer actually ran
+    in a ``Verified:`` block (bare or bold label, value inline or on following
+    list lines). The block is credited as a ``verified_reviews`` signal only when
+    it names >=1 CONCRETE verification token (:data:`_VERIFIED_CHECK_RE` — e.g.
+    ``revert→red``, ``Nx determinism``, ``byte-parity``, ``CI-rollup SUCCESS``).
+    An empty ``Verified:`` line, or one whose items name no concrete token, does
+    NOT count (anti-gaming). The block ends at a blank line or the next charter
+    section label so a token in a later section (e.g. Tech-debt) is not borrowed.
+    Code spans / fenced blocks are stripped first so a token inside code or a
+    test name is never counted.
+    """
+    lines = _strip_code_markup(body).splitlines()
+    for i, line in enumerate(lines):
+        label_m = _VERIFIED_LABEL_RE.match(line)
+        if not label_m:
+            continue
+        block = [label_m.group(1)]
+        j = i + 1
+        while j < len(lines) and lines[j].strip() and not _SECTION_LABEL_RE.match(
+            lines[j]
+        ):
+            block.append(lines[j])
+            j += 1
+        if _VERIFIED_CHECK_RE.search("\n".join(block)):
             return True
     return False
 
@@ -373,6 +449,7 @@ def parse_verdicts(comment_bodies: list[str]) -> list[Verdict]:
                 verdict=verdict_str,
                 false_positive=is_false_positive,
                 changes_requested=changes_requested,
+                verified=_has_verified_checks(body),
             )
         )
     return out
@@ -1054,6 +1131,10 @@ def _account_pr(
     for v in verdicts:
         if v.false_positive and v.requestor:
             bucket(v.requestor).review_false_positives += 1
+        # Credit a verified review only on a CLEAN verdict (not a blocking
+        # Must-fix Request) whose body carried a concrete ``Verified:`` block.
+        if v.verified and not v.changes_requested and v.requestor:
+            bucket(v.requestor).verified_reviews += 1
 
     if pr_had_changes_requested:
         author_sig.rework_cycles += 1
@@ -1132,15 +1213,26 @@ def score_delta(sig: Signals) -> int:
       negative
         - each CI-red merge:                      -1  (hard ding)
         - each review false-positive:             -1
-        - 3+ must-fix items received as author:   -1
+        - 2+ must-fix items received as author:   -1
+        - 2+ rework cycles as author:             -1
       positive (only when the iteration is clean of the negatives above)
         - 2+ PRs merged clean:                    +1
         - 2+ must-fix items caught as reviewer:   +1
+        - 2+ verified reviews as reviewer:        +1  (QA-rigor path — a
+          reviewer's clean verdicts carrying concrete ``Verified:`` receipts;
+          credits demonstrated verification when there were no must-fixes to
+          catch)
+
+    ``rework_cycles`` and ``must_fix_received`` are both in
+    :meth:`Signals.has_negative`, so a rework-/must-fix-heavy wave can never also
+    collect the clean-wave positives above.
     """
     delta = 0
     delta -= sig.ci_red_merges
     delta -= sig.review_false_positives
-    if sig.must_fix_received >= 3:
+    if sig.must_fix_received >= 2:
+        delta -= 1
+    if sig.rework_cycles >= 2:
         delta -= 1
 
     clean = not sig.has_negative()
@@ -1148,6 +1240,8 @@ def score_delta(sig: Signals) -> int:
         if sig.prs_merged >= 2:
             delta += 1
         if sig.must_fix_caught >= 2:
+            delta += 1
+        if sig.verified_reviews >= 2:
             delta += 1
 
     return max(-2, min(2, delta))
@@ -1184,8 +1278,9 @@ def apply_distribution_discipline(
     """
 
     def composite(s: Signals) -> int:
-        # Reward output + good reviewing + difficulty of the work shipped;
-        # penalise the negatives. Pure ranking key, not a trust score. Adding
+        # Reward output + good reviewing (must-fix caught + verified reviews) +
+        # difficulty of the work shipped; penalise the negatives. Pure ranking
+        # key, not a trust score. Adding
         # ``difficulty_points`` (#229) is what makes the reserved-5 mechanical: a
         # flagship correctness fix (weight 3) outranks a one-liner (weight 1) at
         # equal PR count, so the top slot is not a narrative argument. Waves with
@@ -1194,6 +1289,7 @@ def apply_distribution_discipline(
         return (
             s.prs_merged
             + s.must_fix_caught
+            + s.verified_reviews
             + s.difficulty_points
             - s.must_fix_received
             - 2 * s.ci_red_merges
@@ -1225,13 +1321,16 @@ def negative_signal_line(name: str, sig: Signals) -> str:
             gaps.append(f"{sig.ci_red_merges} CI-red merge(s)")
         if sig.must_fix_received:
             gaps.append(f"{sig.must_fix_received} must-fix received")
+        if sig.rework_cycles:
+            gaps.append(f"{sig.rework_cycles} rework cycle(s)")
         if sig.review_false_positives:
             gaps.append(f"{sig.review_false_positives} review false-positive(s)")
         return f"{name}: " + ", ".join(gaps)
     return (
         f"{name}: metrics clean: prs_merged={sig.prs_merged}, "
         f"must_fix_received=0, ci_red_merges=0, false_positives=0, "
-        f"must_fix_caught={sig.must_fix_caught}"
+        f"must_fix_caught={sig.must_fix_caught}, "
+        f"verified_reviews={sig.verified_reviews}"
     )
 
 

--- a/framework/assets/skills/wave-retro/SKILL.md
+++ b/framework/assets/skills/wave-retro/SKILL.md
@@ -165,9 +165,11 @@ PR as the feedback log — never as a separate direct-to-default commit.
 Every row applies the mechanical policy from `trust_signals.py` and cites its numbers:
 
 - **Delta:** `new = clamp(old + delta, 1, 5)` — bidirectional, already clamped to ±2 per
-  wave by `score_delta`. Each CI-red merge / review false-positive is −1; 3+ must-fix
-  received is −1; a clean wave with 2+ PRs merged or 2+ must-fix caught as reviewer is +1
-  each. A single clean PR is **not** a bump.
+  wave by `score_delta`. Each CI-red merge / review false-positive is −1; 2+ must-fix
+  received is −1; 2+ rework cycles is −1; a clean wave with 2+ PRs merged, 2+ must-fix
+  caught as reviewer, or 2+ verified reviews (reviewer verdicts carrying a concrete
+  `Verified:` block) is +1 each — so QA rigor isn't zero-credit when there are no
+  must-fixes. A single clean PR is **not** a bump.
 - **Decay toward neutral:** an engineer with no signal for 3 consecutive waves drifts one
   step toward 3 (`trust_signals.decay(old, waves_since_signal)`). A stale 4 or 2 is no
   longer earned; decay is one step per retro, never a reset.

--- a/framework/recipes/LIB_TRUST_SIGNALS.md
+++ b/framework/recipes/LIB_TRUST_SIGNALS.md
@@ -9,9 +9,11 @@ half; the scoring half is usable standalone on a hand-built `Signals` dict.
 
 ## The scoring model (in brief)
 - `score_delta(sig)` — pure, symmetric, clamped to **[-2, +2]**. `-1` per CI-red
-  merge, `-1` per review false-positive, `-1` if `must_fix_received >= 3`; then
-  (only if the iteration is clean of those negatives) `+1` if `prs_merged >= 2`,
-  `+1` if `must_fix_caught >= 2`. New score = `clamp(NEUTRAL + delta, 1, 5)`.
+  merge, `-1` per review false-positive, `-1` if `must_fix_received >= 2`, `-1` if
+  `rework_cycles >= 2`; then (only if the iteration is clean of those negatives)
+  `+1` if `prs_merged >= 2`, `+1` if `must_fix_caught >= 2`, `+1` if
+  `verified_reviews >= 2` (clean reviewer verdicts carrying a concrete `Verified:`
+  block). New score = `clamp(NEUTRAL + delta, 1, 5)`.
 - `decay(old, n)` — drift one step toward NEUTRAL (3) after 3 unsignalled iterations.
 - `apply_distribution_discipline(proposals)` — **5 is reserved**: a proposed 5
   survives only for the top *composite* performer (and only if strictly positive);

--- a/framework/tests/test_trust_signals.py
+++ b/framework/tests/test_trust_signals.py
@@ -1521,3 +1521,177 @@ def test_pr_comment_histories_fail_open_on_error(monkeypatch) -> None:
 
 def test_pr_comment_histories_bad_repo_is_none() -> None:
     assert ts._pr_comment_histories("no-slash-repo", 702) is None
+
+
+# ===========================================================================
+# Symmetric trust scoring (#254): verified_reviews (+) and the rework /
+# must-fix downward signals. These pin the score_delta weight table and the
+# extraction of the anti-gaming `Verified:` block.
+# ===========================================================================
+
+
+def _verified_body(
+    requestor: str,
+    *,
+    verdict: str = "Replied",
+    verified_lines: tuple[str, ...] = (
+        "revert→red on the failing test",
+        "5× determinism",
+        "byte-parity OK",
+    ),
+    must_fix: str | None = None,
+) -> str:
+    """A charter-format verdict comment carrying a ``Verified:`` block.
+
+    ``verified_lines=()`` emits a bare ``Verified:`` (boilerplate/empty). A
+    ``must_fix`` str makes it a blocking ``Request`` regardless of ``verdict``.
+    """
+    mf = "Must-fix: None" if must_fix is None else f"Must-fix:\n1. {must_fix}"
+    vblock = (
+        "Verified:\n" + "\n".join(f"- {ln}" for ln in verified_lines)
+        if verified_lines
+        else "Verified:"
+    )
+    return (
+        f"Requestor: {requestor}\n"
+        "Requestee: Paloma.Gupta\n"
+        f"RequestOrReplied: {verdict}\n\n"
+        "**Review**\n"
+        f"{mf}\n"
+        f"{vblock}\n"
+        "Tech-debt: None\n"
+    )
+
+
+# ------------------------------------------------- score_delta weight table
+
+
+def test_verified_reviews_two_gives_clean_wave_bonus() -> None:
+    """2+ verified reviews on a clean wave is +1 — the QA-rigor path when there
+    are no must-fixes to catch. Load-bearing on the new positive branch: deleting
+    the ``verified_reviews >= 2`` bump makes ``rigorous`` score 0.
+    """
+    assert ts.score_delta(ts.Signals(prs_merged=1)) == 0  # a lone clean PR: no bump
+    rigorous = ts.Signals(prs_merged=1, verified_reviews=2)
+    assert ts.score_delta(rigorous) == 1
+    # one verified review is not enough — the threshold is 2, like the others.
+    assert ts.score_delta(ts.Signals(prs_merged=1, verified_reviews=1)) == 0
+
+
+def test_rework_cycles_two_dings_and_blocks_clean_bonus() -> None:
+    """``rework_cycles >= 2`` is −1 AND, being a negative now, blocks the
+    clean-wave ``prs_merged >= 2`` bonus (a rework-heavy wave cannot also collect
+    the positive). Load-bearing on both the ding and ``has_negative``.
+    """
+    heavy = ts.Signals(prs_merged=2, rework_cycles=2)
+    assert heavy.has_negative() is True  # rework is now a negative
+    assert ts.score_delta(heavy) == -1  # −1 for rework; +1 bonus is blocked
+    # A single rework cycle is a negative too (blocks the clean-wave bonus) but
+    # does not reach the −1 ding threshold: net 0, not the +1 a clean 2-PR wave
+    # would earn.
+    one = ts.Signals(prs_merged=2, rework_cycles=1)
+    assert one.has_negative() is True
+    assert ts.score_delta(one) == 0
+
+
+def test_must_fix_received_two_now_dings() -> None:
+    """The author ding threshold tightened 3 → 2: two received must-fixes is −1
+    (it was free under the old ``>= 3``). Load-bearing on the threshold constant.
+    """
+    assert ts.score_delta(ts.Signals(prs_merged=1, must_fix_received=2)) == -1
+    # One received must-fix is still free (blocks the bonus, but no ding).
+    assert ts.score_delta(ts.Signals(prs_merged=1, must_fix_received=1)) == 0
+
+
+def test_clean_no_new_signal_wave_scores_exactly_as_before() -> None:
+    """Regression guard: a wave carrying NONE of the new signals scores exactly
+    the prior deltas — 2 clean PRs + 2 catches → +2; a lone clean PR → 0; an
+    empty wave → 0. Ensures the #254 changes are purely additive.
+    """
+    assert ts.score_delta(ts.Signals(prs_merged=2, must_fix_caught=2)) == 2
+    assert ts.score_delta(ts.Signals(prs_merged=1)) == 0
+    assert ts.score_delta(ts.Signals()) == 0
+
+
+# --------------------------------------------------- _has_verified_checks (pure)
+
+
+def test_has_verified_checks_recognizes_concrete_tokens() -> None:
+    assert ts._has_verified_checks("Verified:\n- revert→red\n") is True
+    assert ts._has_verified_checks("Verified:\n- 5× determinism run\n") is True
+    assert ts._has_verified_checks("Verified: byte-parity confirmed\n") is True
+    assert ts._has_verified_checks("Verified:\n- CI rollup SUCCESS\n") is True
+
+
+def test_has_verified_checks_rejects_boilerplate() -> None:
+    assert ts._has_verified_checks("Verified:\n- looks good to me\n") is False
+    assert ts._has_verified_checks("Verified:\n") is False
+    assert ts._has_verified_checks("no verified block at all") is False
+    # A concrete token OUTSIDE the Verified block (in Tech-debt) is not borrowed.
+    assert (
+        ts._has_verified_checks("Verified: none\nTech-debt: byte-parity follow-up\n")
+        is False
+    )
+
+
+# ------------------------------------------------- verified_reviews extraction
+
+
+def test_verified_block_credits_reviewer_verified_review(tmp_path) -> None:
+    """A reviewer's clean verdict with a concrete ``Verified:`` block credits one
+    ``verified_reviews`` to the Requestor — and no phantom catch.
+    """
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Paloma Gupta",
+        repo="o/r",
+        number=800,
+        comment_bodies=[_verified_body("Tariq.Morales")],
+        ci_red=False,
+    )
+    assert sigs["Tariq Morales"].verified_reviews == 1
+    assert sigs["Tariq Morales"].must_fix_caught == 0  # clean review, not a catch
+
+
+def test_boilerplate_verified_block_earns_no_credit(tmp_path) -> None:
+    """An empty or token-less ``Verified:`` block yields verified_reviews=0
+    (anti-gaming). Load-bearing on the concrete-token requirement.
+    """
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    for lines in ((), ("done",), ("looks good",)):
+        sigs: dict[str, ts.Signals] = {}
+        ts._account_pr(
+            sigs,
+            canon,
+            author="Paloma Gupta",
+            repo="o/r",
+            number=801,
+            comment_bodies=[_verified_body("Tariq.Morales", verified_lines=lines)],
+            ci_red=False,
+        )
+        assert sigs.get("Tariq Morales", ts.Signals()).verified_reviews == 0
+
+
+def test_verified_block_on_blocking_request_not_credited(tmp_path) -> None:
+    """A Verified block on a BLOCKING ``Request`` is not a verified review — the
+    catch scores, but verified_reviews stays 0 (only clean verdicts credit it).
+    Load-bearing on the ``not v.changes_requested`` guard.
+    """
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Paloma Gupta",
+        repo="o/r",
+        number=802,
+        comment_bodies=[
+            _verified_body("Tariq.Morales", verdict="Request", must_fix="Fix the bug."),
+        ],
+        ci_red=False,
+    )
+    assert sigs["Tariq Morales"].must_fix_caught == 1
+    assert sigs["Tariq Morales"].verified_reviews == 0

--- a/generic_prompts/GENERIC_LIB_TRUST_SIGNALS_PROMPT.md
+++ b/generic_prompts/GENERIC_LIB_TRUST_SIGNALS_PROMPT.md
@@ -36,6 +36,7 @@ Split the module into two cleanly separated layers:
 | `ci_red_merges` | PRs they authored that merged with a failing required check | negative (hard) |
 | `rework_cycles` | PRs they authored that needed ≥1 rework round | negative |
 | `review_false_positives` | review findings they raised that were later self-retracted | negative (review quality) |
+| `verified_reviews` | clean reviewer verdicts carrying a concrete `Verified:` block (≥1 real check, anti-gaming) | positive (review rigor) |
 
 ### Scoring rules (symmetric, clamped)
 
@@ -43,9 +44,12 @@ A single iteration must not swing trust across the whole scale, so clamp the
 delta to `[-2, +2]`:
 
 - **negative:** −1 per CI-red merge; −1 per review false-positive; −1 if
-  `must_fix_received >= 3`.
+  `must_fix_received >= 2`; −1 if `rework_cycles >= 2`. `rework_cycles` and
+  `must_fix_received` also count as negatives for the clean-wave gate below.
 - **positive (only when the iteration is clean of all negatives):** +1 for
-  `prs_merged >= 2`; +1 for `must_fix_caught >= 2`.
+  `prs_merged >= 2`; +1 for `must_fix_caught >= 2`; +1 for `verified_reviews >= 2`
+  (so demonstrated verification isn't zero-credit when there were no must-fixes
+  to catch).
 
 ### Supporting pure functions
 
@@ -115,20 +119,28 @@ class Signals:
     ci_red_merges: int = 0
     rework_cycles: int = 0
     review_false_positives: int = 0
+    verified_reviews: int = 0
     authored: list[int] = field(default_factory=list)
 
     def has_negative(self) -> bool:
-        return bool(self.must_fix_received or self.ci_red_merges or self.review_false_positives)
+        return bool(
+            self.must_fix_received or self.ci_red_merges
+            or self.review_false_positives or self.rework_cycles
+        )
 
 
 def score_delta(s: Signals) -> int:
     delta = -s.ci_red_merges - s.review_false_positives
-    if s.must_fix_received >= 3:
+    if s.must_fix_received >= 2:
+        delta -= 1
+    if s.rework_cycles >= 2:
         delta -= 1
     if not s.has_negative():
         if s.prs_merged >= 2:
             delta += 1
         if s.must_fix_caught >= 2:
+            delta += 1
+        if s.verified_reviews >= 2:
             delta += 1
     return max(-2, min(2, delta))
 


### PR DESCRIPTION
Closes #254

## Summary
Make the mechanical trust delta in `trust_signals.py` **symmetric** — credit
verified review rigor on a clean wave, and add matching downward signals so
scores can't just inflate. Single-source module (canonical copy under
`framework/assets/lib/`; no `.claude/lib`), so no `.py` byte-parity concern.

### `score_delta` weight table (as implemented, clamp [-2, +2])
| direction | condition | delta |
|---|---|---|
| negative | each `ci_red_merges` | −1 |
| negative | each `review_false_positives` | −1 |
| negative | `must_fix_received >= 2` (was `>= 3`) | −1 |
| negative | `rework_cycles >= 2` (newly score-active) | −1 |
| positive (clean only) | `prs_merged >= 2` | +1 |
| positive (clean only) | `must_fix_caught >= 2` | +1 |
| positive (clean only) | `verified_reviews >= 2` (new) | +1 |

"clean" = `has_negative()` False, which now also includes any `rework_cycles`
(one rework round blocks the clean-wave bonus; the −1 ding only fires at ≥2).

### New `verified_reviews` signal
A reviewer's CLEAN verdict (Requestor) earns one verified review only if its
comment body carries a parseable `Verified:` block naming ≥1 concrete check
(`revert→red` / `Nx determinism` / `byte-parity` / `CI-rollup SUCCESS`). Empty
or token-less blocks earn nothing (anti-gaming, `_has_verified_checks`); a block
on a blocking `Request` is not credited. Also feeds the reserved-5
`apply_distribution_discipline` composite.

### Docs / prose
- `score_delta` docstring, module signal glossary, and `negative_signal_line`
  updated (rework now a named gap; `verified_reviews` shown in metrics-clean receipts).
- wave-retro `SKILL.md` Step-5 scoring bullet updated in BOTH copies —
  **byte-parity confirmed**: `diff .claude/skills/wave-retro/SKILL.md framework/assets/skills/wave-retro/SKILL.md` is empty.
- `framework/recipes/LIB_TRUST_SIGNALS.md` and
  `generic_prompts/GENERIC_LIB_TRUST_SIGNALS_PROMPT.md` restated the mapping as
  prose/code — both updated to match (table row, scoring rules, reference snippet).

### Tests (appended to `framework/tests/test_trust_signals.py`, 100 pass)
verified bonus at 2 / none at 1 / boilerplate→0 at extraction; blocking-Request
Verified not credited; `rework_cycles>=2` dings and blocks the bonus (and =1 is a
negative but no ding); `must_fix_received==2` now dings; clean no-new-signal wave
scores exactly as before (regression guard); `_has_verified_checks` token/boilerplate
unit coverage.

**Load-bearing test:** removing `if sig.verified_reviews >= 2: delta += 1` from
`score_delta` turns `test_verified_reviews_two_gives_clean_wave_bonus` red
(2→+1 becomes 2→0); restored → all 100 pass. `ruff check` clean.
