### PR TITLE
W18 S1: Trust-signal hardening — verified_reviews per-PR dedup (#258) + tighten _VERIFIED_CHECK_RE (#259)

### DIFF
--- a/framework/assets/lib/trust_signals.py
+++ b/framework/assets/lib/trust_signals.py
@@ -216,12 +216,19 @@ _SECTION_LABEL_RE = re.compile(
 _VERIFIED_CHECK_RE = re.compile(
     r"revert\s*(?:→|-+|to)?\s*red"  # revert→red / revert to red / revert-red
     r"|byte[\s-]?parity"  # byte-parity
-    r"|\d+\s*[x×]\s*determinism|determinism"  # Nx / N× determinism
+    r"|\d+\s*[x×]\s*determinism"  # Nx / N× determinism (substantive, quantified)
     r"|ci[\s-]?rollup"  # CI-rollup ...
-    r"|(?:ci|rollup)\b[^\n]*\bsuccess"  # CI/rollup ... SUCCESS
-    r"|green\s+ci|ci\s+green",  # green CI
+    r"|(?:ci|rollup)\b[^\n]*\bsuccess",  # CI/rollup ... SUCCESS
     re.IGNORECASE,
 )
+# #259: the bare ``determinism`` and bare ``green ci`` / ``ci green`` alternations
+# were dropped — they let a NEGATING / non-substantive mention satisfy the gate
+# (e.g. "no determinism check run", "ci green not verified" both matched). Only
+# the substantive forms above are creditable now: the quantified ``Nx
+# determinism`` (a bare "determinism" no longer counts) and a ``CI ... SUCCESS``
+# rollup receipt (a bare "ci green" / "green ci" no longer counts). Genuine
+# blocks — ``revert→red``, ``byte-parity``, ``5× determinism``, ``CI rollup
+# SUCCESS`` — are unaffected.
 
 
 def _strip_code_markup(text: str) -> str:
@@ -1128,13 +1135,24 @@ def _account_pr(
                 if v.requestor:
                     bucket(v.requestor).must_fix_caught += 1
 
+    # #258: dedup ``verified_reviews`` per (reviewer, PR). ``_account_pr`` handles
+    # a single (repo, number), so a reviewer counted once here == counted once for
+    # this PR; distinct reviewers on this PR, and the same reviewer on other PRs
+    # (separate ``_account_pr`` calls), still count independently. Keyed on the
+    # CANONICAL reviewer identity so two spellings of one name
+    # (``Tariq.Morales`` / ``Tariq Morales (QA)``) fold to a single credit.
+    credited_verified: set[str] = set()
     for v in verdicts:
         if v.false_positive and v.requestor:
             bucket(v.requestor).review_false_positives += 1
         # Credit a verified review only on a CLEAN verdict (not a blocking
-        # Must-fix Request) whose body carried a concrete ``Verified:`` block.
+        # Must-fix Request) whose body carried a concrete ``Verified:`` block —
+        # and at most ONCE per reviewer for this PR (#258).
         if v.verified and not v.changes_requested and v.requestor:
-            bucket(v.requestor).verified_reviews += 1
+            reviewer = canon(v.requestor)
+            if reviewer not in credited_verified:
+                credited_verified.add(reviewer)
+                bucket(v.requestor).verified_reviews += 1
 
     if pr_had_changes_requested:
         author_sig.rework_cycles += 1

--- a/framework/tests/test_trust_signals.py
+++ b/framework/tests/test_trust_signals.py
@@ -1695,3 +1695,74 @@ def test_verified_block_on_blocking_request_not_credited(tmp_path) -> None:
     )
     assert sigs["Tariq Morales"].must_fix_caught == 1
     assert sigs["Tariq Morales"].verified_reviews == 0
+
+
+# ===========================================================================
+# Trust-signal hardening (#258 / #259, W18 S1): the verified_reviews signal
+# had the same latent double-counting shape the N=2 review work exposed for
+# must_fix_caught, and _VERIFIED_CHECK_RE credited non-substantive / negating
+# mentions. These pin the per-(reviewer, PR) dedup and the tightened regex.
+# ===========================================================================
+
+
+def test_verified_reviews_deduped_per_reviewer_per_pr(tmp_path) -> None:
+    """#258 (LOAD-BEARING): two clean ``Verified:`` verdicts by the SAME reviewer
+    on the SAME PR credit ``verified_reviews`` exactly ONCE — even across name
+    spellings (``Tariq.Morales`` / ``Tariq Morales (QA)`` fold to one). A DISTINCT
+    reviewer on the same PR still counts, and the same reviewer on a DIFFERENT PR
+    (a separate ``_account_pr`` call) counts again.
+
+    Mutation bar (``_account_pr``): removing the per-(reviewer, PR) dedup set
+    double-counts Tariq's two comments → ``verified_reviews == 2`` on the first PR
+    and ``== 3`` after the second → both dedup assertions fail.
+    """
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Paloma Gupta",
+        repo="o/r",
+        number=810,
+        comment_bodies=[
+            _verified_body("Tariq.Morales"),  # first clean Verified
+            _verified_body("Tariq Morales (QA)"),  # SAME reviewer, variant spelling
+            _verified_body("Nia.Rossi"),  # a DISTINCT reviewer
+        ],
+        ci_red=False,
+    )
+    assert sigs["Tariq Morales"].verified_reviews == 1  # deduped per (reviewer, PR)
+    assert sigs["Nia Rossi"].verified_reviews == 1  # distinct reviewer still counts
+
+    # A DIFFERENT PR (a separate _account_pr call) credits Tariq independently.
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Paloma Gupta",
+        repo="o/r",
+        number=811,
+        comment_bodies=[_verified_body("Tariq.Morales")],
+        ci_red=False,
+    )
+    assert sigs["Tariq Morales"].verified_reviews == 2  # +1 on a different PR
+
+
+def test_verified_check_re_rejects_negating_or_bare_mention() -> None:
+    """#259 (LOAD-BEARING): a NEGATING / non-substantive determinism or CI-green
+    mention no longer satisfies the gate — only the substantive, quantified forms
+    do. The bare ``determinism`` and bare ``green ci`` / ``ci green`` alternations
+    were dropped.
+
+    Mutation bar (``_VERIFIED_CHECK_RE``): restoring the bare ``determinism``
+    alternation makes "no determinism check run" credit → the first assertion
+    flips to True → fails. Likewise restoring ``green ci`` / ``ci green`` re-credits
+    "ci green not verified" → the second assertion fails.
+    """
+    # Negating / non-substantive mentions must NOT count.
+    assert ts._has_verified_checks("Verified:\n- no determinism check run\n") is False
+    assert ts._has_verified_checks("Verified:\n- ci green not verified\n") is False
+    # The substantive, quantified forms are still credited unchanged.
+    assert ts._has_verified_checks("Verified:\n- 5× determinism run\n") is True
+    assert ts._has_verified_checks("Verified:\n- revert→red\n") is True
+    assert ts._has_verified_checks("Verified:\n- byte-parity OK\n") is True
+    assert ts._has_verified_checks("Verified:\n- CI rollup SUCCESS\n") is True


### PR DESCRIPTION
## W18 S1 — Trust-signal hardening: `verified_reviews`

Hardens the `verified_reviews` signal in the **single-source**
`framework/assets/lib/trust_signals.py` (there is NO `.claude/lib` copy in this
repo, so no dual-tree copy is needed). Two file-disjoint fixes, thresholds and
all other signals untouched.

### #258 — per-`(reviewer, PR)` dedup
Two clean `Verified:` verdict comments by the SAME reviewer on the SAME PR used
to double-count toward `verified_reviews` (the same latent shape the N=2 review
work exposed for `must_fix_caught`). `_account_pr` handles a single
`(repo, number)`, so a dedup set keyed on the **canonical** reviewer identity —
folding `Tariq.Morales` / `Tariq Morales (QA)` to one — inside the verdict loop
yields `(requestor, repo, pr)` dedup. Distinct reviewers on one PR, and the same
reviewer across different PRs (separate `_account_pr` calls), still count
independently.

### #259 — tighten `_VERIFIED_CHECK_RE`
Dropped the bare `determinism` and bare `green ci` / `ci green` alternations so a
negating / non-substantive mention (e.g. "no determinism check run", "ci green
not verified") can no longer satisfy the gate. The substantive forms remain
creditable: quantified `Nx determinism`, `revert→red`, `byte-parity`,
`CI ... SUCCESS` rollup receipt.

### revert→red evidence (both new tests load-bearing)
- **`test_verified_reviews_deduped_per_reviewer_per_pr`** — reverting the dedup
  set to the old unconditional `+= 1`: `assert 2 == 1` (Tariq's two same-PR
  comments double-count) → RED. Restored → green.
- **`test_verified_check_re_rejects_negating_or_bare_mention`** — restoring the
  bare `determinism` alternation: `assert True is False` on
  `_has_verified_checks("Verified:\n- no determinism check run\n")` (negating
  mention wrongly credited) → RED. Restored → green.

### Suite / lint
- `ruff check framework/assets/lib/trust_signals.py` — clean.
- `python3 -m pytest framework/tests/test_trust_signals.py -q` — **102 passed**
  (existing anti-gaming battery + both new tests green).

Closes #258
Closes #259
