### PR TITLE
W18 S2: Rulesets-aware CI gate — validate_pr_ci_status reads rulesets, not just classic branch-protection

### DIFF
--- a/framework/assets/hooks/validate_pr_ci_status.py
+++ b/framework/assets/hooks/validate_pr_ci_status.py
@@ -235,25 +235,18 @@ def fetch_pr_base_ref(pr_number: str | None, repo: str | None) -> str | None:
         return None
 
 
-def base_branch_enforces_required_checks(repo: str | None, base: str | None) -> bool | None:
-    """Does *base* enforce required status checks via GitHub branch protection?
+def _classic_enforces_required_checks(repo: str | None, base: str | None) -> bool | None:
+    """Does *base* enforce required checks via CLASSIC branch protection?
 
-    Answers the one question the `--auto`/pending path needs: will GitHub HOLD an
-    `--auto` merge until CI goes green? It does so only when the base branch has a
-    non-empty required-status-checks set.
+    Reads only the legacy branch-protection endpoint
+    (`repos/{repo}/branches/{base}/protection/required_status_checks`).
 
     Returns:
-      True  — the base has a non-empty required-status-checks set. GitHub holds an
-              `--auto` merge until those checks pass, so a still-pending check is
-              safe to warn-allow (GitHub really will wait for green).
-      False — the base has NO required status checks: an unprotected branch, or a
-              protected branch with an empty required set (both 404 this
-              endpoint). GitHub will NOT hold an `--auto` merge for CI, so a
-              pending check can fail AFTER the merge already landed (the W13
-              `node (20)` slip, #230).
-      None  — undeterminable: no repo/base, or a transport/permission error on the
-              query. The caller preserves the fail-open posture and warn-allows,
-              never manufacturing a block on an inability to read.
+      True  — the base has a non-empty required-status-checks set.
+      False — the base has NO required status checks under classic protection: an
+              unprotected branch, or a protected branch with an empty required set
+              (both 404 this endpoint).
+      None  — undeterminable: no repo/base, or a transport/permission error.
 
     A 404 / "branch not protected" is a DEFINITIVE "no required checks configured"
     (→ False), deliberately kept distinct from a transport error (→ None): the
@@ -292,6 +285,106 @@ def base_branch_enforces_required_checks(repo: str | None, base: str | None) -> 
     contexts = data.get("contexts") or []
     checks = data.get("checks") or []
     return bool(contexts or checks)
+
+
+def _rulesets_enforce_required_checks(repo: str | None, base: str | None) -> bool | None:
+    """Does *base* enforce required checks via a GitHub RULESET (#262)?
+
+    Repos that migrated off classic branch protection to *rulesets* configure
+    required status checks under the rulesets API, not the classic
+    `protection/*` endpoints. The classic probe 404s on such a repo and reads it
+    as unenforced — a FALSE NEGATIVE that safe-sides the `--auto`/pending gate
+    into an over-block. This helper closes that gap by reading the branch's
+    effective rules (`repos/{repo}/rules/branches/{base}`), which flattens every
+    ruleset (repo- and org-level) that applies to the branch.
+
+    Returns:
+      True  — at least one applicable `required_status_checks` rule names a
+              non-empty required-checks set. GitHub holds an `--auto` merge until
+              those checks pass, exactly like a classic required set.
+      False — the branch's effective rules contain no enforcing
+              `required_status_checks` rule (this endpoint returns `200 []` for a
+              branch with no rules, so an empty answer is DEFINITIVE not-enforced),
+              or the repo/branch itself is absent (404).
+      None  — undeterminable: no repo/base, or a transport/permission error. The
+              caller preserves fail-open, never manufacturing a block on an
+              inability to read.
+    """
+    if not repo or not base:
+        return None
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{repo}/rules/branches/{base}"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return None
+    if result.returncode != 0:
+        blob = f"{result.stdout}\n{result.stderr}".lower()
+        # This endpoint returns `200 []` for a branch with no rules, so a
+        # non-zero exit is not the "no enforcement" signal a classic 404 is. A
+        # 404 here means the repo/branch itself is absent → definitively no
+        # ruleset enforcement (→ False). Any other failure is undeterminable →
+        # fail-open None.
+        if "404" in blob or "not found" in blob:
+            return False
+        return None
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, list):
+        return None
+    for rule in data:
+        if not isinstance(rule, dict):
+            continue
+        if rule.get("type") != "required_status_checks":
+            continue
+        params = rule.get("parameters") or {}
+        required = params.get("required_status_checks") or []
+        if required:
+            return True
+    return False
+
+
+def base_branch_enforces_required_checks(repo: str | None, base: str | None) -> bool | None:
+    """Does *base* enforce required status checks (classic OR rulesets)?
+
+    Answers the one question the `--auto`/pending path needs: will GitHub HOLD an
+    `--auto` merge until CI goes green? It does so when the base branch has a
+    non-empty required-status-checks set — configured EITHER via classic branch
+    protection OR via a GitHub ruleset (#262). If EITHER source reports
+    enforcement, the base is treated as protected.
+
+    Returns:
+      True  — classic protection OR a ruleset enforces a non-empty required-checks
+              set. A still-pending check under `--auto` is safe to warn-allow
+              (GitHub really will wait for green).
+      False — BOTH sources definitively report no required checks: an unprotected
+              branch with no enforcing ruleset. GitHub will NOT hold an `--auto`
+              merge, so a pending check can fail AFTER the merge lands (the W13
+              `node (20)` slip, #230) → the caller blocks.
+      None  — undeterminable: no repo/base, or a transport/permission error on
+              EITHER probe with neither reporting enforcement. Fail-open: the
+              caller warn-allows, never manufacturing a block on an inability to
+              read. (A read error on one source cannot rule out that the other —
+              unread — source enforces, so a definitive "not enforced" would be
+              unsound.)
+    """
+    classic = _classic_enforces_required_checks(repo, base)
+    if classic is True:
+        return True
+    rulesets = _rulesets_enforce_required_checks(repo, base)
+    if rulesets is True:
+        return True
+    # Neither source reported True. Only assert the definitive "not enforced"
+    # (→ False, the #230 pending/--auto block) when BOTH probes answered
+    # definitively; if either was undeterminable, stay fail-open (None).
+    if classic is None or rulesets is None:
+        return None
+    return False
 
 
 def covering_pr_workflow_exists(repo: str | None, base: str | None) -> bool | None:

--- a/framework/tests/test_validate_pr_ci_status.py
+++ b/framework/tests/test_validate_pr_ci_status.py
@@ -116,68 +116,230 @@ def test_gate_disabled_allows(monkeypatch) -> None:
 
 
 # --------------------------------------------------------------------------- #
-# base_branch_enforces_required_checks — the tri-state
+# _classic_enforces_required_checks — the classic-endpoint tri-state
 # --------------------------------------------------------------------------- #
 
 
-def test_enforces_true_on_nonempty_contexts(monkeypatch) -> None:
+def test_classic_true_on_nonempty_contexts(monkeypatch) -> None:
     monkeypatch.setattr(
         hook.subprocess, "run",
         lambda *a, **k: _FakeProc(0, '{"contexts": ["node (20)"], "checks": []}'),
     )
-    assert hook.base_branch_enforces_required_checks("acme/widget", "main") is True
+    assert hook._classic_enforces_required_checks("acme/widget", "main") is True
 
 
-def test_enforces_true_on_nonempty_checks(monkeypatch) -> None:
+def test_classic_true_on_nonempty_checks(monkeypatch) -> None:
     monkeypatch.setattr(
         hook.subprocess, "run",
         lambda *a, **k: _FakeProc(0, '{"contexts": [], "checks": [{"context": "ci"}]}'),
     )
-    assert hook.base_branch_enforces_required_checks("acme/widget", "main") is True
+    assert hook._classic_enforces_required_checks("acme/widget", "main") is True
 
 
-def test_enforces_false_on_empty_required_set(monkeypatch) -> None:
+def test_classic_false_on_empty_required_set(monkeypatch) -> None:
     monkeypatch.setattr(
         hook.subprocess, "run",
         lambda *a, **k: _FakeProc(0, '{"contexts": [], "checks": []}'),
     )
-    assert hook.base_branch_enforces_required_checks("acme/widget", "main") is False
+    assert hook._classic_enforces_required_checks("acme/widget", "main") is False
 
 
-def test_enforces_false_on_branch_not_protected_404(monkeypatch) -> None:
+def test_classic_false_on_branch_not_protected_404(monkeypatch) -> None:
     # A 404 / "Branch not protected" is DEFINITIVE no-enforcement -> False, NOT None.
     monkeypatch.setattr(
         hook.subprocess, "run",
         lambda *a, **k: _FakeProc(1, "", "gh: Branch not protected (HTTP 404)"),
     )
-    assert hook.base_branch_enforces_required_checks("acme/widget", "main") is False
+    assert hook._classic_enforces_required_checks("acme/widget", "main") is False
 
 
-def test_enforces_none_on_other_error(monkeypatch) -> None:
+def test_classic_none_on_other_error(monkeypatch) -> None:
     # A permission/transport error is undeterminable -> None (fail-open), NOT False.
     monkeypatch.setattr(
         hook.subprocess, "run",
         lambda *a, **k: _FakeProc(1, "", "gh: Bad credentials (HTTP 401)"),
     )
-    assert hook.base_branch_enforces_required_checks("acme/widget", "main") is None
+    assert hook._classic_enforces_required_checks("acme/widget", "main") is None
 
 
-def test_enforces_none_on_timeout(monkeypatch) -> None:
+def test_classic_none_on_timeout(monkeypatch) -> None:
     def _boom(*a, **k):
         raise hook.subprocess.TimeoutExpired(cmd="gh", timeout=15)
 
     monkeypatch.setattr(hook.subprocess, "run", _boom)
-    assert hook.base_branch_enforces_required_checks("acme/widget", "main") is None
+    assert hook._classic_enforces_required_checks("acme/widget", "main") is None
 
 
-def test_enforces_none_on_bad_json(monkeypatch) -> None:
+def test_classic_none_on_bad_json(monkeypatch) -> None:
     monkeypatch.setattr(hook.subprocess, "run", lambda *a, **k: _FakeProc(0, "not json"))
+    assert hook._classic_enforces_required_checks("acme/widget", "main") is None
+
+
+def test_classic_none_without_repo_or_base() -> None:
+    assert hook._classic_enforces_required_checks(None, "main") is None
+    assert hook._classic_enforces_required_checks("acme/widget", None) is None
+
+
+# --------------------------------------------------------------------------- #
+# _rulesets_enforce_required_checks — the rulesets-endpoint tri-state (#262)
+# --------------------------------------------------------------------------- #
+
+# A `rules/branches/{branch}` payload with an enforcing required-status-checks rule.
+_RULESET_ENFORCING = (
+    '[{"type": "required_status_checks", "ruleset_id": 7, '
+    '"parameters": {"required_status_checks": [{"context": "node (20)"}]}}]'
+)
+# A rules payload that exists but enforces something OTHER than status checks.
+_RULESET_NON_CHECK = '[{"type": "pull_request", "ruleset_id": 9, "parameters": {}}]'
+# A required-status-checks rule present but with an EMPTY required set.
+_RULESET_EMPTY_CHECKS = (
+    '[{"type": "required_status_checks", "ruleset_id": 7, '
+    '"parameters": {"required_status_checks": []}}]'
+)
+
+
+def test_rulesets_true_on_enforcing_rule(monkeypatch) -> None:
+    monkeypatch.setattr(
+        hook.subprocess, "run", lambda *a, **k: _FakeProc(0, _RULESET_ENFORCING)
+    )
+    assert hook._rulesets_enforce_required_checks("acme/widget", "main") is True
+
+
+def test_rulesets_false_on_empty_rules(monkeypatch) -> None:
+    # This endpoint returns `200 []` for a branch with no rules -> DEFINITIVE False.
+    monkeypatch.setattr(hook.subprocess, "run", lambda *a, **k: _FakeProc(0, "[]"))
+    assert hook._rulesets_enforce_required_checks("acme/widget", "main") is False
+
+
+def test_rulesets_false_on_non_status_check_rules(monkeypatch) -> None:
+    monkeypatch.setattr(
+        hook.subprocess, "run", lambda *a, **k: _FakeProc(0, _RULESET_NON_CHECK)
+    )
+    assert hook._rulesets_enforce_required_checks("acme/widget", "main") is False
+
+
+def test_rulesets_false_on_empty_required_set(monkeypatch) -> None:
+    # A required_status_checks rule with an empty set enforces nothing -> False.
+    monkeypatch.setattr(
+        hook.subprocess, "run", lambda *a, **k: _FakeProc(0, _RULESET_EMPTY_CHECKS)
+    )
+    assert hook._rulesets_enforce_required_checks("acme/widget", "main") is False
+
+
+def test_rulesets_false_on_absent_repo_404(monkeypatch) -> None:
+    monkeypatch.setattr(
+        hook.subprocess, "run",
+        lambda *a, **k: _FakeProc(1, "", "gh: Not Found (HTTP 404)"),
+    )
+    assert hook._rulesets_enforce_required_checks("acme/widget", "main") is False
+
+
+def test_rulesets_none_on_other_error(monkeypatch) -> None:
+    # A permission/transport error is undeterminable -> None (fail-open), NOT False.
+    monkeypatch.setattr(
+        hook.subprocess, "run",
+        lambda *a, **k: _FakeProc(1, "", "gh: Bad credentials (HTTP 401)"),
+    )
+    assert hook._rulesets_enforce_required_checks("acme/widget", "main") is None
+
+
+def test_rulesets_none_on_timeout(monkeypatch) -> None:
+    def _boom(*a, **k):
+        raise hook.subprocess.TimeoutExpired(cmd="gh", timeout=15)
+
+    monkeypatch.setattr(hook.subprocess, "run", _boom)
+    assert hook._rulesets_enforce_required_checks("acme/widget", "main") is None
+
+
+def test_rulesets_none_on_bad_json(monkeypatch) -> None:
+    monkeypatch.setattr(hook.subprocess, "run", lambda *a, **k: _FakeProc(0, "not json"))
+    assert hook._rulesets_enforce_required_checks("acme/widget", "main") is None
+
+
+def test_rulesets_none_on_non_list_payload(monkeypatch) -> None:
+    # The endpoint should return a list; a dict is malformed -> undeterminable None.
+    monkeypatch.setattr(hook.subprocess, "run", lambda *a, **k: _FakeProc(0, "{}"))
+    assert hook._rulesets_enforce_required_checks("acme/widget", "main") is None
+
+
+def test_rulesets_none_without_repo_or_base() -> None:
+    assert hook._rulesets_enforce_required_checks(None, "main") is None
+    assert hook._rulesets_enforce_required_checks("acme/widget", None) is None
+
+
+# --------------------------------------------------------------------------- #
+# base_branch_enforces_required_checks — classic OR rulesets composition (#262)
+# --------------------------------------------------------------------------- #
+
+
+def _sources(monkeypatch, classic, rulesets) -> None:
+    """Stub the two probe helpers so the combiner can be tested in isolation."""
+    monkeypatch.setattr(hook, "_classic_enforces_required_checks", lambda repo, base: classic)
+    monkeypatch.setattr(hook, "_rulesets_enforce_required_checks", lambda repo, base: rulesets)
+
+
+def test_combiner_classic_true_shortcircuits(monkeypatch) -> None:
+    # classic True -> True, and the rulesets probe is never even consulted.
+    monkeypatch.setattr(hook, "_classic_enforces_required_checks", lambda repo, base: True)
+    monkeypatch.setattr(
+        hook, "_rulesets_enforce_required_checks",
+        lambda repo, base: (_ for _ in ()).throw(AssertionError("rulesets probed")),
+    )
+    assert hook.base_branch_enforces_required_checks("acme/widget", "main") is True
+
+
+def test_combiner_rulesets_true_when_classic_absent(monkeypatch) -> None:
+    # HEADLINE (#262): classic protection ABSENT (False) but a ruleset enforces
+    # required checks -> the base is recognized as protected (True). Reverting the
+    # rulesets branch (see the revert->red test) makes this False.
+    _sources(monkeypatch, classic=False, rulesets=True)
+    assert hook.base_branch_enforces_required_checks("acme/widget", "main") is True
+
+
+def test_combiner_false_only_when_both_definitively_false(monkeypatch) -> None:
+    _sources(monkeypatch, classic=False, rulesets=False)
+    assert hook.base_branch_enforces_required_checks("acme/widget", "main") is False
+
+
+def test_combiner_none_when_classic_error_and_rulesets_false(monkeypatch) -> None:
+    # An unread source can't rule out enforcement -> fail-open None, never False.
+    _sources(monkeypatch, classic=None, rulesets=False)
     assert hook.base_branch_enforces_required_checks("acme/widget", "main") is None
 
 
-def test_enforces_none_without_repo_or_base() -> None:
-    assert hook.base_branch_enforces_required_checks(None, "main") is None
-    assert hook.base_branch_enforces_required_checks("acme/widget", None) is None
+def test_combiner_none_when_rulesets_error_and_classic_false(monkeypatch) -> None:
+    _sources(monkeypatch, classic=False, rulesets=None)
+    assert hook.base_branch_enforces_required_checks("acme/widget", "main") is None
+
+
+def test_combiner_true_even_when_classic_error(monkeypatch) -> None:
+    # classic undeterminable but a ruleset definitively enforces -> True.
+    _sources(monkeypatch, classic=None, rulesets=True)
+    assert hook.base_branch_enforces_required_checks("acme/widget", "main") is True
+
+
+def test_rulesets_branch_is_load_bearing_revert_red(monkeypatch) -> None:
+    """Revert->red proof for the #262 rulesets recognition (in-memory patch only).
+
+    Real function: classic absent + a ruleset enforcing required checks -> True
+    (enforcement recognized). Reversing the production change in memory (patching
+    the rulesets probe back to its pre-#262 no-op that never reports enforcement)
+    flips the SAME inputs to False -> the over-block returns. This proves the
+    rulesets branch is what recognizes the enforcement; without it the gate
+    regresses to the false-negative. No git checkout: the reversal is a monkeypatch.
+    """
+    # Classic branch protection is absent (rulesets-only repo).
+    monkeypatch.setattr(hook, "_classic_enforces_required_checks", lambda repo, base: False)
+
+    # Production behavior: the rulesets probe reports enforcement.
+    monkeypatch.setattr(hook, "_rulesets_enforce_required_checks", lambda repo, base: True)
+    assert hook.base_branch_enforces_required_checks("acme/widget", "main") is True
+
+    # Reverted behavior: pre-#262, rulesets enforcement was never consulted, so the
+    # branch reads as unenforced. The SAME inputs now go False -> the gate would
+    # over-block a rulesets-protected repo. This asserts the branch is load-bearing.
+    monkeypatch.setattr(hook, "_rulesets_enforce_required_checks", lambda repo, base: False)
+    assert hook.base_branch_enforces_required_checks("acme/widget", "main") is False
 
 
 # --------------------------------------------------------------------------- #
@@ -221,6 +383,26 @@ def test_pending_auto_protection_undeterminable_allows(monkeypatch) -> None:
     result = hook.check(_bash(_MERGE_AUTO))
     assert result is not None
     assert result["decision"] == "allow"
+
+
+def test_pending_auto_rulesets_only_enforcement_allows(monkeypatch) -> None:
+    """#262 end-to-end: pending + --auto on a repo whose required checks are
+    enforced ONLY via a ruleset (classic protection absent). The gate must
+    recognize the ruleset enforcement and warn-allow, not over-block.
+
+    This exercises the fix through check() -> base_branch_enforces_required_checks:
+    classic False + ruleset True -> True -> warn-allow. Reverting the rulesets
+    branch would make the combiner return False -> this flips to a BLOCK.
+    """
+    _cfg(monkeypatch)
+    _rollup(monkeypatch, [_PASS_CHECK, _PENDING_CHECK])
+    _base(monkeypatch, "main")
+    monkeypatch.setattr(hook, "_classic_enforces_required_checks", lambda repo, base: False)
+    monkeypatch.setattr(hook, "_rulesets_enforce_required_checks", lambda repo, base: True)
+    result = hook.check(_bash(_MERGE_AUTO))
+    assert result is not None
+    assert result["decision"] == "allow"
+    assert "systemMessage" in result
 
 
 def test_pending_no_auto_blocks(monkeypatch) -> None:


### PR DESCRIPTION
## W18 S2 (#262) — Rulesets-aware CI gate

`validate_pr_ci_status`'s pending/`--auto` path decides whether GitHub will
**hold** an `--auto` merge until CI goes green by asking whether the base branch
enforces required status checks. It read **only** the classic branch-protection
endpoint (`repos/{repo}/branches/{base}/protection/required_status_checks`). A
repo whose required checks are enforced via a **GitHub ruleset** (not classic
protection) 404s that endpoint and read as *unenforced* — a false negative that
safe-sides the gate into an **over-block** of a legitimately-protected repo.

### Change
- Split the probe into `_classic_enforces_required_checks` (classic endpoint,
  logic unchanged) and a new `_rulesets_enforce_required_checks` that reads the
  branch's effective rules (`repos/{repo}/rules/branches/{base}`) and reports
  enforcement when any applicable `required_status_checks` rule names a non-empty
  required set.
- `base_branch_enforces_required_checks` now composes both: **if EITHER source
  reports enforcement, the base is treated as protected** (True). Classic-True
  short-circuits (rulesets not queried).

### Fail-open guarantee (preserved)
- `False` (the #230 pending/`--auto` block) is returned **only when BOTH probes
  answer definitively "no enforcement."**
- If either probe errors / times out / lacks permission with neither reporting
  enforcement, the combiner returns the `unknown` sentinel (`None`) → the caller
  **warn-allows**, never manufacturing a block on an inability to read. A read
  error on one source cannot rule out that the other enforces, so a definitive
  "not enforced" would be unsound. Only the false-negative is fixed; no path that
  previously allowed now hard-blocks.

### Tests (40/40 green, ruff clean)
- Classic-endpoint tri-state retargeted to `_classic_enforces_required_checks`
  (`test_classic_*`).
- New rulesets tri-state (`test_rulesets_*`): enforcing rule → True; `200 []` /
  non-status rule / empty required set → False; 404 → False; other error /
  timeout / bad-JSON / non-list payload → None.
- Combiner composition (`test_combiner_*`): classic-True short-circuit; classic
  absent + ruleset enforces → True; False only when both definitively False;
  None whenever either source is undeterminable.
- **check()-level end-to-end** — `test_pending_auto_rulesets_only_enforcement_allows`:
  pending + `--auto` on a rulesets-only repo (classic absent) → **warn-allow**,
  proving the gate recognizes ruleset enforcement.
- **API-error still fails open** — combiner None tests + `test_rulesets_none_on_*`
  + existing `test_pending_auto_protection_undeterminable_allows` /
  `test_rollup_unreadable_fail_open_allows`.

### revert→red evidence
`test_rulesets_branch_is_load_bearing_revert_red` reverses the production change
**in memory** (monkeypatch only — no `git checkout`): with classic absent, the
real rulesets probe → `base_branch_enforces_required_checks` returns True
(enforcement recognized); patching the rulesets probe back to its pre-#262 no-op
(never reports enforcement) flips the **same inputs** to False → the over-block
returns. This asserts the rulesets branch is what recognizes enforcement.

### Dual-tree byte-parity (#116)
This hook is wired **in-place**: `.claude/settings.json` runs
`framework/assets/hooks/*` directly and there is **no `.claude/hooks/` mirror**
(only `skills/` is byte-mirrored by `reinstall.py`). The canonical file *is* the
runtime file (canonical-by-reference — cannot drift). Verified:
`python3 framework/install/reinstall.py --check` → `reinstall: .claude/ is in
sync with canonical framework/assets/.` (rc=0). No runtime copy was created;
doing so would introduce an unwired duplicate.

Files changed: `framework/assets/hooks/validate_pr_ci_status.py`,
`framework/tests/test_validate_pr_ci_status.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
