### PR TITLE
fix(hooks): guard non-dict rulesets `parameters` in CI-status probe (#269)

### DIFF
--- a/framework/assets/hooks/validate_pr_ci_status.py
+++ b/framework/assets/hooks/validate_pr_ci_status.py
@@ -342,7 +342,15 @@ def _rulesets_enforce_required_checks(repo: str | None, base: str | None) -> boo
             continue
         if rule.get("type") != "required_status_checks":
             continue
-        params = rule.get("parameters") or {}
+        params = rule.get("parameters")
+        # The rulesets API can return `parameters` as a non-dict (e.g. a list),
+        # on which `.get(...)` would raise AttributeError and crash into
+        # fail-open — safe but noisy, and it discards the real enforcement info
+        # carried by the OTHER well-formed rules. A rule whose parameters we
+        # cannot read as a mapping simply carries NO enforcement info: skip it,
+        # don't raise, and don't let it manufacture a false "not enforced".
+        if not isinstance(params, dict):
+            continue
         required = params.get("required_status_checks") or []
         if required:
             return True

--- a/framework/tests/test_validate_pr_ci_status.py
+++ b/framework/tests/test_validate_pr_ci_status.py
@@ -196,6 +196,21 @@ _RULESET_EMPTY_CHECKS = (
     '[{"type": "required_status_checks", "ruleset_id": 7, '
     '"parameters": {"required_status_checks": []}}]'
 )
+# A required-status-checks rule whose `parameters` is a non-dict (a LIST). The
+# rulesets API can shape it this way; `.get(...)` on a list would raise (#269).
+_RULESET_LIST_PARAMS = (
+    '[{"type": "required_status_checks", "ruleset_id": 7, '
+    '"parameters": [{"required_status_checks": [{"context": "node (20)"}]}]}]'
+)
+# A LIST-parameters rule (must be skipped, not raise) sitting BEFORE a
+# well-formed enforcing rule — proves the guard preserves the other rule's
+# enforcement info instead of crashing the whole scan into fail-open.
+_RULESET_LIST_PARAMS_THEN_ENFORCING = (
+    '[{"type": "required_status_checks", "ruleset_id": 7, '
+    '"parameters": [{"required_status_checks": [{"context": "lint"}]}]}, '
+    '{"type": "required_status_checks", "ruleset_id": 8, '
+    '"parameters": {"required_status_checks": [{"context": "node (20)"}]}}]'
+)
 
 
 def test_rulesets_true_on_enforcing_rule(monkeypatch) -> None:
@@ -265,6 +280,29 @@ def test_rulesets_none_on_non_list_payload(monkeypatch) -> None:
 def test_rulesets_none_without_repo_or_base() -> None:
     assert hook._rulesets_enforce_required_checks(None, "main") is None
     assert hook._rulesets_enforce_required_checks("acme/widget", None) is None
+
+
+def test_rulesets_list_parameters_does_not_raise_or_false_enforce(monkeypatch) -> None:
+    # #269: the rulesets API can return `parameters` as a non-dict (a list).
+    # `.get(...)` on a list would raise AttributeError -> crash into fail-open.
+    # The guard skips such a rule as carrying no enforcement info: no raise, and
+    # (with no OTHER enforcing rule) a DEFINITIVE False — not a manufactured one.
+    monkeypatch.setattr(
+        hook.subprocess, "run", lambda *a, **k: _FakeProc(0, _RULESET_LIST_PARAMS)
+    )
+    assert hook._rulesets_enforce_required_checks("acme/widget", "main") is False
+
+
+def test_rulesets_list_parameters_preserves_other_rule_enforcement(monkeypatch) -> None:
+    # The list-parameters rule is skipped, but a well-formed enforcing rule after
+    # it is still honored -> True. Proves the guard preserves real enforcement
+    # info instead of discarding the whole scan on one malformed rule.
+    monkeypatch.setattr(
+        hook.subprocess,
+        "run",
+        lambda *a, **k: _FakeProc(0, _RULESET_LIST_PARAMS_THEN_ENFORCING),
+    )
+    assert hook._rulesets_enforce_required_checks("acme/widget", "main") is True
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## S3 of Wave 19 (Phase 6 W14) — guard non-dict rulesets `parameters` (#269)

Fixes tech-debt **#269** in `_rulesets_enforce_required_checks`
(`framework/assets/hooks/validate_pr_ci_status.py`, the rulesets CI-status probe I
wrote in W18).

### The bug
The scan read `params = rule.get("parameters") or {}`. The GitHub rulesets API can
return a rule's `parameters` as a non-empty **list** rather than a dict. A truthy
list slips past `or {}`, and the next `params.get(...)` raises `AttributeError` —
which crashes the whole scan into fail-open. Safe (no false block), but noisy, and
it **discards the real enforcement info** carried by the other well-formed rules in
the same payload.

### The guard
```python
params = rule.get("parameters")
if not isinstance(params, dict):
    continue
```
A rule whose `parameters` is not a mapping carries **no enforcement info**: it is
skipped, never raised on. The scan continues to the remaining rules, so genuine
enforcement configured by a well-formed sibling rule is still recognized.

### Tri-state preserved exactly
The fail-open tri-state is unchanged in every path:
- **True** — happy path, classic-enforces, rulesets-enforces (incl. a good rule
  after a malformed one)
- **False** — empty rules / 404 / empty required set (definitive not-enforced); a
  malformed rule never manufactures a false "not enforced"
- **None** — no repo/base, transport/permission error, bad JSON, non-list payload
  (the fail-open sentinel meaning "could not determine")

A malformed rule is treated as "no info from this rule," never as "not enforced."

### Tests (added to the existing hook suite; both revert→red against the old form)
- `test_rulesets_list_parameters_does_not_raise_or_false_enforce` — list
  `parameters` does not raise and yields a **definitive False** (no other enforcing
  rule). Reverting the guard reproduces the exact `AttributeError` of #269.
- `test_rulesets_list_parameters_preserves_other_rule_enforcement` — a list-params
  rule is skipped but a well-formed enforcing rule after it is still honored → True.

### Verification
- Full hook suite: **42 passed** (all prior fail-open tests green).
- `ruff check` clean (CI runs only `ruff check`).
- `python3 framework/install/reinstall.py --check` → **rc=0** (single-source hook,
  wired in place via `.claude/settings.json`; no `.claude/hooks/` mirror — no drift).

Closes #274
Closes #269
