### PR TITLE
feat(trust): symmetric scoring-ledger overhaul — 5 heuristics + distribution-health (#272)

### DIFF
--- a/.claude/skills/wave-retro/SKILL.md
+++ b/.claude/skills/wave-retro/SKILL.md
@@ -181,6 +181,10 @@ Every row applies the mechanical policy from `trust_signals.py` and cites its nu
   histories oldest→newest). If it fires (score ≤ 2 in each of the last 3 waves, or ≥ 1
   CI-red merge in each of the last 3 waves), surface a **persona-archive recommendation**
   for owner confirmation — never auto-retire.
+- **Distribution-health probe:** report `trust_signals.distribution_health([...new scores])`
+  on the wave's resulting per-engineer scores — if `degenerate` is True (all pinned at
+  min/max, or zero/low variance), the ledger stopped discriminating: cite its `reasons` in
+  the retro as a process smell (it changes no individual score).
 
 Append a `## Wave {W} Trust Updates ({DATE}) — {theme}` section containing:
 - A `| Rated | Old | New | Reason |` table — every `Reason` cites signal numbers, not

--- a/framework/assets/lib/trust_signals.py
+++ b/framework/assets/lib/trust_signals.py
@@ -21,10 +21,11 @@ Two cleanly separated layers:
     scores.
 
   * **Scoring** (pure, no I/O) — :func:`score_delta`, :func:`decay`,
-    :func:`apply_distribution_discipline`, :func:`negative_signal_line`,
-    :func:`validate_negative_signal_pass`, :func:`retirement_trigger`. Every one
-    is a pure function so the model is unit-testable, and usable standalone on a
-    hand-built signal dict, without touching the SCM at all.
+    :func:`apply_distribution_discipline`, :func:`distribution_health`,
+    :func:`negative_signal_line`, :func:`validate_negative_signal_pass`,
+    :func:`retirement_trigger`. Every one is a pure function so the model is
+    unit-testable, and usable standalone on a hand-built signal dict, without
+    touching the SCM at all.
 
 Durable review-catch ledger (#164)
 -----------------------------------
@@ -110,9 +111,19 @@ Signals per engineer (all integers, all countable from the merged-PR set):
                                review-quality signal).
   verified_reviews             clean verdicts they issued as Requestor whose
                                body carried a concrete ``Verified:`` block
-                               (>=1 real check, e.g. revert→red / Nx
-                               determinism / byte-parity) (positive —
-                               QA-rigor review signal).
+                               (>=1 real check, e.g. revert→red / revert->red /
+                               Nx determinism / byte-parity / N passed / ruff
+                               clean / coverage N%) (positive — QA-rigor review
+                               signal).
+  clean_first_pass             authored PRs merged with no must-fix + no rework
+                               at difficulty tier >=2 (positive — #H2, right
+                               the first time; trivial PRs cannot farm it).
+  missed_catches               clean verdicts they issued as Requestor on a PR
+                               a DIFFERENT reviewer durably caught a must-fix on
+                               (negative — #H4, mirror of must_fix_caught).
+  gate_bypasses                authored PRs merged with the armed review gate
+                               overridden — unresolved must-fix OR < 2 clean
+                               distinct reviews (negative — #H5, hard ding).
   difficulty_points            summed coarse difficulty weight (1-3 per PR,
                                :func:`difficulty_weight`) over authored PRs;
                                feeds the reserved-5 tiebreak, not score_delta.
@@ -214,11 +225,23 @@ _SECTION_LABEL_RE = re.compile(
     re.IGNORECASE,
 )
 _VERIFIED_CHECK_RE = re.compile(
-    r"revert\s*(?:→|-+|to)?\s*red"  # revert→red / revert to red / revert-red
+    # revert→red / revert->red / revert-red / revert to red. The arrow group
+    # ``(?:→|-+>?|to)`` accepts the unicode arrow, an ASCII arrow (``->`` /
+    # ``-->``), a bare hyphen, or the word ``to``. #270: the old ``-+`` alone
+    # consumed only the hyphen(s) of ``->`` and left the ``>`` to break the
+    # ``\s*red`` tail, so ``revert->red`` scored zero and glyph-decided the W18
+    # rotation. ``-+>?`` swallows the whole ASCII arrow.
+    r"revert\s*(?:→|-+>?|to)?\s*red"
     r"|byte[\s-]?parity"  # byte-parity
     r"|\d+\s*[x×]\s*determinism"  # Nx / N× determinism (substantive, quantified)
     r"|ci[\s-]?rollup"  # CI-rollup ...
-    r"|(?:ci|rollup)\b[^\n]*\bsuccess",  # CI/rollup ... SUCCESS
+    r"|(?:ci|rollup)\b[^\n]*\bsuccess"  # CI/rollup ... SUCCESS
+    # Generic suite evidence, each carrying a number or a named tool so a bare
+    # phrase can never satisfy the gate (anti-gaming, mirrors #259):
+    r"|\d+\s+(?:tests?\s+)?pass(?:ed|es|ing)?\b"  # N passed / N tests pass (quantified)
+    r"|ruff\s+clean"  # ruff clean (named tool)
+    r"|coverage\s+\d+\s*%"  # coverage N% (quantified)
+    r"|all\s+green",  # all green (suite-wide receipt)
     re.IGNORECASE,
 )
 # #259: the bare ``determinism`` and bare ``green ci`` / ``ci green`` alternations
@@ -227,8 +250,9 @@ _VERIFIED_CHECK_RE = re.compile(
 # the substantive forms above are creditable now: the quantified ``Nx
 # determinism`` (a bare "determinism" no longer counts) and a ``CI ... SUCCESS``
 # rollup receipt (a bare "ci green" / "green ci" no longer counts). Genuine
-# blocks — ``revert→red``, ``byte-parity``, ``5× determinism``, ``CI rollup
-# SUCCESS`` — are unaffected.
+# blocks — ``revert→red`` / ``revert->red``, ``byte-parity``, ``5× determinism``,
+# ``CI rollup SUCCESS``, ``42 passed``, ``ruff clean``, ``coverage 91%`` — are
+# unaffected. Bare ``tests pass`` (no adjacent number/tool) still scores zero.
 
 
 def _strip_code_markup(text: str) -> str:
@@ -271,6 +295,25 @@ class Signals:
     # (anti-gaming). Feeds :func:`score_delta` (clean +1 at >=2) and the
     # reserved-5 composite; never counted as a negative.
     verified_reviews: int = 0
+    # Clean-first-pass merges (#H2): authored PRs that merged with NO must-fix
+    # received AND no rework cycle at difficulty tier >=2 (:func:`difficulty_weight`
+    # — a trivial one-liner cannot farm it). Positive — rewards getting a
+    # non-trivial change right the first time. Feeds :func:`score_delta` (clean
+    # +1, once/capped, only on an otherwise-clean wave); never a negative.
+    clean_first_pass: int = 0
+    # Missed catches (#H4): CLEAN verdicts the engineer posted (as Requestor) on a
+    # PR where a DIFFERENT reviewer's must-fix was durably recorded (ledger #164 /
+    # edit-history #229 — ungameable by a later comment amendment). Negative — the
+    # mirror of ``must_fix_caught``: negligent approval of a PR that a peer found a
+    # real must-fix on. Feeds :func:`score_delta` (−1 each) and :meth:`has_negative`.
+    missed_catches: int = 0
+    # Gate bypasses (#H5): authored PRs that merged with the armed review gate
+    # overridden — an unresolved must-fix at merge time OR fewer than 2 distinct
+    # clean reviewer verdicts. Negative — a hard ding like ``ci_red_merges``.
+    # Near-zero in a healthy wave (every PR carries 2 clean reviews and no
+    # unresolved must-fix). Feeds :func:`score_delta` (−1 each) and
+    # :meth:`has_negative`.
+    gate_bypasses: int = 0
     # Summed coarse per-PR difficulty weight over the engineer's authored PRs
     # (:func:`difficulty_weight`, #229). A flagship correctness fix accrues 3, a
     # one-line config change 1, so a wave of hard work outranks a wave of trivial
@@ -293,6 +336,9 @@ class Signals:
                 self.rework_cycles,
                 self.review_false_positives,
                 self.verified_reviews,
+                self.clean_first_pass,
+                self.missed_catches,
+                self.gate_bypasses,
             )
         )
 
@@ -302,6 +348,8 @@ class Signals:
             or self.ci_red_merges
             or self.review_false_positives
             or self.rework_cycles
+            or self.missed_catches
+            or self.gate_bypasses
         )
 
 
@@ -1111,14 +1159,24 @@ def _account_pr(
 
     if comment_histories is not None:
         verdicts = verdicts_from_histories(comment_histories)
+        # The CURRENT (live) comment state — for the #H5 gate check the merge-gate
+        # oracle reads: the newest revision of each comment, NOT the durable
+        # history-recovered catch. Absent histories, the live bodies ARE current.
+        current_bodies = [h[0] for h in comment_histories if h]
     else:
         verdicts = parse_verdicts(comment_bodies or [])
+        current_bodies = comment_bodies or []
+    current_verdicts = parse_verdicts(current_bodies)
     catches = [
         c
         for c in (review_catches or [])
         if c.get("repo") == repo and str(c.get("pr")) == str(number)
     ]
 
+    # Durable catchers for this PR (canonical keys) — the reviewers whose must-fix
+    # is authoritative (ledger #164 preferred, else edit-history-aware verdicts
+    # #229). Drives the #H4 missed-catch mirror below.
+    catcher_keys: set[str] = set()
     pr_had_changes_requested = False
     if catches:
         for c in catches:
@@ -1126,6 +1184,7 @@ def _account_pr(
             author_sig.must_fix_received += 1
             requestor = c.get("requestor")
             if requestor:
+                catcher_keys.add(canon(requestor))
                 bucket(requestor).must_fix_caught += 1
     else:
         for v in verdicts:
@@ -1133,6 +1192,7 @@ def _account_pr(
                 pr_had_changes_requested = True
                 author_sig.must_fix_received += 1
                 if v.requestor:
+                    catcher_keys.add(canon(v.requestor))
                     bucket(v.requestor).must_fix_caught += 1
 
     # #258: dedup ``verified_reviews`` per (reviewer, PR). ``_account_pr`` handles
@@ -1156,6 +1216,47 @@ def _account_pr(
 
     if pr_had_changes_requested:
         author_sig.rework_cycles += 1
+
+    # #H4 missed-catch (mirror of ``must_fix_caught``): when this PR had a DURABLE
+    # must-fix catch, any reviewer who posted a CLEAN verdict on the SAME PR — and
+    # is NOT one of the catchers — negligently approved past a real finding. Keyed
+    # on the canonical reviewer so a name-variant of the catcher is excluded, and
+    # deduped per (reviewer, PR). Gated on the catch being durable — the ledger
+    # (#164) or the edit-history-aware path (#229) — so it is ungameable by a comment
+    # amendment; a legacy live-comment-bodies-only PR (no ledger, no history) does
+    # NOT fire it, since that catch could itself be edited away.
+    durable_catch_source = bool(catches) or comment_histories is not None
+    if pr_had_changes_requested and durable_catch_source:
+        dinged: set[str] = set()
+        for v in verdicts:
+            if v.changes_requested or not v.requestor:
+                continue
+            rk = canon(v.requestor)
+            if rk in catcher_keys or rk in dinged:
+                continue
+            dinged.add(rk)
+            bucket(v.requestor).missed_catches += 1
+
+    # #H5 gate-bypass (hard ding, like ``ci_red_merges``): the armed review gate
+    # requires a merge to land with NO unresolved must-fix AND >=2 DISTINCT clean
+    # reviewer verdicts. Read from the CURRENT comment state (what the merge-gate
+    # oracle sees) — an amended-clean history does not manufacture a bypass. This
+    # is near-zero in a healthy wave; a merge that overrode the gate scores −1.
+    unresolved_must_fix = any(v.changes_requested for v in current_verdicts)
+    clean_distinct_reviewers = {
+        canon(v.requestor)
+        for v in current_verdicts
+        if not v.changes_requested and v.requestor
+    }
+    if unresolved_must_fix or len(clean_distinct_reviewers) < 2:
+        author_sig.gate_bypasses += 1
+
+    # #H2 clean-first-pass: a non-trivial (tier >=2) PR merged with no must-fix and
+    # no rework round — got it right the first time. Trivial (<tier2) PRs cannot
+    # farm it. Positive; the +1 is applied once/clamped in ``score_delta`` and only
+    # on an otherwise-clean wave (``has_negative`` gates it).
+    if not pr_had_changes_requested and difficulty >= 2:
+        author_sig.clean_first_pass += 1
 
 
 def extract_signals(
@@ -1231,8 +1332,12 @@ def score_delta(sig: Signals) -> int:
       negative
         - each CI-red merge:                      -1  (hard ding)
         - each review false-positive:             -1
-        - 2+ must-fix items received as author:   -1
-        - 2+ rework cycles as author:             -1
+        - each missed catch as reviewer (#H4):    -1  (mirror of caught — a
+          clean approval past a peer's durable must-fix)
+        - each gate-bypass merge (#H5):           -1  (hard ding — merged with
+          an unresolved must-fix or < 2 clean distinct reviews)
+        - must-fix items received as author:      -1 at >=2, -2 at >=4  (#H3)
+        - rework cycles as author:                -1 at >=2, -2 at >=4  (#H3)
       positive (only when the iteration is clean of the negatives above)
         - 2+ PRs merged clean:                    +1
         - 2+ must-fix items caught as reviewer:   +1
@@ -1240,17 +1345,28 @@ def score_delta(sig: Signals) -> int:
           reviewer's clean verdicts carrying concrete ``Verified:`` receipts;
           credits demonstrated verification when there were no must-fixes to
           catch)
+        - 1+ clean-first-pass merge (#H2):        +1  (once/capped — a
+          non-trivial tier>=2 PR right the first time)
 
-    ``rework_cycles`` and ``must_fix_received`` are both in
-    :meth:`Signals.has_negative`, so a rework-/must-fix-heavy wave can never also
-    collect the clean-wave positives above.
+    ``rework_cycles``, ``must_fix_received``, ``missed_catches`` and
+    ``gate_bypasses`` are all in :meth:`Signals.has_negative`, so a wave carrying
+    any of them can never also collect the clean-wave positives above. The whole
+    delta stays clamped to [-2, +2] so a single iteration cannot swing trust
+    across the scale.
     """
     delta = 0
     delta -= sig.ci_red_merges
     delta -= sig.review_false_positives
-    if sig.must_fix_received >= 2:
+    delta -= sig.missed_catches
+    delta -= sig.gate_bypasses
+    # Graduated author dings (#H3): the ding deepens with the count.
+    if sig.must_fix_received >= 4:
+        delta -= 2
+    elif sig.must_fix_received >= 2:
         delta -= 1
-    if sig.rework_cycles >= 2:
+    if sig.rework_cycles >= 4:
+        delta -= 2
+    elif sig.rework_cycles >= 2:
         delta -= 1
 
     clean = not sig.has_negative()
@@ -1260,6 +1376,8 @@ def score_delta(sig: Signals) -> int:
         if sig.must_fix_caught >= 2:
             delta += 1
         if sig.verified_reviews >= 2:
+            delta += 1
+        if sig.clean_first_pass >= 1:
             delta += 1
 
     return max(-2, min(2, delta))
@@ -1324,6 +1442,104 @@ def apply_distribution_discipline(
         else:
             out[name] = proposed
     return out
+
+
+@dataclass
+class DistributionHealth:
+    """Verdict on whether a wave's resulting score distribution is discriminating.
+
+    A degenerate spread — everyone pinned at the floor, everyone pinned at the
+    ceiling, or everyone on the same score — means the ledger stopped telling
+    engineers apart, which is a process smell worth surfacing in the retro even
+    though it changes no individual score. All fields are derived, pure numbers.
+    """
+
+    n: int
+    scores: list[int]
+    minimum: int
+    maximum: int
+    mean: float
+    variance: float
+    spread: int
+    all_at_min: bool
+    all_at_max: bool
+    zero_variance: bool
+    low_variance: bool
+    degenerate: bool
+    reasons: list[str]
+
+
+def distribution_health(
+    scores,
+    *,
+    min_score: int = MIN_SCORE,
+    max_score: int = MAX_SCORE,
+    low_variance_threshold: float = 0.5,
+) -> DistributionHealth:
+    """Flag a degenerate per-engineer score spread. Pure — no I/O.
+
+    *scores* is the wave's resulting new-score collection — a list/tuple of ints
+    or a ``{name: score}`` dict (values are used). Answers "is the ledger actually
+    discriminating this wave?" by flagging any of:
+
+      * **all pinned at min** — every score == ``min_score`` (the whole team at
+        the floor);
+      * **all pinned at max** — every score == ``max_score`` (5 handed to all,
+        defeating distribution discipline);
+      * **zero variance** — every score identical (spread 0) but not at a rail;
+      * **low variance** — variance at/under *low_variance_threshold* with a
+        non-zero spread (barely discriminating).
+
+    ``degenerate`` is True iff any reason fired. An empty input is not degenerate
+    (nothing to discriminate) and carries a single explanatory reason.
+    """
+    vals = list(scores.values()) if isinstance(scores, dict) else list(scores)
+    vals = [int(v) for v in vals]
+    n = len(vals)
+    if n == 0:
+        return DistributionHealth(
+            n=0, scores=[], minimum=0, maximum=0, mean=0.0, variance=0.0,
+            spread=0, all_at_min=False, all_at_max=False, zero_variance=False,
+            low_variance=False, degenerate=False, reasons=["no scores to assess"],
+        )
+    lo, hi = min(vals), max(vals)
+    mean = sum(vals) / n
+    variance = sum((v - mean) ** 2 for v in vals) / n
+    spread = hi - lo
+    all_at_min = all(v == min_score for v in vals)
+    all_at_max = all(v == max_score for v in vals)
+    zero_variance = n >= 2 and spread == 0 and not (all_at_min or all_at_max)
+    low_variance = n >= 2 and spread > 0 and variance <= low_variance_threshold
+
+    reasons: list[str] = []
+    if all_at_min:
+        reasons.append(f"all {n} scores pinned at min ({min_score})")
+    if all_at_max:
+        reasons.append(f"all {n} scores pinned at max ({max_score})")
+    if zero_variance:
+        reasons.append(
+            f"zero variance (every score == {vals[0]}) — ledger not discriminating"
+        )
+    elif low_variance:
+        reasons.append(
+            f"low variance ({variance:.3f} <= {low_variance_threshold}) — "
+            "ledger barely discriminating"
+        )
+    return DistributionHealth(
+        n=n,
+        scores=vals,
+        minimum=lo,
+        maximum=hi,
+        mean=mean,
+        variance=variance,
+        spread=spread,
+        all_at_min=all_at_min,
+        all_at_max=all_at_max,
+        zero_variance=zero_variance,
+        low_variance=low_variance,
+        degenerate=bool(reasons),
+        reasons=reasons,
+    )
 
 
 def negative_signal_line(name: str, sig: Signals) -> str:

--- a/framework/assets/skills/wave-retro/SKILL.md
+++ b/framework/assets/skills/wave-retro/SKILL.md
@@ -181,6 +181,10 @@ Every row applies the mechanical policy from `trust_signals.py` and cites its nu
   histories oldest→newest). If it fires (score ≤ 2 in each of the last 3 waves, or ≥ 1
   CI-red merge in each of the last 3 waves), surface a **persona-archive recommendation**
   for owner confirmation — never auto-retire.
+- **Distribution-health probe:** report `trust_signals.distribution_health([...new scores])`
+  on the wave's resulting per-engineer scores — if `degenerate` is True (all pinned at
+  min/max, or zero/low variance), the ledger stopped discriminating: cite its `reasons` in
+  the retro as a process smell (it changes no individual score).
 
 Append a `## Wave {W} Trust Updates ({DATE}) — {theme}` section containing:
 - A `| Rated | Old | New | Reason |` table — every `Reason` cites signal numbers, not

--- a/framework/tests/test_trust_signals.py
+++ b/framework/tests/test_trust_signals.py
@@ -1766,3 +1766,348 @@ def test_verified_check_re_rejects_negating_or_bare_mention() -> None:
     assert ts._has_verified_checks("Verified:\n- revert→red\n") is True
     assert ts._has_verified_checks("Verified:\n- byte-parity OK\n") is True
     assert ts._has_verified_checks("Verified:\n- CI rollup SUCCESS\n") is True
+
+
+# ===========================================================================
+# Scoring-ledger overhaul (#272, W19 S1): five symmetric heuristics + a
+# distribution-health probe. Every rule stays a pure function of countable
+# signals and preserves the ±2/wave clamp.
+# ===========================================================================
+
+
+# ---------------------------------------------- H1: broadened Verified token set
+
+
+def test_revert_arrow_ascii_credits_verified_review_270(tmp_path) -> None:
+    """LOAD-BEARING (#270): the ASCII arrow ``revert->red`` MUST match and credit a
+    ``verified_reviews`` signal — the exact glyph that glyph-decided the W18
+    rotation (both #268 reviewers' substantive blocks scored zero because the
+    ``>`` broke the old ``revert\\s*(?:→|-+|to)?\\s*red`` tail). A false-negative
+    here re-opens #270.
+
+    Mutation bar: reverting ``_VERIFIED_CHECK_RE``'s arrow group to the old
+    ``(?:→|-+|to)?`` leaves the ``>`` of ``->`` unconsumed → ``revert->red``
+    stops matching → ``_has_verified_checks`` is False → ``verified_reviews`` is
+    0 → every assertion below fails.
+    """
+    # Pure detector: BOTH the ASCII and the unicode arrow match.
+    assert ts._has_verified_checks("Verified:\n- revert->red on the failing test\n") is True
+    assert ts._has_verified_checks("Verified:\n- revert→red on the failing test\n") is True
+    # Credit path (end-to-end through _account_pr): the ASCII-arrow Verified block
+    # credits exactly one verified_reviews to the reviewer.
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Paloma Gupta",
+        repo="o/r",
+        number=930,
+        comment_bodies=[
+            _verified_body(
+                "Tariq.Morales", verified_lines=("revert->red on the failing test",)
+            ),
+        ],
+        ci_red=False,
+    )
+    assert sigs["Tariq Morales"].verified_reviews == 1
+
+
+def test_verified_check_re_accepts_generic_suite_evidence() -> None:
+    """#H1: generic suite receipts each carrying a number or named tool are
+    creditable; a bare phrase with neither is still rejected (anti-gaming).
+    """
+    for tok in ("42 passed", "42 tests pass", "5 tests passed", "ruff clean",
+                "coverage 91%", "all green"):
+        assert ts._has_verified_checks(f"Verified:\n- {tok}\n") is True, tok
+    # Anti-gaming contract preserved: a bare "tests pass" (no adjacent number or
+    # named tool) does NOT count.
+    assert ts._has_verified_checks("Verified:\n- tests pass\n") is False
+    assert ts._has_verified_checks("Verified:\n- all the tests pass\n") is False
+
+
+# ----------------------------------------------------- H2: clean_first_pass
+
+
+def test_clean_first_pass_credited_on_nontrivial_clean_pr(tmp_path) -> None:
+    """#H2: a tier>=2 PR merged with no must-fix and no rework earns one
+    ``clean_first_pass`` (+1 in the clean-wave branch, once/capped)."""
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Paloma Gupta",
+        repo="o/r",
+        number=900,
+        comment_bodies=[
+            _verdict_body("Tariq.Morales", "Replied", None),
+            _verdict_body("Nia.Rossi", "Replied", None),
+        ],
+        ci_red=False,
+        difficulty=2,
+    )
+    p = sigs["Paloma Gupta"]
+    assert p.clean_first_pass == 1
+    assert p.gate_bypasses == 0  # two clean distinct reviews, nothing unresolved
+    assert ts.score_delta(p) == 1  # the clean-first-pass +1
+
+
+def test_clean_first_pass_not_farmed_by_trivial_pr(tmp_path) -> None:
+    """#H2: a trivial (tier 1) PR cannot farm the clean-first-pass credit."""
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Paloma Gupta",
+        repo="o/r",
+        number=901,
+        comment_bodies=[
+            _verdict_body("Tariq.Morales", "Replied", None),
+            _verdict_body("Nia.Rossi", "Replied", None),
+        ],
+        ci_red=False,
+        difficulty=1,
+    )
+    assert sigs["Paloma Gupta"].clean_first_pass == 0
+
+
+def test_clean_first_pass_blocked_on_unclean_wave() -> None:
+    """#H2: the +1 only fires on an otherwise-clean wave (``has_negative`` gates
+    it) — a must-fix-heavy author with a clean_first_pass gets no bonus."""
+    dirty = ts.Signals(prs_merged=2, clean_first_pass=1, must_fix_received=2)
+    assert dirty.has_negative() is True
+    assert ts.score_delta(dirty) == -1  # the ding, no clean-first-pass +1
+
+
+# ----------------------------------------------------- H3: graduated dings
+
+
+def test_graduated_must_fix_and_rework_dings() -> None:
+    """#H3: dings deepen with count — >=2 is −1, >=4 is −2 — for both
+    ``must_fix_received`` and ``rework_cycles``, still clamped at −2 total."""
+    assert ts.score_delta(ts.Signals(prs_merged=1, must_fix_received=2)) == -1
+    assert ts.score_delta(ts.Signals(prs_merged=1, must_fix_received=4)) == -2
+    assert ts.score_delta(ts.Signals(prs_merged=1, rework_cycles=2)) == -1
+    assert ts.score_delta(ts.Signals(prs_merged=1, rework_cycles=4)) == -2
+    # Combined deep dings stay clamped at −2 (the ±2/wave floor holds).
+    assert ts.score_delta(ts.Signals(must_fix_received=4, rework_cycles=4)) == -2
+
+
+# ------------------------------------------- H4: missed-catch (durable only)
+
+
+def test_missed_catch_dings_clean_reviewer_via_history(tmp_path) -> None:
+    """#H4: on a PR where a DIFFERENT reviewer's must-fix is durably recorded
+    (edit-history path), a reviewer who only posted a CLEAN verdict is dinged one
+    ``missed_catches``; the catcher is never dinged.
+
+    Mutation bar: dropping the ``rk in catcher_keys`` guard dings the catcher too;
+    dropping the durability gate would (correctly) not fire here since history IS
+    durable, but see the live-only test below.
+    """
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Paloma Gupta",
+        repo="o/r",
+        number=910,
+        comment_histories=[
+            # Nia caught a must-fix, later amended in place to clean.
+            [_verdict_body("Nia.Rossi", "Replied", None),
+             _verdict_body("Nia.Rossi", "Request", "Data loss in the amend path.")],
+            # Tariq only ever posted a clean review — negligent approval.
+            [_verdict_body("Tariq.Morales", "Replied", None)],
+        ],
+        ci_red=False,
+    )
+    assert sigs["Nia Rossi"].must_fix_caught == 1
+    assert sigs["Nia Rossi"].missed_catches == 0  # the catcher is not dinged
+    assert sigs["Tariq Morales"].missed_catches == 1  # clean approval past the catch
+
+
+def test_missed_catch_via_ledger_deduped_across_name_variants(tmp_path) -> None:
+    """#H4: the durable ledger (#164) also drives the missed-catch, and a reviewer
+    who posted two clean comments (variant spellings) is dinged exactly once."""
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ledger = [
+        {"repo": "o/r", "pr": 911, "requestor": "Nia.Rossi", "requestee": "Paloma.Gupta"},
+    ]
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Paloma Gupta",
+        repo="o/r",
+        number=911,
+        # All live comments read clean (Nia's was amended); Tariq posts twice.
+        comment_bodies=[
+            _verdict_body("Nia.Rossi", "Replied", None),
+            _verdict_body("Tariq.Morales", "Replied", None),
+            _verdict_body("Tariq Morales (QA)", "Replied", None),
+        ],
+        ci_red=False,
+        review_catches=ledger,
+    )
+    assert sigs["Nia Rossi"].must_fix_caught == 1
+    assert sigs["Nia Rossi"].missed_catches == 0
+    assert sigs["Tariq Morales"].missed_catches == 1  # deduped per (reviewer, PR)
+
+
+def test_missed_catch_not_fired_on_live_comment_only(tmp_path) -> None:
+    """#H4: a legacy live-comment-bodies-only PR (no ledger, no history) does NOT
+    fire the missed-catch — that catch is itself editable, so the signal would be
+    gameable. This mirrors the #203 ``credits_only_blocker`` invariant.
+
+    Mutation bar: dropping the ``durable_catch_source`` gate dings Tariq here →
+    the last assertion fails.
+    """
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Paloma Gupta",
+        repo="o/r",
+        number=912,
+        comment_bodies=[
+            _verdict_body("Nia.Rossi", "Request", "Fix this."),  # live blocking
+            _verdict_body("Tariq.Morales", "Replied", None),  # clean
+        ],
+        ci_red=False,
+    )
+    assert sigs["Nia Rossi"].must_fix_caught == 1
+    assert sigs.get("Tariq Morales", ts.Signals()).missed_catches == 0
+
+
+# ------------------------------------------------------- H5: gate-bypass
+
+
+def test_gate_bypass_on_unresolved_must_fix(tmp_path) -> None:
+    """#H5: a merge whose CURRENT comment state still carries an unresolved
+    blocking must-fix scores one ``gate_bypasses`` (hard ding) on the author."""
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Paloma Gupta",
+        repo="o/r",
+        number=920,
+        comment_bodies=[
+            _verdict_body("Nia.Rossi", "Request", "Still unresolved at merge."),
+            _verdict_body("Tariq.Morales", "Replied", None),
+        ],
+        ci_red=False,
+    )
+    assert sigs["Paloma Gupta"].gate_bypasses == 1
+
+
+def test_gate_bypass_on_too_few_clean_reviews(tmp_path) -> None:
+    """#H5: a merge with fewer than 2 distinct clean reviewer verdicts (the armed
+    gate's bar) scores a gate-bypass."""
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Paloma Gupta",
+        repo="o/r",
+        number=921,
+        comment_bodies=[_verdict_body("Tariq.Morales", "Replied", None)],  # only one
+        ci_red=False,
+    )
+    assert sigs["Paloma Gupta"].gate_bypasses == 1
+
+
+def test_no_gate_bypass_in_healthy_two_clean_review_merge(tmp_path) -> None:
+    """#H5: near-zero in a healthy wave — two distinct clean reviews and nothing
+    unresolved → no gate-bypass. Distinct-count is canonical (a name variant of
+    one reviewer is not a second reviewer)."""
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Paloma Gupta",
+        repo="o/r",
+        number=922,
+        comment_bodies=[
+            _verdict_body("Tariq.Morales", "Replied", None),
+            _verdict_body("Nia.Rossi", "Replied", None),
+        ],
+        ci_red=False,
+        difficulty=2,
+    )
+    assert sigs["Paloma Gupta"].gate_bypasses == 0
+
+
+def test_gate_bypass_variant_spellings_not_two_distinct(tmp_path) -> None:
+    """#H5: two clean comments by the SAME reviewer under different spellings are
+    ONE distinct reviewer → still a gate-bypass (the 2-reviewer bar isn't met)."""
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Paloma Gupta",
+        repo="o/r",
+        number=923,
+        comment_bodies=[
+            _verdict_body("Tariq.Morales", "Replied", None),
+            _verdict_body("Tariq Morales (QA)", "Replied", None),
+        ],
+        ci_red=False,
+    )
+    assert sigs["Paloma Gupta"].gate_bypasses == 1
+
+
+# --------------------------------------------------- distribution_health
+
+
+def test_distribution_health_healthy_spread() -> None:
+    r = ts.distribution_health([2, 3, 4, 5])
+    assert r.degenerate is False
+    assert r.reasons == []
+    assert (r.minimum, r.maximum, r.spread, r.n) == (2, 5, 3, 4)
+
+
+def test_distribution_health_all_pinned_min() -> None:
+    r = ts.distribution_health([1, 1, 1, 1])
+    assert r.all_at_min is True
+    assert r.degenerate is True
+    assert "min" in r.reasons[0]
+
+
+def test_distribution_health_all_pinned_max() -> None:
+    r = ts.distribution_health([5, 5, 5])
+    assert r.all_at_max is True
+    assert r.degenerate is True
+    assert "max" in r.reasons[0]
+
+
+def test_distribution_health_zero_variance_off_the_rails() -> None:
+    # Everyone identical but NOT at a rail → zero-variance flag, not min/max.
+    r = ts.distribution_health([3, 3, 3])
+    assert r.zero_variance is True
+    assert r.all_at_min is False and r.all_at_max is False
+    assert r.degenerate is True
+    assert r.variance == 0.0
+
+
+def test_distribution_health_low_variance_flagged() -> None:
+    r = ts.distribution_health([3, 3, 3, 4])
+    assert r.low_variance is True
+    assert r.zero_variance is False
+    assert r.spread == 1
+    assert r.degenerate is True
+
+
+def test_distribution_health_accepts_dict_and_empty() -> None:
+    d = ts.distribution_health({"a": 2, "b": 4})
+    assert d.n == 2 and d.degenerate is False
+    e = ts.distribution_health([])
+    assert e.n == 0 and e.degenerate is False and e.reasons == ["no scores to assess"]


### PR DESCRIPTION
## Story S1 (Wave 19 / Phase 6 Wave 14) — symmetric trust-ledger overhaul

Single-file overhaul of `framework/assets/lib/trust_signals.py` (canonical, single-source) plus its test module and one `wave-retro` skill touch. Every rule is a pure function of countable signals and preserves the ±2/wave clamp in `score_delta`.

### Heuristics

- **H1 — broadened `Verified:` credited-token set (ABSORBS #270, HIGH).** Fixed `_VERIFIED_CHECK_RE`'s arrow group to `(?:→|-+>?|to)?` so BOTH `revert→red` (unicode) and `revert->red` (ASCII) match — the ASCII arrow's `>` broke the old `revert\s*(?:→|-+|to)?\s*red` tail and **glyph-decided the W18 rotation** (both #268 reviewers' substantive blocks scored zero). Also broadened to generic suite evidence: `N passed` / `N tests pass`, `ruff clean`, `coverage N%`, `all green`. Anti-gaming contract preserved — a bare `tests pass` (no adjacent number or named tool) still scores zero; `42 passed`, `ruff clean`, `coverage 91%` are accepted.
- **H2 — `clean_first_pass` (+).** New `Signals` field; +1 (once, capped, clean-wave only via `has_negative()`) when an author merges a tier>=2 PR (`difficulty_weight`) with `must_fix_received==0` and `rework_cycles==0`. Trivial (<tier2) PRs cannot farm it.
- **H3 — graduated dings.** `must_fix_received` and `rework_cycles` are now −1 at >=2 and −2 at >=4 (was flat −1 at >=2). Clamp still holds at −2.
- **H4 — `missed_catches` (−, mirror of `must_fix_caught`).** New `Signals` field (in `has_negative()`); −1 to a reviewer who posted a CLEAN verdict on a PR where a *different* reviewer's must-fix was **durably** recorded (ledger #164 / edit-history #229). Gated on the durable source so it is ungameable by a comment amendment — a legacy live-comment-only PR does NOT fire it. Deduped per (reviewer, PR); the catcher is never self-dinged.
- **H5 — `gate_bypasses` (− hard, like `ci_red_merges`).** New `Signals` field (in `has_negative()`); −1 when a merge landed with an unresolved must-fix OR fewer than 2 distinct clean reviewer verdicts, read from the CURRENT comment state the merge-gate oracle sees. Near-zero in a healthy wave.

### `distribution_health(scores)`

Pure probe (accepts list or `{name: score}` dict) returning a `DistributionHealth` struct flagging a degenerate spread — all pinned at min, all pinned at max, zero variance, or low variance — so a retro can tell whether the ledger is still discriminating. **Wired into the `wave-retro` skill Step-5 report** (canonical `framework/assets/skills/wave-retro/SKILL.md`; `.claude/skills/` mirror synced via `python3 framework/install/reinstall.py`, not hand-edited).

### Verification

- **Tests:** +19 new (module now 121, full suite **862 passed**). Includes the named load-bearing #270 proof `test_revert_arrow_ascii_credits_verified_review_270` (asserts the ASCII `revert->red` yields a `verified_reviews` credit, both via `_has_verified_checks` and end-to-end through `_account_pr`), plus a durable-vs-live-only test that pins H4's ungameable gate.
- **`ruff check`:** clean (CI runs only `ruff check`).
- **`python3 framework/install/reinstall.py --check`:** rc=0 (no source↔runtime drift).

Closes #272
Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FSSf75g21FAh8cTWNHBrX
