### PR TITLE
feat(cli): add `2real-team restore` — undo an install's tracked file changes (#265)

### DIFF
--- a/framework/install/repo_space.py
+++ b/framework/install/repo_space.py
@@ -236,6 +236,25 @@ def restore_assets(
     return result
 
 
+def find_latest_archive(repo_root: Path | str) -> Path | None:
+    """The most recent consented archive dir (``.claude-backups/<UTC>/`` with a manifest), or None.
+
+    Archives are named by their UTC stamp, so a lexical sort is chronological — the last entry is
+    the newest. Only a directory carrying a :data:`MANIFEST_NAME` counts (a half-made or foreign
+    dir is skipped), so the result is always something :func:`restore_assets` can read. This lives
+    here because ``repo_space`` owns the archive format; both the uninstaller and the standalone
+    ``restore`` command reverse the same archive.
+    """
+    base = Path(repo_root) / BACKUPS_DIRNAME
+    if not base.is_dir():
+        return None
+    archives = sorted(
+        (d for d in base.iterdir() if d.is_dir() and (d / MANIFEST_NAME).is_file()),
+        key=lambda d: d.name,
+    )
+    return archives[-1] if archives else None
+
+
 # ------------------------------------------------------------------- disposition choice
 
 

--- a/framework/install/restore.py
+++ b/framework/install/restore.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Restore a repo's pre-install originals — undo the files an install displaced/overwrote (#265/#273).
+
+Sibling to ``uninstall.py``, but a DIFFERENT contract. Where ``uninstall`` tears out the whole
+framework install set (hooks/lib/skills/config + charter + team artifacts + the managed
+``.gitignore``/``settings.json`` wiring) and, as a side effect, restores any archived originals,
+``restore`` does exactly one thing: **recover the operator's own pre-existing files that an
+install touched**, driven by the reversible manifest (#108) and the install's ``.bak`` backups. It
+does NOT remove the framework's net-new files — use ``uninstall`` for a full teardown.
+
+Two directions, both driven by what the installer recorded
+==========================================================
+An install touches a pre-existing file in one of two reversible ways, and ``restore`` reverses
+each from the exact artifact the installer left behind:
+
+* **moved / backed-up** — in the consented *archive* disposition (#108) the whole pre-existing
+  ``.claude/`` + ``CLAUDE.md`` are MOVED into ``.claude-backups/<UTC>/`` alongside a restore
+  manifest (``archive-manifest.json``). ``restore`` moves them back byte-identical via
+  :func:`repo_space.restore_assets` (``overwrite=True``, since a fresh install now sits at the
+  target). This is the reversible-manifest path.
+* **modified** — where the installer rewrote a file in place it first renamed the operator's
+  original to a non-clobbering ``.bak`` sibling (the root ``CLAUDE.md`` → ``CLAUDE.md.bak`` in the
+  team-CLI path, and the git ``pre-push`` → ``pre-push.bak`` in the framework bootstrapper).
+  ``restore`` moves each ``.bak`` back over the current file, reverting the modification.
+
+Contract boundary — what ``restore`` deliberately is NOT
+========================================================
+* NOT a git-level pristine reset. It reverses only the install's tracked changes to files it
+  actually displaced/overwrote — it never touches untracked edits, other working-tree state, or
+  git history. Recovering a globally pristine tree is git's job (``git checkout``/``stash``), not
+  this command's.
+* NOT the framework teardown. In-place *merges* with no ``.bak`` original (the ``.gitignore``
+  managed block, the ``settings.json`` hook wiring) are un-merged structurally by ``uninstall``,
+  not here — ``restore`` is scoped to the backup/manifest-recoverable originals only.
+
+Preview + consent (fail-safe)
+=============================
+Every run first PRINTS the exact plan (what will be restored + what will be reverted) before any
+mutation. ``--dry-run`` stops there and writes nothing. A live run then asks an explicit ``[y/N]``
+confirmation; ``--non-interactive`` is the automation contract (proceed, no prompt); a non-TTY
+without ``--non-interactive`` REFUSES rather than mutating unattended. A repo with nothing to
+recover is a clean no-op (exit 0).
+
+Stdlib only (no deps). Reuses ``repo_space`` (archive format + restore) and ``bootstrap`` (the
+git-hooks-dir resolver) so the restore set cannot drift from what the install wrote.
+
+Usage
+=====
+  python3 restore.py /path/to/repo                 # preview, confirm [y/N], then restore
+  python3 restore.py /path/to/repo --non-interactive
+  python3 restore.py /path/to/repo --dry-run       # preview only; write nothing
+
+Exit codes: 0 ok / dry-run / nothing-to-do, 1 on a refused run or an unresolved conflict.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import bootstrap  # noqa: E402  (sibling; the git-hooks-dir resolver, so we can't drift)
+import repo_space  # noqa: E402  (sibling; archive format + consented restore, #108)
+
+#: Root file the team-CLI install rewrites, preserving the original as ``CLAUDE.md.bak``.
+_CLAUDE_MD = "CLAUDE.md"
+#: git hook the framework bootstrapper rewrites, preserving the original as ``pre-push.bak``.
+_PRE_PUSH = "pre-push"
+#: The single, non-suffixed backup names that hold the true PRE-INSTALL original. Later suffixed
+#: backups (``.bak.1`` …) captured a subsequent install's own output, not the operator's original,
+#: so they are intentionally NOT restored.
+_BACKUP_SUFFIX = ".bak"
+
+
+# --------------------------------------------------------------------------------- plan model
+
+
+@dataclass
+class BakRevert:
+    """A modified file to revert: move ``backup`` (the pre-install original) back over ``target``."""
+
+    target_rel: str  #: repo-root-relative POSIX path of the file to put back
+    backup: Path  #: absolute path of the ``.bak`` sibling holding the original
+    target: Path  #: absolute path of the current file to overwrite
+
+
+@dataclass
+class RestorePlan:
+    """What a restore would do, resolved BEFORE any mutation (drives the preview + the apply)."""
+
+    archive_dir: Path | None = None
+    archived: list[str] = field(default_factory=list)  #: manifest members present in the archive
+    reverts: list[BakRevert] = field(default_factory=list)  #: ``.bak`` originals to move back
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.archived and not self.reverts
+
+
+@dataclass
+class RestoreReport:
+    """Outcome of :func:`apply_restore`."""
+
+    restored: list[str] = field(default_factory=list)  #: archived members moved back
+    reverted: list[str] = field(default_factory=list)  #: modified files reverted from ``.bak``
+    conflicts: list[str] = field(default_factory=list)  #: archived members left in place
+    notes: list[str] = field(default_factory=list)
+
+
+# ------------------------------------------------------------------------------- discovery
+
+
+def _discover_bak_reverts(target: Path) -> list[BakRevert]:
+    """Find the install's ``.bak`` originals for the files it rewrites in place.
+
+    Deliberately scoped to the two files an install is known to displace — the root ``CLAUDE.md``
+    and the git ``pre-push`` hook — matched by the exact, non-suffixed ``.bak`` name the installer
+    writes for the FIRST (pre-install) original. It does not sweep for arbitrary ``*.bak`` (which
+    could be the operator's own unrelated backups). A ``.bak`` with no current target still counts:
+    the original is moved back into place regardless.
+    """
+    reverts: list[BakRevert] = []
+
+    claude_bak = target / f"{_CLAUDE_MD}{_BACKUP_SUFFIX}"
+    if claude_bak.is_file():
+        reverts.append(
+            BakRevert(target_rel=_CLAUDE_MD, backup=claude_bak, target=target / _CLAUDE_MD)
+        )
+
+    hooks_dir, _note = bootstrap._git_hooks_dir(target)
+    if hooks_dir is not None:
+        pp_bak = hooks_dir / f"{_PRE_PUSH}{_BACKUP_SUFFIX}"
+        if pp_bak.is_file():
+            rel = pp_bak.with_name(_PRE_PUSH)
+            try:
+                target_rel = rel.relative_to(target).as_posix()
+            except ValueError:
+                target_rel = str(rel)  # hooks dir outside the repo (core.hooksPath) — show abs
+            reverts.append(BakRevert(target_rel=target_rel, backup=pp_bak, target=rel))
+
+    return reverts
+
+
+def _archived_members(archive_dir: Path) -> list[str]:
+    """Manifest members that are actually present in ``archive_dir`` (restorable now)."""
+    try:
+        manifest = json.loads((archive_dir / repo_space.MANIFEST_NAME).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    return [
+        entry["name"]
+        for entry in manifest.get("entries", [])
+        if isinstance(entry, dict) and "name" in entry and (archive_dir / entry["name"]).exists()
+    ]
+
+
+def plan_restore(target: Path | str) -> RestorePlan:
+    """Resolve the full restore plan for ``target`` without mutating anything."""
+    target = Path(target).resolve()
+    archive_dir = repo_space.find_latest_archive(target)
+    archived = _archived_members(archive_dir) if archive_dir is not None else []
+    return RestorePlan(
+        archive_dir=archive_dir,
+        archived=archived,
+        reverts=_discover_bak_reverts(target),
+    )
+
+
+# ----------------------------------------------------------------------------------- apply
+
+
+def apply_restore(target: Path | str, plan: RestorePlan, *, dry_run: bool = False) -> RestoreReport:
+    """Execute ``plan``. Restores archived originals first, then reverts ``.bak`` modifications.
+
+    Archived members are moved back with ``overwrite=True`` (a fresh install sits at the target);
+    on a clean restore the spent manifest is consumed and the emptied archive dir pruned so no
+    stale backup lingers. A member already present and NOT overwritable is reported as a conflict.
+    Each ``.bak`` original is then moved back over its current file. ``dry_run`` computes nothing
+    destructive — it just echoes the plan as the report.
+    """
+    target = Path(target).resolve()
+    report = RestoreReport()
+
+    if plan.archive_dir is not None and plan.archived:
+        if dry_run:
+            report.restored.extend(plan.archived)
+        else:
+            res = repo_space.restore_assets(target, plan.archive_dir, overwrite=True)
+            report.restored.extend(res.restored)
+            report.conflicts.extend(res.conflicts)
+            if not res.conflicts:
+                # Clean restore — consume the now-spent manifest and prune the emptied archive dir
+                # (repo_space deliberately leaves the container; #149 finding 4).
+                (plan.archive_dir / repo_space.MANIFEST_NAME).unlink(missing_ok=True)
+                _prune_dir(plan.archive_dir)
+                _prune_dir(plan.archive_dir.parent)  # .claude-backups/ if now empty
+
+    for rev in plan.reverts:
+        if dry_run:
+            report.reverted.append(rev.target_rel)
+            continue
+        if rev.target.exists() or rev.target.is_symlink():
+            if rev.target.is_dir() and not rev.target.is_symlink():
+                shutil.rmtree(rev.target)
+            else:
+                rev.target.unlink()
+        rev.backup.replace(rev.target)  # move the original back (the .bak IS the original)
+        report.reverted.append(rev.target_rel)
+
+    return report
+
+
+def _prune_dir(d: Path) -> None:
+    """Best-effort ``rmdir`` of a now-empty dir (never errors if non-empty / missing)."""
+    try:
+        d.rmdir()
+    except OSError:
+        pass
+
+
+# ------------------------------------------------------------------------------------- CLI
+
+
+def _confirm(target: Path, *, non_interactive: bool, dry_run: bool) -> bool:
+    """Consent gate for the destructive run — mirrors ``uninstall``'s automation contract.
+
+    ``--dry-run`` writes nothing so it always proceeds; ``--non-interactive`` is the automation
+    contract (proceed, no prompt); an interactive TTY is asked ``[y/N]``; a non-TTY without
+    ``--non-interactive`` REFUSES rather than restoring over files unattended.
+    """
+    if dry_run or non_interactive:
+        return True
+    if not sys.stdin.isatty():
+        print(
+            "refusing to restore over files without a TTY — pass --non-interactive to proceed.",
+            file=sys.stderr,
+        )
+        return False
+    ans = input(f"Restore this repo's pre-install originals into {target}? [y/N]: ").strip().lower()
+    return ans in ("y", "yes")
+
+
+def _print_plan(plan: RestorePlan, *, dry_run: bool) -> None:
+    """Print EXACTLY what will be restored/reverted, before any mutation."""
+    verb = "would restore" if dry_run else "will restore"
+    print("\n-- plan --" if dry_run else "\n-- to restore --")
+    if plan.archived:
+        loc = plan.archive_dir.name if plan.archive_dir is not None else "(archive)"
+        for name in plan.archived:
+            print(f"{verb} (moved back):   {name}   <- {repo_space.BACKUPS_DIRNAME}/{loc}/")
+    for rev in plan.reverts:
+        print(f"{verb} (reverted):    {rev.target_rel}   <- {rev.backup.name}")
+    if plan.is_empty:
+        print("(nothing to restore — no archive and no .bak originals from an install)")
+
+
+def _print_report(report: RestoreReport) -> None:
+    print("\n-- result --")
+    if report.restored:
+        print(f"restored (moved back): {', '.join(report.restored)}")
+    if report.reverted:
+        print(f"reverted (from .bak):  {', '.join(report.reverted)}")
+    if report.conflicts:
+        print(
+            f"conflict (left in archive; not overwritten): {', '.join(report.conflicts)}",
+            file=sys.stderr,
+        )
+    for note in report.notes:
+        print(f"note:                  {note}")
+    print("\nDone. Restart Claude Code if a restored file changed the framework wiring.")
+
+
+def cli_restore(target: Path | str, *, dry_run: bool, non_interactive: bool) -> int:
+    """The product entry (shared by ``restore.py`` and the ``2real-team restore`` bridge)."""
+    target = Path(target).resolve()
+    print(f"== 2real framework restore ({'DRY-RUN' if dry_run else 'RESTORE'}) ==")
+    print(f"target repo:   {target}")
+
+    plan = plan_restore(target)
+    _print_plan(plan, dry_run=dry_run)
+
+    if plan.is_empty:
+        return 0
+    if dry_run:
+        print("\n(dry-run — nothing was changed)")
+        return 0
+    if not _confirm(target, non_interactive=non_interactive, dry_run=dry_run):
+        print("aborted — nothing changed.", file=sys.stderr)
+        return 1
+
+    report = apply_restore(target, plan, dry_run=False)
+    _print_report(report)
+    return 1 if report.conflicts else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Restore a repo's pre-install originals — undo the install's tracked "
+        "changes to files it displaced/overwrote (#265). NOT a git pristine reset; NOT a full "
+        "framework teardown (use uninstall.py for that).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("target", nargs="?", default=".", help="Target repo root (default: cwd)")
+    ap.add_argument("--dry-run", action="store_true", help="Print the plan; write nothing")
+    ap.add_argument(
+        "--non-interactive", action="store_true",
+        help="Never prompt (the automation contract); proceed without the [y/N] confirmation",
+    )
+    args = ap.parse_args(argv)
+    return cli_restore(
+        Path(args.target), dry_run=args.dry_run, non_interactive=args.non_interactive
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/framework/install/uninstall.py
+++ b/framework/install/uninstall.py
@@ -409,18 +409,6 @@ def _surgical_claude_removal(
     return removed, preserved
 
 
-def find_latest_archive(target: Path) -> Path | None:
-    """The most recent consented archive dir (``.claude-backups/<UTC>/`` with a manifest), or None."""
-    base = target / repo_space.BACKUPS_DIRNAME
-    if not base.is_dir():
-        return None
-    archives = sorted(
-        (d for d in base.iterdir() if d.is_dir() and (d / repo_space.MANIFEST_NAME).is_file()),
-        key=lambda d: d.name,
-    )
-    return archives[-1] if archives else None
-
-
 def _prune_empty_dirs(*roots: Path) -> None:
     """Best-effort removal of now-empty framework-owned dirs (deepest-first, then the root)."""
     for root in roots:
@@ -475,7 +463,7 @@ def uninstall(target: Path | str, *, dry_run: bool = False) -> dict:
 
     # 2. The .claude tree: restore a consented pre-install archive if one exists (#108), else
     #    surgically remove the enumerated install set + un-merge settings.json.
-    archive_dir = find_latest_archive(target)
+    archive_dir = repo_space.find_latest_archive(target)
     if archive_dir is not None:
         if dry_run:
             report["notes"].append(f"would restore archived pre-install assets from {archive_dir.name}")

--- a/framework/tests/test_restore.py
+++ b/framework/tests/test_restore.py
@@ -1,0 +1,162 @@
+"""Tests for the standalone ``restore`` command (#265/#273).
+
+``restore`` recovers a repo's PRE-INSTALL originals that an install displaced/overwrote, driven
+by the reversible manifest (#108) and the installer's ``.bak`` backups — WITHOUT removing the
+framework's own install set (that is ``uninstall``'s job). Coverage:
+
+* **Round-trip, BOTH directions** — the headline AC: a moved/backed-up file (an archived
+  ``.claude/`` under ``.claude-backups/<UTC>/``) AND a modified file (a rewritten ``CLAUDE.md``
+  whose original the installer kept as ``CLAUDE.md.bak``) both come back byte-identical.
+* **Dry-run preview accuracy** — the plan lists EXACTLY what a live run restores/reverts, and
+  writes nothing.
+* **No mutation without consent** — a non-TTY run without ``--non-interactive`` refuses and leaves
+  the tree untouched.
+* Idempotency / clean no-op on a repo with nothing to recover.
+
+Stdlib + pytest only; everything runs under ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+_INSTALL = _FRAMEWORK_ROOT / "install"
+_RESTORE = _INSTALL / "restore.py"
+if str(_INSTALL) not in sys.path:
+    sys.path.insert(0, str(_INSTALL))
+
+import repo_space  # noqa: E402
+import restore  # noqa: E402
+
+
+# --------------------------------------------------------------------------- helpers
+
+
+def _run_restore(d: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(_RESTORE), str(d), *args],
+        capture_output=True, text=True, stdin=subprocess.DEVNULL,
+    )
+
+
+def _seed_moved_asset(root: Path) -> bytes:
+    """Simulate the *archive* disposition: an original ``.claude/`` MOVED to a backup dir.
+
+    Creates a pre-existing ``.claude/`` with distinctive content, archives it via
+    ``repo_space.archive_assets`` (the exact install path), then lays a fresh framework-ish
+    ``.claude/`` where it stood. Returns the original charter bytes for a byte-identity assert.
+    """
+    claude = root / ".claude"
+    (claude / "team").mkdir(parents=True)
+    original = b"# ORIGINAL charter (pre-install)\n"
+    (claude / "team" / "charter.md").write_bytes(original)
+    repo_space.archive_assets(root)  # MOVES .claude/ into .claude-backups/<UTC>/ + manifest
+    assert not claude.exists()
+    # A fresh install now sits where the original was.
+    (claude / "team").mkdir(parents=True)
+    (claude / "team" / "charter.md").write_bytes(b"# FRESH framework charter\n")
+    return original
+
+
+def _seed_modified_file(root: Path) -> bytes:
+    """Simulate an in-place *modified* file: original kept as ``CLAUDE.md.bak``, fresh written."""
+    original = b"# ORIGINAL repo instructions (pre-install)\n"
+    (root / "CLAUDE.md.bak").write_bytes(original)  # what the installer's rename left behind
+    (root / "CLAUDE.md").write_bytes(b"# FRESH framework CLAUDE.md\n")
+    return original
+
+
+# --------------------------------------------------------------- round-trip, both directions
+
+
+def test_round_trip_restores_both_directions(tmp_path: Path):
+    """The headline AC: a moved/backed-up file AND a modified file both restore byte-identical."""
+    moved_original = _seed_moved_asset(tmp_path)
+    modified_original = _seed_modified_file(tmp_path)
+
+    r = _run_restore(tmp_path, "--non-interactive")
+    assert r.returncode == 0, r.stderr
+
+    # (a) moved/backed-up: the archived original .claude/ is back, byte-identical.
+    assert (tmp_path / ".claude" / "team" / "charter.md").read_bytes() == moved_original
+    # (b) modified: CLAUDE.md reverted to the pre-install original from its .bak.
+    assert (tmp_path / "CLAUDE.md").read_bytes() == modified_original
+    # the spent .bak original was moved back (not left as a stray sibling).
+    assert not (tmp_path / "CLAUDE.md.bak").exists()
+    # the emptied backup container was pruned.
+    assert not (tmp_path / repo_space.BACKUPS_DIRNAME).exists()
+
+
+def test_plan_sees_both_directions(tmp_path: Path):
+    """The resolved plan enumerates the archived member AND the .bak revert before any mutation."""
+    _seed_moved_asset(tmp_path)
+    _seed_modified_file(tmp_path)
+
+    plan = restore.plan_restore(tmp_path)
+    assert plan.archived == [".claude"]
+    assert [rev.target_rel for rev in plan.reverts] == ["CLAUDE.md"]
+    assert not plan.is_empty
+
+
+# ---------------------------------------------------------------------- dry-run preview accuracy
+
+
+def test_dry_run_previews_and_writes_nothing(tmp_path: Path):
+    """--dry-run names exactly what a live run would restore/revert and mutates nothing."""
+    _seed_moved_asset(tmp_path)
+    _seed_modified_file(tmp_path)
+    fresh_charter = (tmp_path / ".claude" / "team" / "charter.md").read_bytes()
+    fresh_claude = (tmp_path / "CLAUDE.md").read_bytes()
+
+    r = _run_restore(tmp_path, "--dry-run")
+    assert r.returncode == 0, r.stderr
+    assert ".claude" in r.stdout and "CLAUDE.md" in r.stdout
+
+    # Nothing changed: the fresh files and the backups are all still in place.
+    assert (tmp_path / ".claude" / "team" / "charter.md").read_bytes() == fresh_charter
+    assert (tmp_path / "CLAUDE.md").read_bytes() == fresh_claude
+    assert (tmp_path / "CLAUDE.md.bak").exists()
+    assert repo_space.find_latest_archive(tmp_path) is not None
+
+
+# ------------------------------------------------------------------- no mutation without consent
+
+
+def test_non_tty_without_flag_refuses(tmp_path: Path):
+    """A non-TTY run without --non-interactive refuses and leaves everything untouched."""
+    _seed_moved_asset(tmp_path)
+    modified_original = _seed_modified_file(tmp_path)
+    fresh_claude = (tmp_path / "CLAUDE.md").read_bytes()
+
+    r = _run_restore(tmp_path)  # stdin is DEVNULL -> not a TTY, no --non-interactive
+    assert r.returncode == 1
+    assert "refusing" in r.stderr.lower()
+
+    # Untouched: fresh CLAUDE.md still present, original still parked in its .bak, archive intact.
+    assert (tmp_path / "CLAUDE.md").read_bytes() == fresh_claude
+    assert (tmp_path / "CLAUDE.md.bak").read_bytes() == modified_original
+    assert repo_space.find_latest_archive(tmp_path) is not None
+
+
+# ------------------------------------------------------------------------------- no-op / idempotent
+
+
+def test_nothing_to_restore_is_clean_noop(tmp_path: Path):
+    """A repo with no archive and no .bak originals is a clean exit-0 no-op."""
+    r = _run_restore(tmp_path, "--non-interactive")
+    assert r.returncode == 0, r.stderr
+    assert "nothing to restore" in r.stdout.lower()
+
+
+def test_restore_is_idempotent(tmp_path: Path):
+    """Re-running after a successful restore finds nothing left to do (clean no-op)."""
+    _seed_moved_asset(tmp_path)
+    _seed_modified_file(tmp_path)
+    assert _run_restore(tmp_path, "--non-interactive").returncode == 0
+
+    r2 = _run_restore(tmp_path, "--non-interactive")
+    assert r2.returncode == 0, r2.stderr
+    assert "nothing to restore" in r2.stdout.lower()

--- a/python/src/real_team/cli.py
+++ b/python/src/real_team/cli.py
@@ -606,6 +606,46 @@ def uninstall(
     console.print("\n[bold green]Framework runtime uninstalled.[/bold green]")
 
 
+@app.command()
+def restore(
+    target: str = typer.Option(".", help="Target directory"),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Preview exactly what would be restored/reverted; write nothing"
+    ),
+    non_interactive: bool = typer.Option(
+        False,
+        "--non-interactive",
+        help="Never prompt; proceed without the confirmation gate (automation)",
+    ),
+) -> None:
+    """Restore this repo's pre-install originals — undo the install's tracked changes.
+
+    Recovers the files an install displaced or overwrote: originals it MOVED into a consented
+    .claude-backups/ archive are moved back, and files it rewrote in place (root CLAUDE.md, the
+    git pre-push hook) are reverted from the .bak the installer left. This is NOT a git-level
+    pristine reset, and it does NOT remove the framework's own files — for a full teardown use
+    `2real-team uninstall`. Always prints the plan before mutating; --dry-run previews only.
+    """
+    from .framework_install import restore_framework
+
+    target_path = Path(target).resolve()
+    proc = restore_framework(
+        target_path, dry_run=dry_run, non_interactive=non_interactive
+    )
+    if proc is None:
+        console.print(
+            "[yellow]Cannot restore:[/yellow] bundled framework assets not found "
+            "(re-run from a source checkout, or use the standalone framework restore command)."
+        )
+        raise typer.Exit(1)
+    if proc.stdout:
+        console.print(proc.stdout.rstrip())
+    if proc.returncode != 0:
+        if proc.stderr:
+            console.print(f"[red]{proc.stderr.strip()}[/red]")
+        raise typer.Exit(proc.returncode)
+
+
 def _extract_field(content: str, field: str) -> str | None:
     """Extract a field value from a roster card."""
     for line in content.splitlines():

--- a/python/src/real_team/framework_install.py
+++ b/python/src/real_team/framework_install.py
@@ -131,3 +131,33 @@ def uninstall_framework(
     if dry_run:
         cmd += ["--dry-run"]
     return subprocess.run(cmd, capture_output=True, text=True)
+
+
+def restore_framework(
+    target: Path,
+    *,
+    dry_run: bool = False,
+    non_interactive: bool = True,
+) -> subprocess.CompletedProcess | None:
+    """Restore a repo's pre-install originals via ``framework/install/restore.py``.
+
+    Undoes the install's tracked changes to files it displaced/overwrote — the consented archive
+    (moved originals) and the ``.bak`` backups of files it rewrote — WITHOUT removing the
+    framework's own install set (that is :func:`uninstall_framework`'s job). Locates the same
+    framework root (wheel-bundled copy first, source checkout as fallback) and runs the
+    deterministic restore command. Defaults to ``non_interactive=True`` so the packaged command
+    never hangs on a prompt; pass ``non_interactive=False`` to let it ask for confirmation on a TTY.
+
+    Returns the CompletedProcess (inspect ``.returncode`` / ``.stdout``), or None when the framework
+    assets could not be located (caller should report a soft notice, not fail).
+    """
+    root = resolve_framework_root()
+    if root is None:
+        return None
+
+    cmd: list[str] = [sys.executable, str(root / "install" / "restore.py"), str(target)]
+    if non_interactive:
+        cmd += ["--non-interactive"]
+    if dry_run:
+        cmd += ["--dry-run"]
+    return subprocess.run(cmd, capture_output=True, text=True)

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1468,3 +1468,58 @@ class TestUninstall:
             app, ["uninstall", "--target", str(tmp_path), "--non-interactive"]
         )
         assert result.exit_code == 0, result.output
+
+
+class TestRestore:
+    """The packaged ``2real-team restore`` command (bridges to framework/install/restore.py)."""
+
+    def _seed_backups(self, tmp_path: Path) -> tuple[bytes, bytes]:
+        """Seed BOTH restore directions: an archived original + an in-place .bak original."""
+        import sys as _sys
+
+        from real_team.framework_install import resolve_framework_root
+
+        root = resolve_framework_root()
+        assert root is not None
+        _sys.path.insert(0, str(root / "install"))
+        import repo_space  # framework sibling
+
+        # (a) moved/backed-up: original .claude/ archived, fresh laid where it stood.
+        claude = tmp_path / ".claude"
+        (claude / "team").mkdir(parents=True)
+        moved_original = b"# ORIGINAL charter\n"
+        (claude / "team" / "charter.md").write_bytes(moved_original)
+        repo_space.archive_assets(tmp_path)
+        (claude / "team").mkdir(parents=True)
+        (claude / "team" / "charter.md").write_bytes(b"# FRESH charter\n")
+
+        # (b) modified: CLAUDE.md rewritten, original kept as CLAUDE.md.bak.
+        modified_original = b"# ORIGINAL CLAUDE.md\n"
+        (tmp_path / "CLAUDE.md.bak").write_bytes(modified_original)
+        (tmp_path / "CLAUDE.md").write_bytes(b"# FRESH CLAUDE.md\n")
+        return moved_original, modified_original
+
+    def test_restore_recovers_both_directions(self, tmp_path: Path):
+        moved_original, modified_original = self._seed_backups(tmp_path)
+        result = runner.invoke(
+            app, ["restore", "--target", str(tmp_path), "--non-interactive"]
+        )
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / ".claude" / "team" / "charter.md").read_bytes() == moved_original
+        assert (tmp_path / "CLAUDE.md").read_bytes() == modified_original
+
+    def test_restore_dry_run_writes_nothing(self, tmp_path: Path):
+        self._seed_backups(tmp_path)
+        fresh = (tmp_path / "CLAUDE.md").read_bytes()
+        result = runner.invoke(
+            app, ["restore", "--target", str(tmp_path), "--dry-run", "--non-interactive"]
+        )
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "CLAUDE.md").read_bytes() == fresh
+        assert (tmp_path / "CLAUDE.md.bak").exists()
+
+    def test_restore_nothing_to_do_is_clean(self, tmp_path: Path):
+        result = runner.invoke(
+            app, ["restore", "--target", str(tmp_path), "--non-interactive"]
+        )
+        assert result.exit_code == 0, result.output


### PR DESCRIPTION
## Summary

Adds a first-class **`2real-team restore`** product command that undoes an install's tracked changes to files it **displaced or overwrote**, surfacing the reversible-manifest machinery (#108) that until now was only reachable indirectly through `uninstall`.

`restore` recovers the operator's **pre-install originals** — WITHOUT removing the framework's own net-new install set. That distinction is the whole point of the command: `uninstall` is "remove the framework (and, as a side effect, give my originals back)"; `restore` is "give my originals back, leave the framework alone."

## Both-directions restore (owner requirement)

Each direction is reversed from exactly the artifact the installer left behind:

| Direction | What the install did | What `restore` does |
|---|---|---|
| **moved / backed-up** | consented *archive* disposition MOVED pre-existing `.claude/` + `CLAUDE.md` into `.claude-backups/<UTC>/` with a restore manifest | moves them back byte-identical via `repo_space.restore_assets` (`overwrite=True`, since a fresh install now sits there); spent manifest + emptied container pruned |
| **modified** | rewrote a file in place after renaming the original to a `.bak` (root `CLAUDE.md` → `CLAUDE.md.bak`; git `pre-push` → `pre-push.bak`) | moves each `.bak` original back over the current file |

## Dry-run + consent

- Every run **prints the exact plan** (what will be restored + what will be reverted) **before any mutation**.
- `--dry-run` stops there and writes nothing.
- A live run takes an explicit `[y/N]` confirmation; `--non-interactive` is the automation opt-out; a **non-TTY without `--non-interactive` refuses** rather than mutating unattended.
- A repo with nothing to recover is a clean exit-0 no-op; the command is idempotent.

## Contract (documented in `--help` and the module docstring)

"Undo the install's tracked changes to files it displaced/overwrote." Explicitly **NOT**:
- a git-level pristine reset (untracked edits / history / other working-tree state are never touched — that's `git checkout`/`stash`);
- a framework teardown — in-place *merges* with no `.bak` original (the `.gitignore` managed block, the `settings.json` hook wiring) are un-merged structurally by **`uninstall`**, not here. `restore` is scoped to backup/manifest-recoverable originals only.

## Design decision — manifest-restore vs git install-branch

**Chosen: manifest-restore NOW; git-native install-branch as a documented follow-up.**

Rationale: the reversible-manifest + `.bak` machinery already exists, is stdlib-only, **git-independent**, and test-proven — it works in a non-git dir and needs zero new install-time plumbing. A git-native install-branch workflow (install onto a dedicated branch → merge when satisfied, or `git branch -D` to walk away) is attractive for a clean "walk away" story but requires a **new git-native install mode** that does not exist today and is a larger cross-cutting change (and degrades in non-git / dirty-tree / detached-HEAD cases). Recommended as a follow-up that would *complement*, not replace, manifest-restore.

## Files

- `framework/install/restore.py` **(new)** — plan / apply / CLI (stdlib-only; reuses `repo_space` + `bootstrap` so it can't drift from the install).
- `framework/install/repo_space.py` — `find_latest_archive` moved here (its natural home; `repo_space` owns the archive format).
- `framework/install/uninstall.py` — now delegates to `repo_space.find_latest_archive` (DRY; behaviour-preserving).
- `python/src/real_team/framework_install.py` — `restore_framework` bridge (mirrors `uninstall_framework`).
- `python/src/real_team/cli.py` — the `restore` command (mirrors `uninstall`).
- `framework/tests/test_restore.py` **(new)** + `python/tests/test_cli.py::TestRestore`.

## Node parity

The node CLI does **not** mirror the teardown family — `uninstall` is python-only too — so `restore` follows that established precedent and is python-only. No `framework/assets/` shared assets were touched. Node parity for the whole teardown family (`uninstall` + `restore`) is a documented follow-up.

## Verification

- **Round-trip, both directions** (`test_restore.py`): a moved/backed-up file (archived `.claude/`) AND a modified file (`CLAUDE.md` reverted from `CLAUDE.md.bak`) both restore byte-identical. Dry-run-accuracy + no-mutation-without-consent + idempotent-no-op also covered.
- **Real end-to-end** through the product CLI: `2real-team init` (which backs up a pre-existing `CLAUDE.md` to `.bak`) → `restore --dry-run` previews the exact revert → live `restore` recovers the original bytes.
- `ruff check` clean; **849** framework tests + **119** CLI tests green; `python3 framework/install/reinstall.py --check` rc=0.

Closes #273
Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FSSf75g21FAh8cTWNHBrX
