### PR TITLE
feat(node): teardown/restore parity — port uninstall + restore to the node CLI (#280)

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -72,6 +72,20 @@ install [Python 3](https://www.python.org/downloads/) and re-run
 2real-team randomize-member "Ada Park"
 ```
 
+### Teardown
+
+Both commands bridge to the bundled Python (like `init`), so they share the
+Python runtime requirement above. Left interactive they keep the Python side's
+consent gate — they prompt on a TTY and refuse on a non-TTY rather than
+mutating unattended; `--non-interactive` is the automation contract and
+`--dry-run` previews without writing.
+
+```bash
+2real-team uninstall           # Remove the framework runtime; restore pre-install state
+2real-team uninstall --dry-run # Preview what would be removed; write nothing
+2real-team restore             # Put back originals the install displaced (not a full teardown)
+```
+
 ## What's in this package
 
 - `dist/` — the compiled CLI

--- a/node/src/bootstrap.ts
+++ b/node/src/bootstrap.ts
@@ -11,7 +11,10 @@ import Mustache from "mustache";
 import {
   installFramework,
   describeInstallResult,
+  runTeardown,
+  describeTeardownDegradation,
   type FrameworkInstallResult,
+  type TeardownCommand,
 } from "./framework-install.js";
 
 const _require = createRequire(import.meta.url);
@@ -949,5 +952,63 @@ export function showStatus(opts: { target: string }): void {
   if (existsSync(skillsDir)) {
     const skillCount = readdirSync(skillsDir).filter((f) => f.endsWith(".md")).length;
     console.log(`\nSkills installed: ${skillCount}`);
+  }
+}
+
+interface TeardownOptions {
+  target: string;
+  dryRun?: boolean;
+  nonInteractive?: boolean;
+}
+
+/**
+ * Uninstall the framework runtime — restore the repo to its pre-install state.
+ *
+ * Thin bridge to the bundled `framework/install/uninstall.py` (same spawn/argv
+ * pattern as `installFramework`). Removes the framework-owned install set and
+ * restores any pre-install assets a consented install archived; idempotent.
+ */
+export function uninstall(opts: TeardownOptions): void {
+  runTeardownCommand("uninstall", opts);
+}
+
+/**
+ * Restore this repo's pre-install originals — undo the install's tracked
+ * changes without removing the framework's own files (that is `uninstall`).
+ *
+ * Thin bridge to the bundled `framework/install/restore.py`.
+ */
+export function restore(opts: TeardownOptions): void {
+  runTeardownCommand("restore", opts);
+}
+
+/**
+ * Shared body for the teardown/restore commands: bridge to the bundled Python,
+ * echo its plan/output, and mirror the Python CLI's exit contract (nonzero
+ * subprocess exit propagates; a bridge that could not run is a hard failure).
+ */
+function runTeardownCommand(command: TeardownCommand, opts: TeardownOptions): void {
+  const target = resolve(opts.target);
+  const result = runTeardown(command, target, {
+    dryRun: opts.dryRun,
+    nonInteractive: opts.nonInteractive,
+  });
+
+  if (result.kind !== "ran") {
+    console.error(describeTeardownDegradation(command, result));
+    process.exit(1);
+  }
+
+  if (result.stdout.trim()) {
+    console.log(result.stdout.trimEnd());
+  }
+  if (result.status !== 0) {
+    if (result.stderr.trim()) {
+      console.error(result.stderr.trim());
+    }
+    process.exit(result.status);
+  }
+  if (command === "uninstall") {
+    console.log("\nFramework runtime uninstalled.");
   }
 }

--- a/node/src/framework-install.ts
+++ b/node/src/framework-install.ts
@@ -197,3 +197,126 @@ export function describeInstallResult(result: FrameworkInstallResult): string {
       return "Installed the framework runtime (hooks/lib/skills/config).";
   }
 }
+
+// ---------------------------------------------------------------------------
+// Teardown/restore family — the reverse of installFramework.
+//
+// `uninstall` and `restore` are thin bridges to the same bundled Python
+// commands (`framework/install/uninstall.py`, `framework/install/restore.py`),
+// spawned exactly like the bootstrapper so the teardown logic keeps a single
+// source of truth in Python. They mirror the Python package's
+// `real_team.framework_install.{uninstall,restore}_framework` bridges.
+// ---------------------------------------------------------------------------
+
+export type TeardownCommand = "uninstall" | "restore";
+
+export interface TeardownOptions {
+  /** Preview only; the subprocess writes nothing (`--dry-run`). */
+  dryRun?: boolean;
+  /**
+   * Automation contract: never prompt (`--non-interactive`). Left falsy, the
+   * subprocess keeps its consent gate — it prompts on a TTY and REFUSES on a
+   * non-TTY rather than mutating unattended. Passing this through unchanged is
+   * what preserves the Python side's safety contract end-to-end.
+   */
+  nonInteractive?: boolean;
+}
+
+export type TeardownResult =
+  | { kind: "ran"; status: number; stdout: string; stderr: string; argv: string[] }
+  | { kind: "no-framework" }
+  | { kind: "no-python" };
+
+/**
+ * Build the exact argv used to subprocess a teardown command. Mirrors the
+ * uninstall.py / restore.py argparse contract: a positional target followed by
+ * the optional `--non-interactive` then `--dry-run` flags (same order the
+ * Python bridge emits).
+ */
+export function buildTeardownArgv(
+  python: string,
+  frameworkRoot: string,
+  command: TeardownCommand,
+  target: string,
+  opts: TeardownOptions = {},
+): string[] {
+  const argv = [python, join(frameworkRoot, "install", `${command}.py`), target];
+  if (opts.nonInteractive) argv.push("--non-interactive");
+  if (opts.dryRun) argv.push("--dry-run");
+  return argv;
+}
+
+/**
+ * Reverse a framework install in `target` via its own bundled Python command.
+ *
+ * Degrades the same way as {@link installFramework}: `{ kind: "no-framework" }`
+ * when the bundled assets are missing, `{ kind: "no-python" }` when no Python 3
+ * interpreter is on PATH. Unlike `init` (where degradation is a soft notice on
+ * top of completed scaffolding) a teardown that cannot run has done nothing, so
+ * callers should surface it as a hard failure.
+ */
+export function runTeardown(
+  command: TeardownCommand,
+  target: string,
+  opts: TeardownOptions = {},
+  runner: SpawnRunner = defaultRunner,
+): TeardownResult {
+  const root = resolveFrameworkRoot();
+  if (root === null) return { kind: "no-framework" };
+
+  const python = findPython(runner);
+  if (python === null) return { kind: "no-python" };
+
+  const argv = buildTeardownArgv(python, root, command, target, opts);
+  const res = runner(argv[0], argv.slice(1), { encoding: "utf-8" });
+  return {
+    kind: "ran",
+    status: res.status ?? 1,
+    stdout: String(res.stdout ?? ""),
+    stderr: String(res.stderr ?? ""),
+    argv,
+  };
+}
+
+/** Uninstall the framework runtime — thin alias over {@link runTeardown}. */
+export function uninstallFramework(
+  target: string,
+  opts: TeardownOptions = {},
+  runner: SpawnRunner = defaultRunner,
+): TeardownResult {
+  return runTeardown("uninstall", target, opts, runner);
+}
+
+/** Restore a repo's pre-install originals — thin alias over {@link runTeardown}. */
+export function restoreFramework(
+  target: string,
+  opts: TeardownOptions = {},
+  runner: SpawnRunner = defaultRunner,
+): TeardownResult {
+  return runTeardown("restore", target, opts, runner);
+}
+
+/**
+ * Human-readable degradation message for a teardown that could not run. Mirrors
+ * describeInstallResult's phrasing for the shared no-framework / no-python
+ * cases, worded for a teardown (nothing was scaffolded to fall back on).
+ */
+export function describeTeardownDegradation(
+  command: TeardownCommand,
+  result: { kind: "no-framework" } | { kind: "no-python" },
+): string {
+  switch (result.kind) {
+    case "no-framework":
+      return (
+        `Cannot ${command}: bundled framework assets not found ` +
+        `(re-run from a source checkout, or use the standalone framework ${command} command).`
+      );
+    case "no-python":
+      return (
+        `Cannot ${command}: no Python 3 interpreter found on PATH.\n` +
+        "The teardown/restore logic is a Python command bundled with this package.\n" +
+        "Install python3 (https://www.python.org/downloads/) and re-run, or use the\n" +
+        "Python package instead: `pip install 2real-team-framework`."
+      );
+  }
+}

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -15,6 +15,8 @@ import {
   randomizeMember,
   validateTeam,
   showStatus,
+  uninstall,
+  restore,
 } from "./bootstrap.js";
 import { readPackageVersion } from "./version.js";
 
@@ -129,6 +131,40 @@ program
   .option("--target <dir>", "Target directory", ".")
   .action(async (opts) => {
     showStatus({ target: opts.target });
+  });
+
+program
+  .command("uninstall")
+  .description("Uninstall the framework runtime — restore the repo to its pre-install state")
+  .option("--target <dir>", "Target directory", ".")
+  .option("--dry-run", "Preview what would be removed; write nothing")
+  .option(
+    "--non-interactive",
+    "Never prompt; proceed without the confirmation gate (automation)",
+  )
+  .action(async (opts) => {
+    uninstall({
+      target: opts.target,
+      dryRun: opts.dryRun,
+      nonInteractive: opts.nonInteractive,
+    });
+  });
+
+program
+  .command("restore")
+  .description("Restore this repo's pre-install originals — undo the install's tracked changes")
+  .option("--target <dir>", "Target directory", ".")
+  .option("--dry-run", "Preview exactly what would be restored/reverted; write nothing")
+  .option(
+    "--non-interactive",
+    "Never prompt; proceed without the confirmation gate (automation)",
+  )
+  .action(async (opts) => {
+    restore({
+      target: opts.target,
+      dryRun: opts.dryRun,
+      nonInteractive: opts.nonInteractive,
+    });
   });
 
 program.parse();

--- a/node/tests/teardown-bridge.test.ts
+++ b/node/tests/teardown-bridge.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for the Node -> Python teardown/restore bridge: exact argv mapping for
+ * `uninstall`/`restore`, safety-flag pass-through (`--dry-run` /
+ * `--non-interactive`), the spawn-runner wiring (injected fake — no real
+ * process is spawned), degradation results, and the degradation messages.
+ *
+ * These are the parity guards for #280: they go red if the bridge stops
+ * forwarding a safety flag, targets the wrong command script, or fails to
+ * degrade when the runtime is unavailable.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  buildTeardownArgv,
+  runTeardown,
+  uninstallFramework,
+  restoreFramework,
+  describeTeardownDegradation,
+  resolveFrameworkRoot,
+  type SpawnRunner,
+  type SpawnResult,
+  type TeardownCommand,
+} from "../src/framework-install.js";
+
+interface Call {
+  cmd: string;
+  args: string[];
+}
+
+/** Runner that answers python `--version` probes and the teardown call. */
+function makeRunner(
+  calls: Call[],
+  pythonResults: Record<string, SpawnResult>,
+  teardownResult: SpawnResult = { status: 0, stdout: "", stderr: "" },
+): SpawnRunner {
+  return (cmd, args) => {
+    calls.push({ cmd, args });
+    if (args.length === 1 && args[0] === "--version") {
+      return pythonResults[cmd] ?? { status: null, error: new Error(`ENOENT: ${cmd}`) };
+    }
+    return teardownResult;
+  };
+}
+
+const PYTHON3_OK: Record<string, SpawnResult> = { python3: { status: 0 } };
+
+describe("buildTeardownArgv — exact flag mapping", () => {
+  it("maps uninstall to uninstall.py with no flags by default", () => {
+    const argv = buildTeardownArgv("python3", "/fw", "uninstall", "/target");
+    expect(argv).toEqual(["python3", join("/fw", "install", "uninstall.py"), "/target"]);
+  });
+
+  it("maps restore to restore.py", () => {
+    const argv = buildTeardownArgv("python3", "/fw", "restore", "/target");
+    expect(argv[1]).toBe(join("/fw", "install", "restore.py"));
+  });
+
+  it("forwards --non-interactive then --dry-run in that order", () => {
+    const argv = buildTeardownArgv("python3", "/fw", "uninstall", "/t", {
+      nonInteractive: true,
+      dryRun: true,
+    });
+    expect(argv).toEqual([
+      "python3",
+      join("/fw", "install", "uninstall.py"),
+      "/t",
+      "--non-interactive",
+      "--dry-run",
+    ]);
+  });
+
+  it("forwards only --dry-run when non-interactive is unset (consent gate preserved)", () => {
+    const argv = buildTeardownArgv("python3", "/fw", "restore", "/t", { dryRun: true });
+    expect(argv).toContain("--dry-run");
+    expect(argv).not.toContain("--non-interactive");
+  });
+
+  it("forwards only --non-interactive when dry-run is unset", () => {
+    const argv = buildTeardownArgv("python3", "/fw", "uninstall", "/t", {
+      nonInteractive: true,
+    });
+    expect(argv).toContain("--non-interactive");
+    expect(argv).not.toContain("--dry-run");
+  });
+});
+
+describe("runTeardown — spawn wiring + degradation", () => {
+  const cmds: TeardownCommand[] = ["uninstall", "restore"];
+
+  for (const command of cmds) {
+    it(`subprocesses the bundled ${command}.py with the mapped argv`, () => {
+      const calls: Call[] = [];
+      const runner = makeRunner(calls, PYTHON3_OK, { status: 0, stdout: "ok", stderr: "" });
+      const result = runTeardown(command, "/target", { nonInteractive: true }, runner);
+
+      expect(result.kind).toBe("ran");
+      if (result.kind !== "ran") return;
+      const root = resolveFrameworkRoot()!;
+      expect(result.argv).toEqual([
+        "python3",
+        join(root, "install", `${command}.py`),
+        "/target",
+        "--non-interactive",
+      ]);
+      // Last spawn is the teardown subprocess itself, with the same argv.
+      const last = calls[calls.length - 1];
+      expect([last.cmd, ...last.args]).toEqual(result.argv);
+    });
+  }
+
+  it("passes --dry-run through to the subprocess", () => {
+    const calls: Call[] = [];
+    const runner = makeRunner(calls, PYTHON3_OK);
+    runTeardown("restore", "/target", { dryRun: true }, runner);
+    const last = calls[calls.length - 1];
+    expect(last.args).toContain("--dry-run");
+  });
+
+  it("does NOT pass --non-interactive when unset (subprocess keeps its consent gate)", () => {
+    const calls: Call[] = [];
+    const runner = makeRunner(calls, PYTHON3_OK);
+    runTeardown("uninstall", "/target", {}, runner);
+    const last = calls[calls.length - 1];
+    expect(last.args).not.toContain("--non-interactive");
+  });
+
+  it("degrades to no-python without invoking the teardown subprocess", () => {
+    const calls: Call[] = [];
+    const runner = makeRunner(calls, {});
+    const result = runTeardown("uninstall", "/target", { nonInteractive: true }, runner);
+    expect(result).toEqual({ kind: "no-python" });
+    // Only the two interpreter probes — never the teardown subprocess.
+    expect(calls.map((c) => c.cmd)).toEqual(["python3", "python"]);
+  });
+
+  it("surfaces a nonzero teardown exit with stderr", () => {
+    const runner = makeRunner([], PYTHON3_OK, { status: 5, stdout: "", stderr: "boom" });
+    const result = runTeardown("restore", "/target", { nonInteractive: true }, runner);
+    expect(result.kind).toBe("ran");
+    if (result.kind !== "ran") return;
+    expect(result.status).toBe(5);
+    expect(result.stderr).toBe("boom");
+  });
+});
+
+describe("uninstallFramework / restoreFramework — thin aliases", () => {
+  it("uninstallFramework targets uninstall.py", () => {
+    const calls: Call[] = [];
+    const runner = makeRunner(calls, PYTHON3_OK);
+    const result = uninstallFramework("/t", { nonInteractive: true }, runner);
+    expect(result.kind).toBe("ran");
+    if (result.kind !== "ran") return;
+    expect(result.argv[1].endsWith(join("install", "uninstall.py"))).toBe(true);
+  });
+
+  it("restoreFramework targets restore.py", () => {
+    const calls: Call[] = [];
+    const runner = makeRunner(calls, PYTHON3_OK);
+    const result = restoreFramework("/t", { nonInteractive: true }, runner);
+    expect(result.kind).toBe("ran");
+    if (result.kind !== "ran") return;
+    expect(result.argv[1].endsWith(join("install", "restore.py"))).toBe(true);
+  });
+});
+
+describe("CLI wiring", () => {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const src = readFileSync(resolve(__dirname, "..", "src", "index.ts"), "utf-8");
+
+  it("registers the uninstall and restore commands", () => {
+    expect(src).toContain('.command("uninstall")');
+    expect(src).toContain('.command("restore")');
+  });
+
+  it("exposes --dry-run and --non-interactive on both teardown commands", () => {
+    // Both flags appear (once per command); the actions forward them through.
+    expect(src.match(/"--dry-run"/g)?.length).toBeGreaterThanOrEqual(2);
+    expect(src.match(/"--non-interactive"/g)?.length).toBeGreaterThanOrEqual(2);
+    expect(src).toContain("dryRun: opts.dryRun");
+    expect(src).toContain("nonInteractive: opts.nonInteractive");
+  });
+});
+
+describe("describeTeardownDegradation", () => {
+  it("explains missing bundled assets per command", () => {
+    const msg = describeTeardownDegradation("uninstall", { kind: "no-framework" });
+    expect(msg).toContain("Cannot uninstall");
+    expect(msg).toContain("bundled framework assets not found");
+  });
+
+  it("explains the no-python degradation with recovery paths", () => {
+    const msg = describeTeardownDegradation("restore", { kind: "no-python" });
+    expect(msg).toContain("Cannot restore");
+    expect(msg).toContain("python3");
+    expect(msg).toContain("pip install 2real-team-framework");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #280. The teardown/restore family was **Python-only** — the node CLI shipped install-only. This ports **both `uninstall` and `restore`** to the node CLI as thin bridges to the same bundled Python commands (`framework/install/uninstall.py` + `restore.py`), reaching parity with `2real-team` and reusing the existing `installFramework` spawn/argv pattern so the teardown logic keeps a single source of truth in Python.

**Decision (the issue asks whether to mirror at all):** mirror both. The node `init` already bridges to the bundled Python installer; there is no principled reason for teardown to diverge, and the asymmetry was the drift the issue flags. No asymmetry documented — full parity.

### Changes (all inside `node/`)
- **`src/framework-install.ts`** — `buildTeardownArgv` / `runTeardown` + `uninstallFramework` / `restoreFramework` thin aliases + `describeTeardownDegradation`. Same `resolveFrameworkRoot` + `findPython` degradation (`no-framework` / `no-python`) as `installFramework`; unlike `init`, a teardown that cannot run is a hard failure (nothing was scaffolded to fall back on).
- **`src/index.ts`** — register `uninstall` and `restore` commands with `--target`, `--dry-run`, `--non-interactive`.
- **`src/bootstrap.ts`** — `uninstall()` / `restore()` command bodies mirroring the Python CLI's echo-plan + exit contract (subprocess stdout echoed, nonzero exit propagated).
- **`README.md`** — teardown section.

### Safety contract (preserved end-to-end)
`--dry-run` and `--non-interactive` pass through unchanged. Left interactive, the Python consent gate stays intact: it prompts on a TTY and **refuses on a non-TTY** rather than mutating unattended. `--dry-run` previews without writing.

## Testing
- **`tests/teardown-bridge.test.ts`** (17 load-bearing tests) — go red if the bridge stops forwarding a safety flag, targets the wrong command script, or fails to degrade:
  - `buildTeardownArgv` exact argv mapping for `uninstall`→`uninstall.py` and `restore`→`restore.py`, `--non-interactive` then `--dry-run` order, and each flag independently.
  - `runTeardown` spawn wiring via the injected `SpawnRunner` (no real process spawned): mapped argv for both commands, `--dry-run` pass-through, `--non-interactive` withheld when unset (consent gate preserved), `no-python` degrades without invoking the subprocess, nonzero exit surfaced with stderr.
  - `uninstallFramework` / `restoreFramework` alias command targeting.
  - `describeTeardownDegradation` messages.
  - CLI wiring: both commands registered with both flags forwarded.
- `npm run build` (tsc — the type gate) GREEN. (`npm run lint`/eslint is not installed in this package — pre-existing; `tsc` is the type check.)
- `npx vitest run` GREEN: **156 passed (6 files)**, run **twice** for determinism (RNG/dedupe flake-sensitivity per #234) — identical both runs.
- End-to-end smoke (real Python subprocess, not mocked): `uninstall`/`restore` `--dry-run --non-interactive` on a fresh dir (clean no-op), and a live `init` → `uninstall --non-interactive` roundtrip (confirmed `framework.config.json` present after init, gone after uninstall, exit 0).

Reviewers: **Ibrahim El-Amin** + **Tariq Morales**.
