### PR TITLE
feat(install): git-native install-branch staging mode (#279)

### DIFF
--- a/framework/install/install_branch.py
+++ b/framework/install/install_branch.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+"""Stage a framework install onto a throwaway git branch — trial an install, then merge or delete (#279).
+
+The git-native sibling of ``restore.py``. Both answer "let me try this install and back out cleanly
+if I don't like it", but from opposite ends:
+
+* ``restore`` is the **git-independent** path: the install lands on your working tree, and ``restore``
+  reverses the tracked file changes afterward via the reversible manifest (#108) + the ``.bak``
+  backups the installer left. It needs no git and works in a dirty tree.
+* ``install_branch`` (this module) is the **git-native** path: it creates a dedicated install branch
+  off the current HEAD, runs the install there, and commits the whole install set as ONE commit on
+  that branch. Undo is a git operation — you either ``git merge`` the branch when satisfied or
+  ``git branch -D`` it to walk away, with zero manifest bookkeeping to reason about.
+
+When to prefer which
+====================
+* Prefer **install-branch** when the target is a clean git repo and you want an all-or-nothing trial
+  you can review as a single diff (``git diff <orig>..<branch>``) and accept or discard atomically.
+* Prefer **restore** when you're in a non-git repo, your tree is dirty, or you've already installed
+  onto your working branch and want to selectively undo the install's file changes.
+
+How they COMPOSE (they do not conflict)
+=======================================
+install-branch does not replace or consume the manifest path — it wraps a git envelope AROUND the
+very same install. The install action it runs is the ordinary bootstrapper, which still writes its
+manifest + ``.bak`` backups; those artifacts are simply captured inside the branch commit. So on a
+staged install branch BOTH undo routes remain available and independent:
+
+* discard the whole trial  -> ``git branch -D <branch>`` (drops the install *and* its manifest), or
+* selectively revert files  -> run ``restore`` on the branch (uses the captured manifest/``.bak``).
+
+install-branch never deletes a manifest, and ``restore`` never touches a branch, so running one
+cannot corrupt the other's state.
+
+Degradation policy — REFUSE, don't silently fall back (deliberate design call)
+==============================================================================
+In a **non-git repo** there is no branch to create; in a **dirty working tree** staging onto a branch
+cut from a dirty HEAD would fold the operator's own uncommitted work into the "install" commit,
+breaking the clean merge/discard guarantee this mode exists to provide. In both cases we REFUSE with
+an actionable message that points at the ``restore`` path (``install`` normally, then ``restore`` to
+undo) rather than silently switching strategies: the two paths have different, non-substitutable
+contracts, and a silent fall-back would surprise the operator and quietly void the "walk away clean"
+promise. The choice is the operator's, made with full information.
+
+Preview + consent (fail-safe, mirrors ``restore``)
+==================================================
+Every run first PRINTS the plan (git status, the branch it will create, whether it will leave you on
+that branch). ``--dry-run`` stops there and creates nothing. A live run then asks an explicit
+``[y/N]``; ``--non-interactive`` is the automation contract (proceed, no prompt); a non-TTY without
+``--non-interactive`` REFUSES rather than mutating unattended. If the install action fails midway, the
+branch is rolled back (checkout original, delete the branch) so the tree is left as it was found.
+
+Stdlib only (no deps). The engine takes the install action as a callable so it stays git-only and
+testable; the CLI wires that callable to the framework ``bootstrap.py`` (extra args pass through).
+
+Usage
+=====
+  python3 install_branch.py /path/to/repo --owner my-org         # preview, [y/N], stage on a branch
+  python3 install_branch.py /path/to/repo --owner my-org --non-interactive
+  python3 install_branch.py /path/to/repo --dry-run              # preview only; create nothing
+  python3 install_branch.py /path/to/repo --branch try/real-team # pick the install-branch name
+  python3 install_branch.py /path/to/repo --return               # leave tree on the original branch
+
+Exit codes: 0 ok / dry-run / staged, 1 on a refused run, a collision, or a failed install.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Sequence
+
+#: The install branch created off the current HEAD unless ``--branch`` overrides it.
+DEFAULT_BRANCH = "real-team/install"
+#: Commit identity for the staged-install commit. Applied via per-commit ``-c`` flags (NEVER global
+#: git config), so staging never mutates the operator's git identity — matches the charter rule.
+_COMMIT_NAME = "2real-team installer"
+_COMMIT_EMAIL = "noreply@2real-team.local"
+
+#: An install action mutates the working tree in ``target``; it must raise on failure.
+InstallAction = Callable[[Path], None]
+
+
+# --------------------------------------------------------------------------------- git helpers
+
+
+def _git(target: Path, *args: str, check: bool = False) -> subprocess.CompletedProcess:
+    """Run ``git -C <target> <args>`` capturing output; ``check`` raises on non-zero."""
+    return subprocess.run(
+        ["git", "-C", str(target), *args],
+        capture_output=True, text=True, check=check,
+    )
+
+
+def is_git_repo(target: Path) -> bool:
+    """True if ``target`` is inside a git work tree."""
+    r = _git(target, "rev-parse", "--is-inside-work-tree")
+    return r.returncode == 0 and r.stdout.strip() == "true"
+
+
+def is_dirty(target: Path) -> bool:
+    """True if the work tree has staged or unstaged changes (untracked files included)."""
+    r = _git(target, "status", "--porcelain")
+    return r.returncode == 0 and bool(r.stdout.strip())
+
+
+def current_ref(target: Path) -> str | None:
+    """The current branch name, or a short commit sha when HEAD is detached; None if unresolved."""
+    r = _git(target, "symbolic-ref", "--quiet", "--short", "HEAD")
+    if r.returncode == 0 and r.stdout.strip():
+        return r.stdout.strip()
+    r = _git(target, "rev-parse", "--short", "HEAD")
+    return r.stdout.strip() if r.returncode == 0 and r.stdout.strip() else None
+
+
+def branch_exists(target: Path, name: str) -> bool:
+    """True if a local branch ``name`` already exists (a collision we refuse to clobber)."""
+    return _git(target, "rev-parse", "--verify", "--quiet", f"refs/heads/{name}").returncode == 0
+
+
+# --------------------------------------------------------------------------------- plan model
+
+
+@dataclass
+class StagePlan:
+    """What a stage would do, resolved BEFORE any mutation (drives the preview + the guard)."""
+
+    target: Path
+    git_ok: bool
+    dirty: bool
+    branch: str
+    original_ref: str | None
+    branch_collision: bool
+
+    @property
+    def can_stage(self) -> bool:
+        return self.git_ok and not self.dirty and not self.branch_collision
+
+    @property
+    def blocker(self) -> str | None:
+        """Actionable reason a live stage is refused, or None when it can proceed."""
+        if not self.git_ok:
+            return (
+                f"{self.target} is not a git repository — there is no branch to stage onto.\n"
+                "  Use a plain install and `restore` to undo it (the git-independent path)."
+            )
+        if self.dirty:
+            return (
+                "the working tree has uncommitted changes — staging onto a branch cut from a "
+                "dirty HEAD would fold them into the install commit.\n"
+                "  Commit or stash them first, or use a plain install and `restore` to undo it."
+            )
+        if self.branch_collision:
+            return (
+                f"branch '{self.branch}' already exists — refusing to reuse or clobber it.\n"
+                f"  Delete it (git branch -D {self.branch}) or pass --branch <name>."
+            )
+        return None
+
+
+@dataclass
+class StageReport:
+    """Outcome of :func:`stage_install`."""
+
+    staged: bool = False
+    branch: str | None = None
+    original_ref: str | None = None
+    commit: str | None = None
+    on_branch: bool = False  #: True if the tree is left checked out on the install branch
+    notes: list[str] = field(default_factory=list)
+
+
+# --------------------------------------------------------------------------------- planning
+
+
+def plan_stage(target: Path | str, *, branch: str | None = None) -> StagePlan:
+    """Resolve the stage plan for ``target`` without mutating anything."""
+    target = Path(target).resolve()
+    git_ok = is_git_repo(target)
+    name = branch or DEFAULT_BRANCH
+    return StagePlan(
+        target=target,
+        git_ok=git_ok,
+        dirty=is_dirty(target) if git_ok else False,
+        branch=name,
+        original_ref=current_ref(target) if git_ok else None,
+        branch_collision=branch_exists(target, name) if git_ok else False,
+    )
+
+
+# --------------------------------------------------------------------------------- apply
+
+
+def stage_install(
+    target: Path | str,
+    install_action: InstallAction,
+    *,
+    branch: str | None = None,
+    dry_run: bool = False,
+    non_interactive: bool = False,
+    keep_checkout: bool = True,
+) -> StageReport:
+    """Create an install branch off HEAD, run ``install_action`` there, and commit the result.
+
+    Returns a :class:`StageReport`. On any refusal (non-git, dirty tree, branch collision, declined
+    consent) nothing is created and ``staged`` is False. On a live run the branch is created and
+    switched to, ``install_action`` mutates the tree, everything is committed as one commit, and —
+    unless ``keep_checkout`` is False — the tree is left on the install branch for the operator to
+    try. If ``install_action`` raises, the branch is rolled back (checkout original, delete branch)
+    so the tree is left as found, and the error propagates. ``dry_run`` creates nothing.
+    """
+    target = Path(target).resolve()
+    plan = plan_stage(target, branch=branch)
+    report = StageReport(branch=plan.branch, original_ref=plan.original_ref)
+
+    if not plan.can_stage:
+        report.notes.append(plan.blocker or "cannot stage")
+        return report
+    if dry_run:
+        report.notes.append(f"dry-run — would create branch '{plan.branch}' and stage the install")
+        return report
+
+    orig = plan.original_ref
+    if orig is None:  # unresolved HEAD (broken repo) — nothing to branch from / return to
+        report.notes.append("cannot resolve the current HEAD to branch from — commit first.")
+        return report
+    if _git(target, "checkout", "-b", plan.branch).returncode != 0:
+        report.notes.append(f"failed to create branch '{plan.branch}'")
+        return report
+
+    try:
+        install_action(target)
+    except Exception:
+        _rollback(target, orig, plan.branch)
+        raise
+
+    _git(target, "add", "-A")
+    if _git(target, "diff", "--cached", "--quiet").returncode == 0:
+        # The install produced no changes — don't leave a dangling empty branch behind.
+        _rollback(target, orig, plan.branch)
+        report.notes.append("install produced no changes; install branch removed (nothing to try).")
+        return report
+
+    msg = f"chore(install): stage 2real-team framework install on {plan.branch}"
+    commit = _git(
+        target,
+        "-c", f"user.name={_COMMIT_NAME}",
+        "-c", f"user.email={_COMMIT_EMAIL}",
+        "commit", "-m", msg,
+    )
+    if commit.returncode != 0:
+        _rollback(target, orig, plan.branch)
+        report.notes.append(f"failed to commit the staged install: {commit.stderr.strip()}")
+        return report
+
+    head = _git(target, "rev-parse", "--short", "HEAD")
+    report.commit = head.stdout.strip() or None
+    report.staged = True
+
+    if keep_checkout:
+        report.on_branch = True
+    else:
+        _git(target, "checkout", orig)
+        report.on_branch = False
+    return report
+
+
+def _rollback(target: Path, original_ref: str, branch: str) -> None:
+    """Best-effort undo of a partial stage: return to ``original_ref`` and delete ``branch``.
+
+    Safe to ``git clean -fd`` the untracked debris a half-run install left: we only stage from a
+    verified-clean tree (a dirty tree is refused upfront), so anything untracked here is install
+    output, never the operator's own work.
+    """
+    _git(target, "checkout", "--force", original_ref)
+    _git(target, "clean", "-fd")
+    _git(target, "branch", "-D", branch)
+
+
+# --------------------------------------------------------------------------------- CLI plumbing
+
+
+def _confirm(plan: StagePlan, *, non_interactive: bool) -> bool:
+    """Consent gate for the live stage — mirrors ``restore``'s automation contract.
+
+    ``--non-interactive`` proceeds without prompting (automation); an interactive TTY is asked
+    ``[y/N]``; a non-TTY without ``--non-interactive`` REFUSES rather than mutating unattended.
+    """
+    if non_interactive:
+        return True
+    if not sys.stdin.isatty():
+        print(
+            "refusing to create an install branch without a TTY — pass --non-interactive to proceed.",
+            file=sys.stderr,
+        )
+        return False
+    ans = input(f"Stage the install onto branch '{plan.branch}'? [y/N]: ").strip().lower()
+    return ans in ("y", "yes")
+
+
+def _print_plan(plan: StagePlan, *, dry_run: bool) -> None:
+    print("\n-- plan --")
+    if not plan.git_ok:
+        print("git repo:      no")
+        return
+    print(f"git repo:      yes (on {plan.original_ref})")
+    print(f"working tree:  {'dirty' if plan.dirty else 'clean'}")
+    verb = "would create" if dry_run else "will create"
+    print(f"install branch: {verb} '{plan.branch}'"
+          + ("  [ALREADY EXISTS]" if plan.branch_collision else ""))
+
+
+def _print_report(report: StageReport) -> None:
+    print("\n-- result --")
+    if not report.staged:
+        for note in report.notes:
+            print(f"note: {note}")
+        return
+    b, orig = report.branch, report.original_ref
+    print(f"staged install on branch '{b}' (commit {report.commit}).")
+    if report.on_branch:
+        print(f"you are on '{b}' now — try it out, then:")
+        print(f"  keep it:    git checkout {orig} && git merge {b}")
+        print(f"  discard it: git checkout {orig} && git branch -D {b}")
+    else:
+        print(f"your tree is back on '{orig}' (clean); the install is parked on '{b}'.")
+        print(f"  review it:  git diff {orig}..{b}")
+        print(f"  keep it:    git merge {b}")
+        print(f"  discard it: git branch -D {b}")
+    for note in report.notes:
+        print(f"note: {note}")
+
+
+def cli_stage(
+    target: Path | str,
+    install_action: InstallAction,
+    *,
+    branch: str | None,
+    dry_run: bool,
+    non_interactive: bool,
+    keep_checkout: bool,
+) -> int:
+    """Product entry: preview -> consent -> stage. Shared by the CLI and the ``2real-team`` bridge."""
+    target = Path(target).resolve()
+    print(f"== 2real framework install-branch ({'DRY-RUN' if dry_run else 'STAGE'}) ==")
+    print(f"target repo:   {target}")
+
+    plan = plan_stage(target, branch=branch)
+    _print_plan(plan, dry_run=dry_run)
+
+    if not plan.can_stage:
+        print(f"\nrefusing to stage: {plan.blocker}", file=sys.stderr)
+        return 1
+    if dry_run:
+        print("\n(dry-run — nothing was created)")
+        return 0
+    if not _confirm(plan, non_interactive=non_interactive):
+        print("aborted — nothing created.", file=sys.stderr)
+        return 1
+
+    try:
+        report = stage_install(
+            target, install_action, branch=branch, dry_run=False,
+            non_interactive=non_interactive, keep_checkout=keep_checkout,
+        )
+    except Exception as exc:
+        # The engine already rolled the branch back before re-raising; report cleanly, don't dump
+        # a traceback at the operator.
+        print(f"\ninstall failed — branch '{plan.branch}' rolled back, tree left as found.\n"
+              f"  {exc}", file=sys.stderr)
+        return 1
+    _print_report(report)
+    return 0 if report.staged else 1
+
+
+def _bootstrap_action(passthrough: Sequence[str]) -> InstallAction:
+    """Build the default install action: run the framework ``bootstrap.py`` in ``--non-interactive``.
+
+    Extra CLI args (``--owner``, ``--model``, …) pass straight through to the bootstrapper. Runs
+    inside the already-checked-out install branch, so its writes land there. Raises on a non-zero
+    bootstrap exit so :func:`stage_install` rolls the branch back.
+    """
+    def _action(target: Path) -> None:
+        cmd = [
+            sys.executable, str(Path(__file__).resolve().parent / "bootstrap.py"),
+            str(target), "--non-interactive", *passthrough,
+        ]
+        proc = subprocess.run(cmd, text=True)
+        if proc.returncode != 0:
+            raise RuntimeError(f"framework bootstrap failed (exit {proc.returncode})")
+
+    return _action
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Stage a framework install onto a throwaway git branch so you can merge it when "
+        "satisfied or `git branch -D` to walk away clean (#279). The git-native sibling of "
+        "restore.py; refuses in a non-git repo or dirty tree (use install + restore there). "
+        "Unrecognized args pass through to bootstrap.py.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("target", nargs="?", default=".", help="Target repo root (default: cwd)")
+    ap.add_argument("--branch", default=None,
+                    help=f"Install branch name to create (default: {DEFAULT_BRANCH})")
+    ap.add_argument("--dry-run", action="store_true", help="Print the plan; create nothing")
+    ap.add_argument("--non-interactive", action="store_true",
+                    help="Never prompt (the automation contract); proceed without [y/N]")
+    ap.add_argument("--return", dest="return_to_original", action="store_true",
+                    help="After staging, check the original branch back out (tree left clean; "
+                         "install parked on the branch) instead of staying on the install branch")
+    args, passthrough = ap.parse_known_args(argv)
+
+    return cli_stage(
+        Path(args.target),
+        _bootstrap_action(passthrough),
+        branch=args.branch,
+        dry_run=args.dry_run,
+        non_interactive=args.non_interactive,
+        keep_checkout=not args.return_to_original,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/framework/tests/test_install_branch.py
+++ b/framework/tests/test_install_branch.py
@@ -1,0 +1,236 @@
+"""Tests for the git-native ``install_branch`` staging mode (#279).
+
+``install_branch`` stages a framework install onto a throwaway branch off HEAD so the operator can
+``git merge`` it when satisfied or ``git branch -D`` to walk away clean. It is the git-native sibling
+of ``restore`` (the git-independent, manifest-driven undo). Coverage:
+
+* **Branch creation + commit** — the headline AC: a clean git repo gets a new install branch with
+  the install committed as one commit; the operator is left on that branch to try it.
+* **--return parks the install** — with ``keep_checkout=False`` the tree returns to the original
+  branch (clean) and the install lives only on the install branch.
+* **Composes with manifest-restore** — the installer's manifest/``.bak`` are committed on the branch
+  AND ``restore`` still sees them there (the two undo paths coexist, don't conflict).
+* **Degrades by refusing** — a dirty tree, a non-git repo, and a pre-existing branch each refuse
+  with an actionable message and create nothing.
+* **dry-run creates nothing**; **a failed install rolls the branch back**; **a non-TTY refuses**.
+
+Stdlib + pytest only; everything runs under ``tmp_path``. Git identity is supplied per-command via
+``-c`` flags so tests never touch global git config.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+_INSTALL = _FRAMEWORK_ROOT / "install"
+_INSTALL_BRANCH = _INSTALL / "install_branch.py"
+if str(_INSTALL) not in sys.path:
+    sys.path.insert(0, str(_INSTALL))
+
+import install_branch  # noqa: E402
+import repo_space  # noqa: E402
+import restore  # noqa: E402
+
+
+# --------------------------------------------------------------------------- helpers
+
+
+def _git(root: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(root),
+         "-c", "user.name=Test", "-c", "user.email=test@test.local", *args],
+        capture_output=True, text=True,
+    )
+
+
+def _init_repo(root: Path) -> None:
+    """A git repo with one commit (a real HEAD to branch off), no global config touched."""
+    _git(root, "init", "-q")
+    (root / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "seed")
+
+
+def _write_file_action(rel: str, body: bytes) -> install_branch.InstallAction:
+    def _action(target: Path) -> None:
+        p = target / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(body)
+    return _action
+
+
+def _current_branch(root: Path) -> str:
+    return _git(root, "symbolic-ref", "--short", "HEAD").stdout.strip()
+
+
+# --------------------------------------------------------------- branch creation + commit
+
+
+def test_stage_creates_branch_and_commits(tmp_path: Path):
+    """The headline AC: a clean git repo gets an install branch with the install committed on it."""
+    _init_repo(tmp_path)
+    orig = _current_branch(tmp_path)
+
+    report = install_branch.stage_install(
+        tmp_path, _write_file_action(".claude/marker", b"installed\n"), non_interactive=True
+    )
+
+    assert report.staged is True, report.notes
+    assert report.on_branch is True
+    assert report.branch == install_branch.DEFAULT_BRANCH
+    # We are on the new install branch, which exists and differs from the original.
+    assert _current_branch(tmp_path) == install_branch.DEFAULT_BRANCH
+    assert install_branch.branch_exists(tmp_path, install_branch.DEFAULT_BRANCH)
+    # The install landed and was COMMITTED (working tree is clean, file present).
+    assert (tmp_path / ".claude" / "marker").read_bytes() == b"installed\n"
+    assert not install_branch.is_dirty(tmp_path)
+    # The original branch has no marker — the install lives only on the install branch.
+    _git(tmp_path, "checkout", "-q", orig)
+    assert not (tmp_path / ".claude" / "marker").exists()
+
+
+def test_stage_return_parks_install_on_branch(tmp_path: Path):
+    """--return leaves the tree on the original branch (clean); the install lives on the branch."""
+    _init_repo(tmp_path)
+    orig = _current_branch(tmp_path)
+
+    report = install_branch.stage_install(
+        tmp_path, _write_file_action(".claude/marker", b"x\n"),
+        non_interactive=True, keep_checkout=False,
+    )
+
+    assert report.staged is True
+    assert report.on_branch is False
+    assert _current_branch(tmp_path) == orig
+    # Working tree is back to pristine — the marker is NOT here...
+    assert not (tmp_path / ".claude" / "marker").exists()
+    assert not install_branch.is_dirty(tmp_path)
+    # ...but it IS on the install branch.
+    show = _git(tmp_path, "show", f"{install_branch.DEFAULT_BRANCH}:.claude/marker")
+    assert show.returncode == 0 and show.stdout == "x\n"
+
+
+# --------------------------------------------------------------- composes with manifest-restore
+
+
+def test_composes_with_manifest_restore(tmp_path: Path):
+    """The installer's manifest/.bak are committed on the branch AND restore still sees them there."""
+    _init_repo(tmp_path)
+
+    def _installer_like(target: Path) -> None:
+        # A pre-existing .claude/ archived (moved) + a fresh one laid where it stood, plus an
+        # in-place-modified CLAUDE.md whose original is kept as CLAUDE.md.bak — exactly the two
+        # reversible dispositions restore reverses.
+        claude = target / ".claude"
+        (claude / "team").mkdir(parents=True)
+        (claude / "team" / "charter.md").write_bytes(b"# ORIGINAL\n")
+        repo_space.archive_assets(target)  # MOVES .claude/ into .claude-backups/<UTC>/ + manifest
+        (claude / "team").mkdir(parents=True)
+        (claude / "team" / "charter.md").write_bytes(b"# FRESH\n")
+        (target / "CLAUDE.md.bak").write_bytes(b"# ORIGINAL md\n")
+        (target / "CLAUDE.md").write_bytes(b"# FRESH md\n")
+
+    report = install_branch.stage_install(tmp_path, _installer_like, non_interactive=True)
+    assert report.staged is True
+
+    # The manifest + .bak were captured in the branch commit (tree is clean, artifacts present).
+    assert not install_branch.is_dirty(tmp_path)
+    assert repo_space.find_latest_archive(tmp_path) is not None
+    assert (tmp_path / "CLAUDE.md.bak").is_file()
+
+    # And restore — the OTHER undo path — still sees both directions on the staged branch: the two
+    # compose rather than conflict.
+    plan = restore.plan_restore(tmp_path)
+    assert plan.archived == [".claude"]
+    assert [rev.target_rel for rev in plan.reverts] == ["CLAUDE.md"]
+
+
+# --------------------------------------------------------------- degradation: refuse, create nothing
+
+
+def test_dirty_tree_refuses(tmp_path: Path):
+    """A dirty working tree refuses (would fold uncommitted work into the install commit)."""
+    _init_repo(tmp_path)
+    (tmp_path / "dirty.txt").write_text("uncommitted\n", encoding="utf-8")  # untracked -> dirty
+    assert install_branch.is_dirty(tmp_path)
+
+    report = install_branch.stage_install(
+        tmp_path, _write_file_action(".claude/marker", b"x\n"), non_interactive=True
+    )
+    assert report.staged is False
+    assert not install_branch.branch_exists(tmp_path, install_branch.DEFAULT_BRANCH)
+    assert any("uncommitted" in n for n in report.notes)
+
+
+def test_non_git_repo_refuses(tmp_path: Path):
+    """A non-git target refuses with a message pointing at the restore path — and creates nothing."""
+    report = install_branch.stage_install(
+        tmp_path, _write_file_action(".claude/marker", b"x\n"), non_interactive=True
+    )
+    assert report.staged is False
+    assert not (tmp_path / ".claude").exists()
+    assert any("not a git repository" in n for n in report.notes)
+
+
+def test_branch_collision_refuses(tmp_path: Path):
+    """An existing install branch refuses rather than reusing or clobbering it."""
+    _init_repo(tmp_path)
+    _git(tmp_path, "branch", install_branch.DEFAULT_BRANCH)
+
+    report = install_branch.stage_install(
+        tmp_path, _write_file_action(".claude/marker", b"x\n"), non_interactive=True
+    )
+    assert report.staged is False
+    assert any("already exists" in n for n in report.notes)
+
+
+def test_dry_run_creates_nothing(tmp_path: Path):
+    """--dry-run resolves the plan but creates no branch and runs no install."""
+    _init_repo(tmp_path)
+    report = install_branch.stage_install(
+        tmp_path, _write_file_action(".claude/marker", b"x\n"), non_interactive=True, dry_run=True
+    )
+    assert report.staged is False
+    assert not install_branch.branch_exists(tmp_path, install_branch.DEFAULT_BRANCH)
+    assert not (tmp_path / ".claude").exists()
+    assert any("dry-run" in n for n in report.notes)
+
+
+def test_failed_install_rolls_back(tmp_path: Path):
+    """If the install action raises, the branch is rolled back and the tree left as found."""
+    _init_repo(tmp_path)
+    orig = _current_branch(tmp_path)
+
+    def _boom(target: Path) -> None:
+        (target / ".claude").mkdir()
+        (target / ".claude" / "partial").write_text("half\n", encoding="utf-8")
+        raise RuntimeError("install blew up")
+
+    with pytest.raises(RuntimeError, match="install blew up"):
+        install_branch.stage_install(tmp_path, _boom, non_interactive=True)
+
+    # Rolled back: original branch restored, install branch gone, no partial files left.
+    assert _current_branch(tmp_path) == orig
+    assert not install_branch.branch_exists(tmp_path, install_branch.DEFAULT_BRANCH)
+    assert not (tmp_path / ".claude").exists()
+    assert not install_branch.is_dirty(tmp_path)
+
+
+# --------------------------------------------------------------- CLI consent (no mutation unattended)
+
+
+def test_cli_non_tty_without_flag_refuses(tmp_path: Path):
+    """A non-TTY CLI run without --non-interactive refuses at the consent gate; nothing is created."""
+    _init_repo(tmp_path)
+    r = subprocess.run(
+        [sys.executable, str(_INSTALL_BRANCH), str(tmp_path)],
+        capture_output=True, text=True, stdin=subprocess.DEVNULL,
+    )
+    assert r.returncode == 1
+    assert "refusing" in r.stderr.lower()
+    assert not install_branch.branch_exists(tmp_path, install_branch.DEFAULT_BRANCH)

--- a/python/src/real_team/cli.py
+++ b/python/src/real_team/cli.py
@@ -667,6 +667,17 @@ def install_branch(
         help="After staging, check the original branch back out (tree left clean; install "
         "parked on the branch) instead of staying on the install branch",
     ),
+    expect: str = typer.Option(
+        "any",
+        "--expect",
+        help="repo.expect for the staged bootstrap: fresh|existing|any (default: any — "
+        "install-branch targets an existing repo)",
+    ),
+    config: str = typer.Option(
+        None,
+        "--config",
+        help="Path to a unified YAML install config threaded to the staged bootstrap",
+    ),
 ) -> None:
     """Stage a framework install onto a throwaway git branch — trial it, then merge or delete.
 
@@ -683,6 +694,8 @@ def install_branch(
         target_path,
         branch=branch,
         owner=owner,
+        install_config=config,
+        expect=expect,
         dry_run=dry_run,
         non_interactive=non_interactive,
         return_to_original=return_to_original,

--- a/python/src/real_team/cli.py
+++ b/python/src/real_team/cli.py
@@ -646,6 +646,61 @@ def restore(
         raise typer.Exit(proc.returncode)
 
 
+@app.command(name="install-branch")
+def install_branch(
+    target: str = typer.Option(".", help="Target directory"),
+    owner: str = typer.Option(None, help="scm.owner (GitHub org/user) for the staged install"),
+    branch: str = typer.Option(
+        None, "--branch", help="Install branch name to create (default: real-team/install)"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Preview the plan; create no branch"
+    ),
+    non_interactive: bool = typer.Option(
+        False,
+        "--non-interactive",
+        help="Never prompt; proceed without the confirmation gate (automation)",
+    ),
+    return_to_original: bool = typer.Option(
+        False,
+        "--return",
+        help="After staging, check the original branch back out (tree left clean; install "
+        "parked on the branch) instead of staying on the install branch",
+    ),
+) -> None:
+    """Stage a framework install onto a throwaway git branch — trial it, then merge or delete.
+
+    The git-native sibling of `2real-team restore`: instead of installing onto your working tree
+    (undo later via the manifest), it creates a dedicated install branch off HEAD, runs the install
+    there, and commits it as one commit. Try it out, then `git merge` the branch to keep it or
+    `git branch -D` to walk away clean — no manifest bookkeeping. Refuses in a non-git repo or a
+    dirty tree (use a plain install + `restore` there); --dry-run previews only.
+    """
+    from .framework_install import stage_install_framework
+
+    target_path = Path(target).resolve()
+    proc = stage_install_framework(
+        target_path,
+        branch=branch,
+        owner=owner,
+        dry_run=dry_run,
+        non_interactive=non_interactive,
+        return_to_original=return_to_original,
+    )
+    if proc is None:
+        console.print(
+            "[yellow]Cannot stage install:[/yellow] bundled framework assets not found "
+            "(re-run from a source checkout, or use the standalone install-branch command)."
+        )
+        raise typer.Exit(1)
+    if proc.stdout:
+        console.print(proc.stdout.rstrip())
+    if proc.returncode != 0:
+        if proc.stderr:
+            console.print(f"[red]{proc.stderr.strip()}[/red]")
+        raise typer.Exit(proc.returncode)
+
+
 def _extract_field(content: str, field: str) -> str | None:
     """Extract a field value from a roster card."""
     for line in content.splitlines():

--- a/python/src/real_team/framework_install.py
+++ b/python/src/real_team/framework_install.py
@@ -161,3 +161,63 @@ def restore_framework(
     if dry_run:
         cmd += ["--dry-run"]
     return subprocess.run(cmd, capture_output=True, text=True)
+
+
+def stage_install_framework(
+    target: Path,
+    *,
+    branch: str | None = None,
+    owner: str | None = None,
+    shell: str = "bash",
+    merge_model: str | None = None,
+    install_config: Path | str | None = None,
+    with_ontology: bool | None = None,
+    dry_run: bool = False,
+    non_interactive: bool = True,
+    return_to_original: bool = False,
+) -> subprocess.CompletedProcess | None:
+    """Stage a framework install onto a throwaway git branch via ``install/install_branch.py``.
+
+    The git-native sibling of :func:`restore_framework`: rather than installing onto the working
+    tree (undo later via the manifest), it creates a dedicated install branch off HEAD, runs the
+    ordinary bootstrapper there, and commits the install as one commit — so the operator can
+    ``git merge`` it when satisfied or ``git branch -D`` to walk away. Refuses (exit 1) in a
+    non-git repo or dirty tree.
+
+    The staging flags (``branch``/``dry_run``/``non_interactive``/``return_to_original``) are
+    consumed by ``install_branch.py``; the install-shape flags (``owner``/``shell``/``merge_model``
+    /… — the same set :func:`install_framework` builds) pass THROUGH it to the bootstrapper that
+    runs on the branch. ``--no-team`` is always forwarded (the CLI owns roster scaffolding), as in
+    :func:`install_framework`.
+
+    Returns the CompletedProcess, or None when the framework assets could not be located.
+    """
+    root = resolve_framework_root()
+    if root is None:
+        return None
+
+    cmd: list[str] = [sys.executable, str(root / "install" / "install_branch.py"), str(target)]
+    # Staging flags consumed by install_branch.py itself.
+    if branch:
+        cmd += ["--branch", branch]
+    if dry_run:
+        cmd += ["--dry-run"]
+    if non_interactive:
+        cmd += ["--non-interactive"]
+    if return_to_original:
+        cmd += ["--return"]
+    # Install-shape flags that pass THROUGH to the bootstrapper run on the branch (mirrors
+    # install_framework's flag construction).
+    cmd += ["--no-team", "--shell", shell]
+    if install_config:
+        cmd += ["--install-config", str(install_config)]
+    if owner:
+        cmd += ["--owner", owner]
+    if merge_model:
+        cmd += ["--merge-model", merge_model]
+    if with_ontology is True:
+        cmd += ["--with-ontology"]
+    elif with_ontology is False:
+        cmd += ["--no-ontology"]
+
+    return subprocess.run(cmd, capture_output=True, text=True)

--- a/python/src/real_team/framework_install.py
+++ b/python/src/real_team/framework_install.py
@@ -172,6 +172,7 @@ def stage_install_framework(
     merge_model: str | None = None,
     install_config: Path | str | None = None,
     with_ontology: bool | None = None,
+    expect: str | None = None,
     dry_run: bool = False,
     non_interactive: bool = True,
     return_to_original: bool = False,
@@ -186,9 +187,14 @@ def stage_install_framework(
 
     The staging flags (``branch``/``dry_run``/``non_interactive``/``return_to_original``) are
     consumed by ``install_branch.py``; the install-shape flags (``owner``/``shell``/``merge_model``
-    /… — the same set :func:`install_framework` builds) pass THROUGH it to the bootstrapper that
-    runs on the branch. ``--no-team`` is always forwarded (the CLI owns roster scaffolding), as in
-    :func:`install_framework`.
+    /``expect``/… — the same set :func:`install_framework` builds, plus ``expect``) pass THROUGH
+    it to the bootstrapper that runs on the branch. ``--no-team`` is always forwarded (the CLI owns
+    roster scaffolding), as in :func:`install_framework`.
+
+    ``expect`` forwards ``--expect`` (``fresh``/``existing``/``any``) to the staged bootstrap's
+    fresh-vs-existing gate. Staging by definition targets a repo that already has a HEAD commit
+    (there is nothing to branch from otherwise), so callers should default this to ``"any"`` —
+    the shipped bootstrapper default (``fresh``) refuses every realistic install-branch target.
 
     Returns the CompletedProcess, or None when the framework assets could not be located.
     """
@@ -219,5 +225,7 @@ def stage_install_framework(
         cmd += ["--with-ontology"]
     elif with_ontology is False:
         cmd += ["--no-ontology"]
+    if expect:
+        cmd += ["--expect", expect]
 
     return subprocess.run(cmd, capture_output=True, text=True)

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1523,3 +1523,38 @@ class TestRestore:
             app, ["restore", "--target", str(tmp_path), "--non-interactive"]
         )
         assert result.exit_code == 0, result.output
+
+
+class TestInstallBranch:
+    """The packaged ``2real-team install-branch`` command (bridges to install_branch.py, #279)."""
+
+    def test_non_git_repo_refuses(self, tmp_path: Path):
+        """A non-git target refuses (exit 1) and creates nothing (message wraps under rich, so
+        assert behaviorally; the engine test covers the exact message text)."""
+        result = runner.invoke(
+            app, ["install-branch", "--target", str(tmp_path), "--non-interactive"]
+        )
+        assert result.exit_code == 1, result.output
+        assert "git repo" in result.output.lower()  # the plan line printed before refusing
+        assert not (tmp_path / ".claude").exists()
+
+    def test_dry_run_creates_no_branch(self, tmp_path: Path):
+        """--dry-run on a clean git repo previews the plan; creates no branch and no files."""
+        import subprocess
+
+        subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "-c", "user.name=T", "-c", "user.email=t@t",
+             "commit", "-q", "--allow-empty", "-m", "seed"], check=True,
+        )
+        result = runner.invoke(
+            app,
+            ["install-branch", "--target", str(tmp_path), "--dry-run", "--non-interactive"],
+        )
+        assert result.exit_code == 0, result.output
+        branches = subprocess.run(
+            ["git", "-C", str(tmp_path), "branch", "--list", "real-team/install"],
+            capture_output=True, text=True,
+        )
+        assert branches.stdout.strip() == ""
+        assert not (tmp_path / ".claude").exists()

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1558,3 +1558,75 @@ class TestInstallBranch:
         )
         assert branches.stdout.strip() == ""
         assert not (tmp_path / ".claude").exists()
+
+    def test_succeeds_on_realistic_repo(self, tmp_path: Path):
+        """Regression for #283's must-fix: a real repo (HEAD commit + a tracked file) is exactly
+        what install-branch exists to target, but the staged bootstrap used to run with no
+        ``--expect`` and inherit the shipped default ``repo.expect=fresh`` — which the
+        fresh-vs-existing gate REFUSES for a repo with a commit, rolling the staged branch back.
+        The command must default ``--expect`` to ``any`` so this succeeds out of the box."""
+        import subprocess
+
+        subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+        (tmp_path / "README.md").write_text("# realistic repo\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(tmp_path), "add", "README.md"], check=True)
+        subprocess.run(
+            ["git", "-C", str(tmp_path), "-c", "user.name=T", "-c", "user.email=t@t",
+             "commit", "-q", "-m", "seed"], check=True,
+        )
+        result = runner.invoke(
+            app, ["install-branch", "--target", str(tmp_path), "--non-interactive"]
+        )
+        assert result.exit_code == 0, result.output
+        branches = subprocess.run(
+            ["git", "-C", str(tmp_path), "branch", "--list", "real-team/install"],
+            capture_output=True, text=True,
+        )
+        assert "real-team/install" in branches.stdout
+        installed = subprocess.run(
+            ["git", "-C", str(tmp_path), "show", "real-team/install:.claude/framework.config.json"],
+            capture_output=True, text=True,
+        )
+        assert installed.returncode == 0, installed.stderr
+
+    def _capture_cmd(self, monkeypatch) -> dict:
+        import subprocess
+
+        import real_team.framework_install as fi
+
+        captured: dict = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        monkeypatch.setattr(fi.subprocess, "run", fake_run)
+        return captured
+
+    def test_default_threads_expect_any(self, monkeypatch, tmp_path: Path):
+        """Without an explicit --expect, the CLI must default to "any" — install-branch targets
+        an existing repo by definition, and the bootstrapper's shipped default (repo.expect=fresh)
+        would refuse it. subprocess.run is faked here to isolate flag-threading from the (heavy,
+        already-covered-elsewhere) real bootstrap run."""
+        captured = self._capture_cmd(monkeypatch)
+        result = runner.invoke(
+            app, ["install-branch", "--target", str(tmp_path), "--non-interactive"]
+        )
+        assert result.exit_code == 0, result.output
+        cmd = captured["cmd"]
+        assert "--expect" in cmd
+        assert cmd[cmd.index("--expect") + 1] == "any"
+
+    def test_expect_and_config_override_threaded(self, monkeypatch, tmp_path: Path):
+        captured = self._capture_cmd(monkeypatch)
+        cfg = tmp_path / "install.yaml"
+        cfg.write_text("version: 1\n", encoding="utf-8")
+        result = runner.invoke(
+            app,
+            ["install-branch", "--target", str(tmp_path), "--expect", "existing",
+             "--config", str(cfg), "--non-interactive"],
+        )
+        assert result.exit_code == 0, result.output
+        cmd = captured["cmd"]
+        assert "--expect" in cmd and "existing" in cmd
+        assert "--install-config" in cmd and str(cfg) in cmd

--- a/python/tests/test_framework_install.py
+++ b/python/tests/test_framework_install.py
@@ -67,6 +67,26 @@ class TestStageInstallFrameworkBridge:
         assert "--owner" in cmd and "acme" in cmd
         assert "--merge-model" in cmd and "wave-branch" in cmd
 
+    def test_expect_threaded(self, monkeypatch, tmp_path: Path):
+        """``expect`` forwards --expect to the bootstrapper that runs on the staged branch —
+        the fix for #283's must-fix (the staged bootstrap used to inherit the shipped default
+        repo.expect=fresh, which refuses every realistic install-branch target)."""
+        from real_team.framework_install import stage_install_framework
+
+        captured = _capture(monkeypatch)
+        stage_install_framework(tmp_path, expect="existing")
+        cmd = captured["cmd"]
+        assert "--expect" in cmd and "existing" in cmd
+
+    def test_expect_omitted_when_unset(self, monkeypatch, tmp_path: Path):
+        """The bridge itself has no expect default (None): the CLI is the one that defaults to
+        "any"; leaving expect unset here threads no --expect flag at all."""
+        from real_team.framework_install import stage_install_framework
+
+        captured = _capture(monkeypatch)
+        stage_install_framework(tmp_path)
+        assert "--expect" not in captured["cmd"]
+
     def test_no_assets_returns_none(self, monkeypatch, tmp_path: Path):
         import real_team.framework_install as fi
 

--- a/python/tests/test_framework_install.py
+++ b/python/tests/test_framework_install.py
@@ -1,0 +1,74 @@
+"""Bridge tests for ``framework_install`` — argv threading for the packaged install commands.
+
+These lock the flag-forwarding contract of the bridges without running the (heavy) bootstrapper:
+``subprocess.run`` is monkeypatched to capture the argv the bridge builds. The focus here is
+:func:`stage_install_framework` (#279) — it must forward the staging flags to ``install_branch.py``
+AND pass the install-shape flags through to the bootstrapper that runs on the branch.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def _capture(monkeypatch) -> dict:
+    import real_team.framework_install as fi
+
+    captured: dict = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(fi.subprocess, "run", fake_run)
+    return captured
+
+
+class TestStageInstallFrameworkBridge:
+    def test_targets_install_branch_module(self, monkeypatch, tmp_path: Path):
+        from real_team.framework_install import stage_install_framework
+
+        captured = _capture(monkeypatch)
+        stage_install_framework(tmp_path)
+        cmd = captured["cmd"]
+        assert cmd[1].endswith("install_branch.py")
+        assert str(tmp_path) in cmd
+        # --no-team is always forwarded (the CLI owns roster scaffolding), like install_framework.
+        assert "--no-team" in cmd
+
+    def test_non_interactive_default_on(self, monkeypatch, tmp_path: Path):
+        """Packaged default never hangs on a prompt: --non-interactive is threaded by default."""
+        from real_team.framework_install import stage_install_framework
+
+        captured = _capture(monkeypatch)
+        stage_install_framework(tmp_path)
+        assert "--non-interactive" in captured["cmd"]
+
+    def test_staging_flags_threaded(self, monkeypatch, tmp_path: Path):
+        from real_team.framework_install import stage_install_framework
+
+        captured = _capture(monkeypatch)
+        stage_install_framework(
+            tmp_path, branch="try/x", dry_run=True, return_to_original=True
+        )
+        cmd = captured["cmd"]
+        assert "--branch" in cmd and "try/x" in cmd
+        assert "--dry-run" in cmd
+        assert "--return" in cmd
+
+    def test_install_shape_flags_pass_through(self, monkeypatch, tmp_path: Path):
+        """owner/merge-model pass THROUGH install_branch.py to the bootstrapper on the branch."""
+        from real_team.framework_install import stage_install_framework
+
+        captured = _capture(monkeypatch)
+        stage_install_framework(tmp_path, owner="acme", merge_model="wave-branch")
+        cmd = captured["cmd"]
+        assert "--owner" in cmd and "acme" in cmd
+        assert "--merge-model" in cmd and "wave-branch" in cmd
+
+    def test_no_assets_returns_none(self, monkeypatch, tmp_path: Path):
+        import real_team.framework_install as fi
+
+        monkeypatch.setattr(fi, "resolve_framework_root", lambda: None)
+        assert fi.stage_install_framework(tmp_path) is None


### PR DESCRIPTION
## Summary

Closes #279. Adds a **git-native install-branch staging mode** — the coherent "trial an install safely" follow-up to the manifest-restore path shipped in #278.

`framework/install/install_branch.py` stages a framework install onto a dedicated throwaway branch cut from the current HEAD, committed as **one commit**, so an operator can `git merge` it when satisfied or `git branch -D` to walk away clean — no manifest bookkeeping to reason about.

## Design

- **Surface.** Standalone `install_branch.py` (engine + CLI) and a product bridge `2real-team install-branch` (`framework_install.stage_install_framework`). Flags: `--branch`, `--dry-run`, `--non-interactive`, `--return` (leave the tree on the original branch with the install parked on the branch, instead of staying on the install branch to try it). The engine takes the install action as a **callable** so it stays git-only and testable; the CLI wires that callable to `bootstrap.py` with pass-through args.
- **Degradation — REFUSE, don't silently fall back.** In a non-git repo (no branch to make) or a dirty tree (would fold uncommitted work into the install commit, voiding the clean merge/discard guarantee) it refuses with an actionable message pointing at the `install` + `restore` path. Justified in the module docstring: the two paths have non-substitutable contracts and a silent switch would surprise the operator.
- **Composes with manifest-restore.** Staging runs the ordinary installer, which still writes its manifest/`.bak` — captured inside the branch commit — so `restore` still works on a staged branch. install-branch never consumes a manifest and `restore` never touches a branch, so neither corrupts the other. The full "when to prefer which" + "how they compose" documentation lives in `install_branch.py`'s module docstring.
- **Fail-safe.** Preview -> `[y/N]` consent -> `--dry-run`/`--non-interactive`/non-TTY-refuses, mirroring `restore`. If the install action fails midway, the branch is rolled back (checkout original + `git clean -fd` the debris + delete branch) so the tree is left exactly as found; the CLI reports it cleanly (no traceback). Stdlib-only, per-commit `-c` identity for the staged commit (never global git config).

Verified end-to-end against a throwaway git repo: dry-run creates nothing; a live stage runs the real bootstrapper, commits it as one commit, prints the exact merge/discard commands, and `git branch -D` walks away with the working tree restored.

## Load-bearing tests (revert -> red)

`framework/tests/test_install_branch.py` (engine, injected fake install action):
- `test_stage_creates_branch_and_commits` — branch created + install committed, left on it
- `test_stage_return_parks_install_on_branch` — `--return` leaves tree clean on original; install on the branch
- `test_composes_with_manifest_restore` — manifest/`.bak` committed on the branch AND `restore.plan_restore` still sees both directions
- `test_dirty_tree_refuses`, `test_non_git_repo_refuses`, `test_branch_collision_refuses` — degrade by refusing, create nothing
- `test_dry_run_creates_nothing`, `test_failed_install_rolls_back`, `test_cli_non_tty_without_flag_refuses`

`python/tests/test_framework_install.py` — bridge argv threading (staging flags consumed by `install_branch.py`; install-shape flags pass through to bootstrap).
`python/tests/test_cli.py::TestInstallBranch` — `install-branch` non-git refusal + dry-run creates no branch.

## Testing

```
ruff check framework/                         # pass
cd python && ruff check src/ tests/           # pass
python3 -m pytest framework/tests/ -q         # 879 passed
cd python && PYTHONPATH=src python3 -m pytest -q   # 139 passed
```
(In a worktree the editable install points at the main checkout, so CLI/bridge tests need `PYTHONPATH=src`; CI runs against the real checkout.)

Reviewers: **Paloma Gupta** + **Tariq Morales**.
