### PR TITLE
fix(trust): credit review value in the reserved-5 composite (#275)

### DIFF
--- a/framework/assets/lib/trust_signals.py
+++ b/framework/assets/lib/trust_signals.py
@@ -177,6 +177,13 @@ NEUTRAL = 3
 MIN_SCORE = 1
 MAX_SCORE = 5
 
+# Reserved-5 composite (#275): review-value signals (``must_fix_caught``,
+# ``verified_reviews``) are weighted up and ``difficulty_points`` is capped so
+# authoring can no longer single-handedly out-rank real review work. See
+# :func:`apply_distribution_discipline`.
+REVIEW_VALUE_WEIGHT = 2
+DIFFICULTY_COMPOSITE_CAP = 2
+
 # Decay: no trust-relevant signal for this many iterations → drift one step
 # toward NEUTRAL (a 4 with nothing to say for 3 iterations is no longer a 4).
 DECAY_AFTER_WAVES = 3
@@ -1422,11 +1429,22 @@ def apply_distribution_discipline(
         # equal PR count, so the top slot is not a narrative argument. Waves with
         # no diffstat plumbed (``difficulty_points == 0`` for everyone — e.g. a
         # hand-built Signals dict) rank exactly as before.
+        #
+        # #275: ``difficulty_points`` is author-only — a pure reviewer accrues 0
+        # of it no matter how valuable the review, so it used to dominate the
+        # composite outright (a flagship author always outranked a defect-catching
+        # reviewer). Two live waves reproduced the reserved-5 rotating away from
+        # the reviewer who caught the wave's only real defect toward a merely-
+        # clean author. Fix: weight the review-value signals (``must_fix_caught``,
+        # ``verified_reviews``) at ``REVIEW_VALUE_WEIGHT`` and cap
+        # ``difficulty_points``' contribution at ``DIFFICULTY_COMPOSITE_CAP`` so
+        # difficulty can tip a close race but can no longer single-handedly bury
+        # real review work.
         return (
             s.prs_merged
-            + s.must_fix_caught
-            + s.verified_reviews
-            + s.difficulty_points
+            + REVIEW_VALUE_WEIGHT * s.must_fix_caught
+            + REVIEW_VALUE_WEIGHT * s.verified_reviews
+            + min(s.difficulty_points, DIFFICULTY_COMPOSITE_CAP)
             - s.must_fix_received
             - 2 * s.ci_red_merges
             - 2 * s.review_false_positives

--- a/framework/tests/test_trust_signals.py
+++ b/framework/tests/test_trust_signals.py
@@ -1494,6 +1494,64 @@ def test_distribution_unchanged_without_difficulty() -> None:
     assert out["B"] == ts.MAX_SCORE - 1
 
 
+# ------------------------------------------- reserved-5 composite (#275)
+
+
+def test_review_value_lets_reviewer_hold_reserved_5_over_clean_author() -> None:
+    """The W20 regression: a pure reviewer who caught a real defect and filed a
+    verified review (no authoring, no difficulty) must be able to out-composite
+    a clean author who shipped a flagship diff but added zero review value.
+    Before #275 ``difficulty_points`` alone decided the reserved 5, so the
+    reviewer (composite 2) lost to the author (composite 4) every time — the
+    exact shape that demoted Tariq 5→4 in favour of Nia in Wave 20.
+    """
+    reviewer = ts.Signals(must_fix_caught=1, verified_reviews=1)  # difficulty=0
+    clean_author = ts.Signals(prs_merged=1, difficulty_points=3)  # no review value
+    out = ts.apply_distribution_discipline(
+        {
+            "Reviewer": (ts.MAX_SCORE, reviewer),
+            "Author": (ts.MAX_SCORE, clean_author),
+        }
+    )
+    assert out["Reviewer"] == ts.MAX_SCORE  # holds the 5 on review value
+    assert out["Author"] == ts.MAX_SCORE - 1  # merely clean, no longer dominant
+
+
+def test_merely_clean_author_without_review_value_does_not_win_reserved_5() -> None:
+    """Guard: the reserve discipline still holds under the new weighting — an
+    author with no review value and no signal at all (composite 0) cannot claim
+    the 5 just because everyone else in the pool is net-negative that iteration.
+    """
+    zero_signal = ts.Signals()  # nothing happened — composite 0
+    had_a_must_fix = ts.Signals(prs_merged=1, must_fix_received=1)  # composite 0
+    out = ts.apply_distribution_discipline(
+        {
+            "Quiet": (ts.MAX_SCORE, zero_signal),
+            "Dinged": (3, had_a_must_fix),
+        }
+    )
+    assert out["Quiet"] == ts.MAX_SCORE - 1  # composite 0 is not strictly positive
+    assert out["Dinged"] == 3  # proposed <5 passes through untouched
+
+
+def test_difficulty_composite_cap_prevents_single_handed_dominance() -> None:
+    """A flagship diff (difficulty=5, well above the cap) no longer buries a
+    reviewer who caught one real defect and filed one verified review — the
+    capped difficulty contribution (``DIFFICULTY_COMPOSITE_CAP``) can tip a
+    close race but can't out-rank real review work by raw diffstat size alone.
+    """
+    flagship_author = ts.Signals(prs_merged=1, difficulty_points=5)
+    reviewer = ts.Signals(must_fix_caught=1, verified_reviews=1)
+    out = ts.apply_distribution_discipline(
+        {
+            "Flagship": (ts.MAX_SCORE, flagship_author),
+            "Reviewer": (ts.MAX_SCORE, reviewer),
+        }
+    )
+    assert out["Reviewer"] == ts.MAX_SCORE
+    assert out["Flagship"] == ts.MAX_SCORE - 1
+
+
 # ------------------------------------------- _pr_comment_histories (I/O, mocked)
 
 


### PR DESCRIPTION
## What changed

`apply_distribution_discipline`'s reserved-5 composite in
`framework/assets/lib/trust_signals.py` was dominated by `difficulty_points`,
which is author-only. A pure reviewer accrues 0 of it no matter how valuable
the review, so a reviewer could never out-composite a clean author for the
reserved 5.

Fixes #275 (data point #2 — Wave 20): the reserved-5 rotated away from Tariq
(caught the wave's only real defect: `must_fix_caught=1`, `verified_reviews=1`)
to Nia (clean author, `difficulty_points=3`, no review value) — demoting the
person who did the highest-value review work of the wave.

### Fix

- `REVIEW_VALUE_WEIGHT = 2` — `must_fix_caught` and `verified_reviews` now
  count double in the composite.
- `DIFFICULTY_COMPOSITE_CAP = 2` — `difficulty_points`' contribution is capped
  so a single flagship diff can no longer single-handedly bury real review
  work.
- The ±2/wave delta clamp and the 1–5 scale are untouched — this is a
  composite fix, not a range change (the scale-broadening trigger in #275 did
  not fire; only the reserved-5 composite trigger did).
- `apply_distribution_discipline`'s contract is preserved: 5 still reserved
  for the iteration's exceptional relative performer(s) with strictly-positive
  composite, extra proposed 5s capped to 4, ≤4 passes through unchanged.

### Tests (`framework/tests/test_trust_signals.py`)

- `test_review_value_lets_reviewer_hold_reserved_5_over_clean_author` — the
  W20 regression case, reproduced with hand-built `Signals` and asserted
  against `apply_distribution_discipline`'s output. Reviewer now holds the 5.
- `test_merely_clean_author_without_review_value_does_not_win_reserved_5` —
  guard: reserve discipline still holds, a zero-signal author cannot claim the
  5 by default.
- `test_difficulty_composite_cap_prevents_single_handed_dominance` — locks
  the cap so raw diffstat size alone can't out-rank real review work.
- Existing composite tests (`test_difficulty_breaks_reserved_5_toward_flagship_author`,
  `test_distribution_unchanged_without_difficulty`) still pass unchanged.

### Verification

- `ruff check framework/assets/lib/trust_signals.py framework/tests/` — all
  checks passed.
- `pytest framework/tests/test_trust_signals.py -q` — 124 passed.
- revert→red: reverted the composite to the old (uncapped/unweighted)
  formula, the two new regression tests failed (`assert 4 == 5`) as expected;
  restored → 124 passed again.
- `python3 framework/install/reinstall.py --check` → rc 0, "`.claude/` is in
  sync with canonical `framework/assets/`." (no `.claude/lib` mirror exists in
  this repo; the lib is wired in place, so no drift expected or found.)

### Dogfood note

Wave 21's retro will score under this new composite. Wave 20's trust deltas
are parked pending this fix per the #275 owner decision (see the issue's
Data point #2 comment) — un-parking is a separate Wave 21 step, not part of
this PR.

Co-Authored-By: Paloma Gupta <Paloma.Gupta@gmail.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
