### PR TITLE
fix(trust): make trust_signals + review_load author-exclusive (#288)

### DIFF
--- a/.claude/skills/wave-end/review_load.py
+++ b/.claude/skills/wave-end/review_load.py
@@ -74,22 +74,31 @@ class ReviewLoad:
 def review_load(prs, *, canon=None) -> dict[str, ReviewLoad]:
     """Pure: fold a wave's verdict comments into ``{reviewer: ReviewLoad}``.
 
-    ``prs`` is an iterable of ``(pr_key, comment_bodies)`` — ``pr_key`` any
-    hashable PR identity, ``comment_bodies`` the list of that PR's issue-comment
-    body strings. ``canon`` is an optional ``name -> canonical_name`` mapper
-    (default identity); pass ``trust_signals._canonicalizer(cfg)`` to fold name
-    variants to their roster identity exactly as the scorer does.
+    ``prs`` is an iterable of ``(pr_key, author, comment_bodies)`` — ``pr_key``
+    any hashable PR identity, ``author`` that PR's author identity (the head
+    commit author name the scorer buckets by; may be ``None`` when unknown),
+    ``comment_bodies`` the list of that PR's issue-comment body strings.
+    ``canon`` is an optional ``name -> canonical_name`` mapper (default
+    identity); pass ``trust_signals._canonicalizer(cfg)`` to fold name variants
+    to their roster identity exactly as the scorer does.
 
     Verdicts with no ``Requestor:`` are skipped (nobody to attribute the load
-    to). Ordering of ``prs`` never affects the counts — the result is a pure
-    function of the multiset of (reviewer, pr) pairs.
+    to). A verdict whose ``Requestor:`` resolves to the PR's own ``author`` is
+    author-excluded (#288): the author wearing reviewer grammar on their own PR
+    is not a review turn and must not add to anyone's load — the same exclusion
+    ``trust_signals`` applies to the scoring signals, via the shared
+    :func:`trust_signals.is_author_self_review` helper. Ordering of ``prs`` never
+    affects the counts — the result is a pure function of the multiset of
+    (reviewer, pr) pairs.
     """
     canon = canon or (lambda n: n)
     out: dict[str, ReviewLoad] = {}
-    for pr_key, comment_bodies in prs:
+    for pr_key, author, comment_bodies in prs:
         seen_this_pr: set[str] = set()
         for v in ts.parse_verdicts(comment_bodies):
             if not v.requestor:
+                continue
+            if ts.is_author_self_review(v.requestor, author, canon):
                 continue
             name = canon(v.requestor)
             load = out.setdefault(name, ReviewLoad())
@@ -139,7 +148,12 @@ def extract_review_load(
     prs = ts.merged_prs(wave, status_path, label=label, cfg=cfg)
     canon = ts._canonicalizer(cfg)
     rows = [
-        (pr["number"], ts._pr_comment_bodies(pr["repo"], pr["number"])) for pr in prs
+        (
+            pr["number"],
+            pr.get("commit_author_name"),
+            ts._pr_comment_bodies(pr["repo"], pr["number"]),
+        )
+        for pr in prs
     ]
     return review_load(rows, canon=canon)
 

--- a/.claude/team/.charter-manifest.json
+++ b/.claude/team/.charter-manifest.json
@@ -6,7 +6,7 @@
     "charter.md": "b2d200f1de236bc1ba6d997917be5e186504a05c12015e392b1ecf7291564dfb",
     "commits.md": "c9d5e7349f0ead70cb37dd8cf20a7753fe3bea5c943ad56fe3f661dc4daaab67",
     "hooks.md": "77d72942082cf0dd1fb45da686376d8813d3e2b30ebe1ec4f99e432ef0fdb1d5",
-    "issues.md": "173291a720f55cf7fccc6fb2094eedbe1cf768ab3cbe988c755b7a2fb64ac35e",
+    "issues.md": "85008051a334ad87926be7c00ce0fd58e9b865e2a399db819ccbeaf064cbbde2",
     "pull-requests.md": "86eb6d9592c9e607e982d66cf9483391bb2319a5daaca1b82a6ea952f2baa99a",
     "skills.md": "dcc93b623b5f62cbac412634d4d3b04c3731c5a4a0892dd3227c70241703e81e"
   }

--- a/.claude/team/.charter-manifest.json
+++ b/.claude/team/.charter-manifest.json
@@ -7,7 +7,7 @@
     "commits.md": "c9d5e7349f0ead70cb37dd8cf20a7753fe3bea5c943ad56fe3f661dc4daaab67",
     "hooks.md": "77d72942082cf0dd1fb45da686376d8813d3e2b30ebe1ec4f99e432ef0fdb1d5",
     "issues.md": "85008051a334ad87926be7c00ce0fd58e9b865e2a399db819ccbeaf064cbbde2",
-    "pull-requests.md": "86eb6d9592c9e607e982d66cf9483391bb2319a5daaca1b82a6ea952f2baa99a",
+    "pull-requests.md": "2885ddcd76d6a5f4d8c63e36b77b71163cda165c5e2567d15a8e4d0e104cf1cd",
     "skills.md": "dcc93b623b5f62cbac412634d4d3b04c3731c5a4a0892dd3227c70241703e81e"
   }
 }

--- a/.claude/team/.charter-manifest.json
+++ b/.claude/team/.charter-manifest.json
@@ -6,7 +6,7 @@
     "charter.md": "b2d200f1de236bc1ba6d997917be5e186504a05c12015e392b1ecf7291564dfb",
     "commits.md": "c9d5e7349f0ead70cb37dd8cf20a7753fe3bea5c943ad56fe3f661dc4daaab67",
     "hooks.md": "77d72942082cf0dd1fb45da686376d8813d3e2b30ebe1ec4f99e432ef0fdb1d5",
-    "issues.md": "18d7a6a6e31112abad5ae6f92635c268168cce750b3372aacfa9d875f3dfbc9d",
+    "issues.md": "173291a720f55cf7fccc6fb2094eedbe1cf768ab3cbe988c755b7a2fb64ac35e",
     "pull-requests.md": "86eb6d9592c9e607e982d66cf9483391bb2319a5daaca1b82a6ea952f2baa99a",
     "skills.md": "dcc93b623b5f62cbac412634d4d3b04c3731c5a4a0892dd3227c70241703e81e"
   }

--- a/.claude/team/charter/issues.md
+++ b/.claude/team/charter/issues.md
@@ -157,6 +157,18 @@ fields (the exact form the roster carries) — `trust_signals.py` keys reviewer
 identity off that field, so a nickname or role suffix (`Tariq (QA)`) attributes
 the signal to the wrong (or no) engineer.
 
+**This grammar is reviewer-only — a PR author's reply to a must-fix is a PLAIN
+comment, NEVER a `Requestor:` / `RequestOrReplied:` verdict.** The `Requestor:`
+field names a *reviewer*, and a reviewer reviews someone else's PR; if the PR
+author answers a must-fix by wearing the verdict header on their own PR, the
+scorer would read them as a third reviewer of their own PR and manufacture
+spurious `verified_reviews` / `missed_catches` (the Wave-21 slip, #288). So when
+you are the author, just reply in prose ("Fixed in <sha> — <what changed>"), with
+no verdict header. As a durable backstop the scorer and the review-load counter
+now **author-exclude** any verdict whose `Requestor:` resolves to the PR's own
+author (mirroring the merge gate's exclusion of a self-addressed verdict), but
+the convention is still to never post one.
+
 ### Request vs. Replied, Must-fix vs. Tech-debt (semantics)
 
 The tokens carry meaning beyond their shape. `validate_review_comment_format`

--- a/.claude/team/charter/issues.md
+++ b/.claude/team/charter/issues.md
@@ -164,10 +164,12 @@ author answers a must-fix by wearing the verdict header on their own PR, the
 scorer would read them as a third reviewer of their own PR and manufacture
 spurious `verified_reviews` / `missed_catches` (the Wave-21 slip, #288). So when
 you are the author, just reply in prose ("Fixed in <sha> — <what changed>"), with
-no verdict header. As a durable backstop the scorer and the review-load counter
-now **author-exclude** any verdict whose `Requestor:` resolves to the PR's own
-author (mirroring the merge gate's exclusion of a self-addressed verdict), but
-the convention is still to never post one.
+no verdict header. As a durable backstop the trust scorer and the review-load
+counter now **author-exclude** any verdict whose `Requestor:` resolves to the
+PR's own author. (Scoring only — the armed merge-gate approval oracle
+`pr_review_state.compute_state` does NOT yet author-exclude, so an author's own
+self-verdict still counts toward the merge bar; that live self-approval gap is
+tracked separately in #293.) The convention is still to never post one.
 
 ### Request vs. Replied, Must-fix vs. Tech-debt (semantics)
 

--- a/.claude/team/charter/pull-requests.md
+++ b/.claude/team/charter/pull-requests.md
@@ -164,12 +164,23 @@ of that PR's verdicts, per the verdict grammar in [issues.md](issues.md). The
 2 reviewers must be 2 *different* people; the
 same reviewer counted twice does not satisfy the bar, and no self-review is permitted.
 
-This assignment convention is what the armed merge gate mechanically enforces (§ The
+This assignment convention is what the armed merge gate partly enforces (§ The
 N-reviewer merge gate): the oracle counts clean approvals over **distinct `Requestor:`
-identities other than the author**, so assigning fewer than 2
-distinct non-author reviewers leaves the PR unable to reach `approved` — it cannot
-merge. Assign the full slate at kickoff so the process the gate checks and the process
-the team runs are the same one.
+identities**, so assigning fewer than 2 distinct reviewers leaves
+the PR unable to reach `approved` — it cannot merge. Assign the full slate at kickoff
+so the process the gate checks and the process the team runs are the same one.
+
+> **Documented contract the code does NOT yet meet (#293).** The gate is *intended* to
+> count distinct `Requestor:` identities **other than the author**, matching the
+> author-exclusive assignment above. The current oracle
+> (`pr_review_state.compute_state`) does NOT exclude the author — it counts every
+> distinct `Requestor:`, so an author's own clean self-verdict still counts toward the
+> bar (a **live self-approval bypass**: author self-verdict + one genuine reviewer
+> reaches `approved` at `reviewers_required=2`). #293 brings the code up to this
+> contract by reusing `trust_signals.is_author_self_review`. Until it lands, the
+> author-exclusive bar rests on the assignment convention plus the reviewer-only
+> verdict grammar ([issues.md](issues.md)) — not on the gate. (The trust *scorer* is
+> already author-exclusive, per #288.)
 
 ## CI Gates
 

--- a/framework/assets/lib/trust_signals.py
+++ b/framework/assets/lib/trust_signals.py
@@ -1115,8 +1115,14 @@ def is_author_self_review(requestor: str | None, author: str | None, canon) -> b
     reply that slipped into ``Requestor:`` form — the Wave-21 slip), never a
     genuine third-party review. Author-exclusion drops it before it can accrue
     any reviewer signal (``must_fix_caught`` / ``verified_reviews`` /
-    ``missed_catches`` / review-load), mirroring the merge gate's exclusion of a
-    self-addressed verdict (the botfarm ``#657`` prior art).
+    ``missed_catches`` / review-load), mirroring the merge gate's self-review
+    exclusion. Modeled on the shared author-resolution helper botfarm's review
+    gate consolidated (same purpose) — but that gate keys the drop off the
+    ``Requestee:`` (addressed-author) field, whereas our charter grammar puts the
+    reviewer in ``Requestor:``, so the exclusion trigger flips to the Requestor.
+    Here author and reviewer identities are already folded through the roster
+    *canon*, so resolution is a single canonical-equality check (no separate
+    branch-name / login anchors to reconcile as the hook has).
 
     Both identities are folded through *canon* so name variants
     (``Ibrahim.El-Amin`` / ``Ibrahim El-Amin (Senior)``) compare equal. Fail-open

--- a/framework/assets/lib/trust_signals.py
+++ b/framework/assets/lib/trust_signals.py
@@ -1115,14 +1115,24 @@ def is_author_self_review(requestor: str | None, author: str | None, canon) -> b
     reply that slipped into ``Requestor:`` form — the Wave-21 slip), never a
     genuine third-party review. Author-exclusion drops it before it can accrue
     any reviewer signal (``must_fix_caught`` / ``verified_reviews`` /
-    ``missed_catches`` / review-load), mirroring the merge gate's self-review
-    exclusion. Modeled on the shared author-resolution helper botfarm's review
-    gate consolidated (same purpose) — but that gate keys the drop off the
-    ``Requestee:`` (addressed-author) field, whereas our charter grammar puts the
-    reviewer in ``Requestor:``, so the exclusion trigger flips to the Requestor.
-    Here author and reviewer identities are already folded through the roster
-    *canon*, so resolution is a single canonical-equality check (no separate
-    branch-name / login anchors to reconcile as the hook has).
+    ``missed_catches`` / review-load).
+
+    SCOPE (do not overstate): #288 makes only the two SCORING surfaces
+    (``trust_signals`` + ``review_load``) author-exclusive. This repo's ARMED
+    merge-gate oracle (``pr_review_state.compute_state``, consumed by the
+    ``validate_pr_review`` hook) counts approvals over distinct ``Requestor``\\ s
+    with NO author-exclusion, so an author's own clean self-verdict still counts
+    toward the review bar — a live self-approval bypass, tracked separately in
+    #293. This helper does NOT close that; nothing here should be read as the
+    merge gate excluding self-verdicts.
+
+    The helper's SHAPE is modeled on the shared author-resolution helper
+    botfarm's review gate consolidated — but that (botfarm) gate keys its drop
+    off the ``Requestee:`` (addressed-author) field, whereas our charter grammar
+    puts the reviewer in ``Requestor:``, so the exclusion trigger flips to the
+    Requestor. Here author and reviewer identities are already folded through the
+    roster *canon*, so resolution is a single canonical-equality check (no
+    separate branch-name / login anchors to reconcile as the hook has).
 
     Both identities are folded through *canon* so name variants
     (``Ibrahim.El-Amin`` / ``Ibrahim El-Amin (Senior)``) compare equal. Fail-open
@@ -1212,8 +1222,10 @@ def _account_pr(
     # reviewer signal (``must_fix_caught`` / ``verified_reviews`` /
     # ``missed_catches`` / false-positives) is ever attributed to the author for
     # their own PR, and so the #H5 gate-bypass check counts only true third-party
-    # reviewers — mirroring the merge gate's self-addressed exclusion. The ledger
-    # path is filtered at its own loop below.
+    # reviewers. This is a SCORING-side exclusion only; the armed merge-gate
+    # oracle (``pr_review_state.compute_state``) does NOT yet author-exclude — a
+    # live self-approval bypass tracked in #293. The ledger path is filtered at
+    # its own loop below.
     verdicts = [
         v for v in verdicts if not is_author_self_review(v.requestor, author, canon)
     ]

--- a/framework/assets/lib/trust_signals.py
+++ b/framework/assets/lib/trust_signals.py
@@ -1106,6 +1106,29 @@ def _canonicalizer(cfg):
     return canon
 
 
+def is_author_self_review(requestor: str | None, author: str | None, canon) -> bool:
+    """True when a verdict's ``Requestor:`` resolves to the PR's own author (#288).
+
+    The charter's ``Requestor:`` field names the REVIEWER, and a reviewer reviews
+    someone else's PR — so a verdict whose Requestor canonicalizes to the PR
+    author is the author wearing reviewer grammar on their own PR (a must-fix
+    reply that slipped into ``Requestor:`` form — the Wave-21 slip), never a
+    genuine third-party review. Author-exclusion drops it before it can accrue
+    any reviewer signal (``must_fix_caught`` / ``verified_reviews`` /
+    ``missed_catches`` / review-load), mirroring the merge gate's exclusion of a
+    self-addressed verdict (the botfarm ``#657`` prior art).
+
+    Both identities are folded through *canon* so name variants
+    (``Ibrahim.El-Amin`` / ``Ibrahim El-Amin (Senior)``) compare equal. Fail-open
+    and total: a missing ``requestor`` or ``author`` is never a self-review (so a
+    verdict with no attributable reviewer, or a PR with an unknown author, is
+    left for the caller to handle as before). Pure — no I/O.
+    """
+    if not requestor or not author:
+        return False
+    return canon(requestor) == canon(author)
+
+
 def _account_pr(
     signals: dict[str, Signals],
     canon,
@@ -1174,6 +1197,25 @@ def _account_pr(
         verdicts = parse_verdicts(comment_bodies or [])
         current_bodies = comment_bodies or []
     current_verdicts = parse_verdicts(current_bodies)
+
+    # #288 author-exclusion: the charter's ``Requestor:`` names the REVIEWER, and
+    # a reviewer reviews someone else's PR. A verdict whose Requestor resolves to
+    # THIS PR's own author is the author wearing reviewer grammar on their own PR
+    # (a must-fix reply that slipped into ``Requestor:`` form — the Wave-21 slip),
+    # never a genuine review. Drop those here, before any accounting, so no
+    # reviewer signal (``must_fix_caught`` / ``verified_reviews`` /
+    # ``missed_catches`` / false-positives) is ever attributed to the author for
+    # their own PR, and so the #H5 gate-bypass check counts only true third-party
+    # reviewers — mirroring the merge gate's self-addressed exclusion. The ledger
+    # path is filtered at its own loop below.
+    verdicts = [
+        v for v in verdicts if not is_author_self_review(v.requestor, author, canon)
+    ]
+    current_verdicts = [
+        v
+        for v in current_verdicts
+        if not is_author_self_review(v.requestor, author, canon)
+    ]
     catches = [
         c
         for c in (review_catches or [])
@@ -1187,9 +1229,15 @@ def _account_pr(
     pr_had_changes_requested = False
     if catches:
         for c in catches:
+            requestor = c.get("requestor")
+            # #288: a ledger catch whose Requestor resolves to the PR author is a
+            # self-catch (author == reviewer), not a real changes-requested round
+            # — exclude it exactly as the comment-parsing path above excludes an
+            # author self-verdict.
+            if is_author_self_review(requestor, author, canon):
+                continue
             pr_had_changes_requested = True
             author_sig.must_fix_received += 1
-            requestor = c.get("requestor")
             if requestor:
                 catcher_keys.add(canon(requestor))
                 bucket(requestor).must_fix_caught += 1

--- a/framework/assets/skills/wave-end/review_load.py
+++ b/framework/assets/skills/wave-end/review_load.py
@@ -74,22 +74,31 @@ class ReviewLoad:
 def review_load(prs, *, canon=None) -> dict[str, ReviewLoad]:
     """Pure: fold a wave's verdict comments into ``{reviewer: ReviewLoad}``.
 
-    ``prs`` is an iterable of ``(pr_key, comment_bodies)`` — ``pr_key`` any
-    hashable PR identity, ``comment_bodies`` the list of that PR's issue-comment
-    body strings. ``canon`` is an optional ``name -> canonical_name`` mapper
-    (default identity); pass ``trust_signals._canonicalizer(cfg)`` to fold name
-    variants to their roster identity exactly as the scorer does.
+    ``prs`` is an iterable of ``(pr_key, author, comment_bodies)`` — ``pr_key``
+    any hashable PR identity, ``author`` that PR's author identity (the head
+    commit author name the scorer buckets by; may be ``None`` when unknown),
+    ``comment_bodies`` the list of that PR's issue-comment body strings.
+    ``canon`` is an optional ``name -> canonical_name`` mapper (default
+    identity); pass ``trust_signals._canonicalizer(cfg)`` to fold name variants
+    to their roster identity exactly as the scorer does.
 
     Verdicts with no ``Requestor:`` are skipped (nobody to attribute the load
-    to). Ordering of ``prs`` never affects the counts — the result is a pure
-    function of the multiset of (reviewer, pr) pairs.
+    to). A verdict whose ``Requestor:`` resolves to the PR's own ``author`` is
+    author-excluded (#288): the author wearing reviewer grammar on their own PR
+    is not a review turn and must not add to anyone's load — the same exclusion
+    ``trust_signals`` applies to the scoring signals, via the shared
+    :func:`trust_signals.is_author_self_review` helper. Ordering of ``prs`` never
+    affects the counts — the result is a pure function of the multiset of
+    (reviewer, pr) pairs.
     """
     canon = canon or (lambda n: n)
     out: dict[str, ReviewLoad] = {}
-    for pr_key, comment_bodies in prs:
+    for pr_key, author, comment_bodies in prs:
         seen_this_pr: set[str] = set()
         for v in ts.parse_verdicts(comment_bodies):
             if not v.requestor:
+                continue
+            if ts.is_author_self_review(v.requestor, author, canon):
                 continue
             name = canon(v.requestor)
             load = out.setdefault(name, ReviewLoad())
@@ -139,7 +148,12 @@ def extract_review_load(
     prs = ts.merged_prs(wave, status_path, label=label, cfg=cfg)
     canon = ts._canonicalizer(cfg)
     rows = [
-        (pr["number"], ts._pr_comment_bodies(pr["repo"], pr["number"])) for pr in prs
+        (
+            pr["number"],
+            pr.get("commit_author_name"),
+            ts._pr_comment_bodies(pr["repo"], pr["number"]),
+        )
+        for pr in prs
     ]
     return review_load(rows, canon=canon)
 

--- a/framework/assets/team/charter/issues.md
+++ b/framework/assets/team/charter/issues.md
@@ -157,6 +157,18 @@ fields (the exact form the roster carries) — `trust_signals.py` keys reviewer
 identity off that field, so a nickname or role suffix (`Tariq (QA)`) attributes
 the signal to the wrong (or no) engineer.
 
+**This grammar is reviewer-only — a PR author's reply to a must-fix is a PLAIN
+comment, NEVER a `Requestor:` / `RequestOrReplied:` verdict.** The `Requestor:`
+field names a *reviewer*, and a reviewer reviews someone else's PR; if the PR
+author answers a must-fix by wearing the verdict header on their own PR, the
+scorer would read them as a third reviewer of their own PR and manufacture
+spurious `verified_reviews` / `missed_catches` (the Wave-21 slip, #288). So when
+you are the author, just reply in prose ("Fixed in <sha> — <what changed>"), with
+no verdict header. As a durable backstop the scorer and the review-load counter
+now **author-exclude** any verdict whose `Requestor:` resolves to the PR's own
+author (mirroring the merge gate's exclusion of a self-addressed verdict), but
+the convention is still to never post one.
+
 ### Request vs. Replied, Must-fix vs. Tech-debt (semantics)
 
 The tokens carry meaning beyond their shape. `validate_review_comment_format`

--- a/framework/assets/team/charter/issues.md
+++ b/framework/assets/team/charter/issues.md
@@ -164,10 +164,12 @@ author answers a must-fix by wearing the verdict header on their own PR, the
 scorer would read them as a third reviewer of their own PR and manufacture
 spurious `verified_reviews` / `missed_catches` (the Wave-21 slip, #288). So when
 you are the author, just reply in prose ("Fixed in <sha> — <what changed>"), with
-no verdict header. As a durable backstop the scorer and the review-load counter
-now **author-exclude** any verdict whose `Requestor:` resolves to the PR's own
-author (mirroring the merge gate's exclusion of a self-addressed verdict), but
-the convention is still to never post one.
+no verdict header. As a durable backstop the trust scorer and the review-load
+counter now **author-exclude** any verdict whose `Requestor:` resolves to the
+PR's own author. (Scoring only — the armed merge-gate approval oracle
+`pr_review_state.compute_state` does NOT yet author-exclude, so an author's own
+self-verdict still counts toward the merge bar; that live self-approval gap is
+tracked separately in #293.) The convention is still to never post one.
 
 ### Request vs. Replied, Must-fix vs. Tech-debt (semantics)
 

--- a/framework/assets/team/charter/pull-requests.md
+++ b/framework/assets/team/charter/pull-requests.md
@@ -164,12 +164,23 @@ of that PR's verdicts, per the verdict grammar in [issues.md](issues.md). The
 {{reviewers_required}} reviewers must be {{reviewers_required}} *different* people; the
 same reviewer counted twice does not satisfy the bar, and no self-review is permitted.
 
-This assignment convention is what the armed merge gate mechanically enforces (§ The
+This assignment convention is what the armed merge gate partly enforces (§ The
 N-reviewer merge gate): the oracle counts clean approvals over **distinct `Requestor:`
-identities other than the author**, so assigning fewer than {{reviewers_required}}
-distinct non-author reviewers leaves the PR unable to reach `approved` — it cannot
-merge. Assign the full slate at kickoff so the process the gate checks and the process
-the team runs are the same one.
+identities**, so assigning fewer than {{reviewers_required}} distinct reviewers leaves
+the PR unable to reach `approved` — it cannot merge. Assign the full slate at kickoff
+so the process the gate checks and the process the team runs are the same one.
+
+> **Documented contract the code does NOT yet meet (#293).** The gate is *intended* to
+> count distinct `Requestor:` identities **other than the author**, matching the
+> author-exclusive assignment above. The current oracle
+> (`pr_review_state.compute_state`) does NOT exclude the author — it counts every
+> distinct `Requestor:`, so an author's own clean self-verdict still counts toward the
+> bar (a **live self-approval bypass**: author self-verdict + one genuine reviewer
+> reaches `approved` at `reviewers_required=2`). #293 brings the code up to this
+> contract by reusing `trust_signals.is_author_self_review`. Until it lands, the
+> author-exclusive bar rests on the assignment convention plus the reviewer-only
+> verdict grammar ([issues.md](issues.md)) — not on the gate. (The trust *scorer* is
+> already author-exclusive, per #288.)
 
 ## CI Gates
 

--- a/framework/tests/test_trust_signals.py
+++ b/framework/tests/test_trust_signals.py
@@ -660,6 +660,115 @@ def test_durable_ledger_attributes_two_distinct_reviewers(tmp_path) -> None:
     assert sigs["Nia Rossi"].must_fix_caught == 1
 
 
+# =========================================================================== #288 author-exclusion
+# The charter's ``Requestor:`` names the REVIEWER, and a reviewer reviews someone
+# ELSE's PR. A verdict whose Requestor resolves to the PR's own author is the
+# author wearing reviewer grammar on their own PR (the W21 slip: a must-fix reply
+# that landed in ``Requestor:`` form on the author's own PR — issue #288). It must
+# accrue NO reviewer signal. These drive the real ``_account_pr`` and are the
+# mutation bar for the exclusion: reverting the filter re-introduces the spurious
+# signals and each test goes red.
+# ===========================================================================
+
+
+def test_account_pr_author_self_verdict_excluded_from_reviewer_signals(tmp_path) -> None:
+    """The W21 exact scenario: a PR authored by Ibrahim gets ONE genuine must-fix
+    from a real reviewer (Nia), and Ibrahim's own reply wears ``Requestor:
+    Ibrahim`` on his own PR carrying a clean ``Verified:`` block.
+
+    The author self-verdict must be author-excluded: it earns Ibrahim NO
+    ``verified_reviews`` (it is not a review) and NO ``missed_catches`` (he is not
+    a negligent third reviewer of his own PR). The genuine reviewer's catch still
+    lands, and the author still takes the real must-fix he received.
+
+    Mutation bar: reverting the author-exclusion filter credits Ibrahim's clean
+    self-verdict as a verified review (``verified_reviews == 1``) and — because the
+    PR has a durable catch he did not make — dings him a missed catch
+    (``missed_catches == 1``); both assertions below then fail.
+    """
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Ibrahim El-Amin",
+        repo="o/r",
+        number=287,
+        comment_histories=[
+            [_verdict_body("Nia.Rossi", "Request", "Fix the real bug.")],
+            [_verified_body("Ibrahim.El-Amin")],  # author self-verdict, clean + Verified
+        ],
+        ci_red=False,
+    )
+    # Genuine reviewer's catch is credited; the author takes the real must-fix.
+    assert sigs["Nia Rossi"].must_fix_caught == 1
+    assert sigs["Ibrahim El-Amin"].must_fix_received == 1
+    assert sigs["Ibrahim El-Amin"].rework_cycles == 1
+    # The author self-verdict accrues NO reviewer signal to the author.
+    assert sigs["Ibrahim El-Amin"].verified_reviews == 0
+    assert sigs["Ibrahim El-Amin"].missed_catches == 0
+
+
+def test_account_pr_author_self_request_is_not_a_received_mustfix(tmp_path) -> None:
+    """An author's own ``Request`` with a Must-fix on their own PR (Requestor ==
+    author) is not a reviewer catch: it credits the author NO ``must_fix_caught``,
+    is NOT a ``must_fix_received`` for them, and starts NO ``rework_cycles`` round.
+    A genuine reviewer's clean verdict on the same PR is untouched.
+
+    Mutation bar: reverting the filter counts the author as their own reviewer —
+    ``must_fix_caught == 1``, ``must_fix_received == 1``, ``rework_cycles == 1`` —
+    and all three assertions fail.
+    """
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Ibrahim El-Amin",
+        repo="o/r",
+        number=290,
+        comment_bodies=[
+            _verdict_body("Ibrahim.El-Amin", "Request", "I flag my own bug."),
+            _verdict_body("Nia.Rossi", "Replied", None),  # genuine clean reviewer
+        ],
+        ci_red=False,
+    )
+    assert sigs["Ibrahim El-Amin"].must_fix_received == 0
+    assert sigs["Ibrahim El-Amin"].must_fix_caught == 0
+    assert sigs["Ibrahim El-Amin"].rework_cycles == 0
+
+
+def test_account_pr_ledger_self_catch_excluded(tmp_path) -> None:
+    """A durable-ledger catch whose Requestor is the PR author (a self-catch) is
+    author-excluded just like the comment path: it is not counted, while a genuine
+    reviewer's ledger catch on the same PR still lands.
+
+    Mutation bar: reverting the ledger-loop filter counts the self-catch —
+    ``must_fix_received == 2`` and the author gains ``must_fix_caught == 1`` — and
+    the assertions fail.
+    """
+    canon = ts._canonicalizer(_roster_cfg(tmp_path, _ROSTER))
+    sigs: dict[str, ts.Signals] = {}
+    ledger = [
+        {"repo": "o/r", "pr": 700, "requestor": "Ibrahim.El-Amin", "requestee": "Ibrahim.El-Amin"},
+        {"repo": "o/r", "pr": 700, "requestor": "Nia.Rossi", "requestee": "Ibrahim.El-Amin"},
+    ]
+    ts._account_pr(
+        sigs,
+        canon,
+        author="Ibrahim El-Amin",
+        repo="o/r",
+        number=700,
+        comment_bodies=[_verdict_body("Nia.Rossi", "Replied", None)],
+        ci_red=False,
+        review_catches=ledger,
+    )
+    assert sigs["Ibrahim El-Amin"].must_fix_received == 1  # only the genuine catch
+    assert sigs["Nia Rossi"].must_fix_caught == 1
+    assert sigs["Ibrahim El-Amin"].must_fix_caught == 0  # no self-catch credit
+    assert sigs["Ibrahim El-Amin"].rework_cycles == 1
+
+
 # ===========================================================================
 # Integration-branch resolution (#100): phase-aware branch.integration template.
 # ===========================================================================

--- a/framework/tests/test_wave_end_review_load.py
+++ b/framework/tests/test_wave_end_review_load.py
@@ -38,8 +38,8 @@ def _verdict(requestor: str, requestee: str, must_fix: str = "None") -> str:
 
 def test_counts_one_verdict_per_reviewer_per_pr() -> None:
     prs = [
-        (1, [_verdict("Nia.Rossi", "Paloma.Gupta"), _verdict("Tariq.Morales", "Paloma.Gupta")]),
-        (2, [_verdict("Nia.Rossi", "Ibrahim.El-Amin"), _verdict("Paloma.Gupta", "Ibrahim.El-Amin")]),
+        (1, "Paloma.Gupta", [_verdict("Nia.Rossi", "Paloma.Gupta"), _verdict("Tariq.Morales", "Paloma.Gupta")]),
+        (2, "Ibrahim.El-Amin", [_verdict("Nia.Rossi", "Ibrahim.El-Amin"), _verdict("Paloma.Gupta", "Ibrahim.El-Amin")]),
     ]
     loads = rl.review_load(prs)
     assert loads["Nia.Rossi"].verdicts == 2
@@ -51,7 +51,7 @@ def test_counts_one_verdict_per_reviewer_per_pr() -> None:
 def test_two_verdicts_same_pr_counts_two_verdicts_one_pr() -> None:
     """A reviewer posting two verdict comments on ONE PR is 2 verdicts but 1 PR."""
     prs = [
-        (7, [_verdict("Nia.Rossi", "Paloma.Gupta", must_fix="- fix X"), _verdict("Nia.Rossi", "Paloma.Gupta")]),
+        (7, "Paloma.Gupta", [_verdict("Nia.Rossi", "Paloma.Gupta", must_fix="- fix X"), _verdict("Nia.Rossi", "Paloma.Gupta")]),
     ]
     loads = rl.review_load(prs)
     assert loads["Nia.Rossi"].verdicts == 2
@@ -62,26 +62,75 @@ def test_amend_in_place_does_not_inflate_count() -> None:
     """The amendment convention edits the SAME comment — the count is over the
     final comment set, so an amended Request→Replied is still one verdict."""
     posted_then_amended = [_verdict("Tariq.Morales", "Paloma.Gupta")]  # ends as one Replied
-    loads = rl.review_load([(9, posted_then_amended)])
+    loads = rl.review_load([(9, "Paloma.Gupta", posted_then_amended)])
     assert loads["Tariq.Morales"].verdicts == 1
     assert loads["Tariq.Morales"].prs_reviewed == 1
 
 
 def test_verdict_without_requestor_is_skipped() -> None:
     no_requestor = "RequestOrReplied: Replied\n\nMust-fix: None\n"
-    loads = rl.review_load([(3, [no_requestor, _verdict("Nia.Rossi", "Paloma.Gupta")])])
+    loads = rl.review_load([(3, "Paloma.Gupta", [no_requestor, _verdict("Nia.Rossi", "Paloma.Gupta")])])
     assert set(loads) == {"Nia.Rossi"}
     assert loads["Nia.Rossi"].verdicts == 1
 
 
 def test_non_verdict_comments_ignored() -> None:
     chatter = "LGTM, nice work!\n"
-    loads = rl.review_load([(4, [chatter, _verdict("Paloma.Gupta", "Nia.Rossi")])])
+    loads = rl.review_load([(4, "Nia.Rossi", [chatter, _verdict("Paloma.Gupta", "Nia.Rossi")])])
     assert set(loads) == {"Paloma.Gupta"}
 
 
+def test_author_self_verdict_is_excluded() -> None:
+    """#288: a verdict whose Requestor is the PR's own author (the author wearing
+    reviewer grammar on their own PR — the W21 slip) never adds to the load; a
+    genuine reviewer on the same PR still counts."""
+    prs = [
+        (
+            5,
+            "Ibrahim.El-Amin",
+            [
+                # Ibrahim's own must-fix reply that slipped into Requestor grammar
+                # on his own PR — author-excluded, contributes nothing.
+                _verdict("Ibrahim.El-Amin", "Ibrahim.El-Amin"),
+                # A genuine reviewer of Ibrahim's PR — still counts.
+                _verdict("Paloma.Gupta", "Ibrahim.El-Amin"),
+            ],
+        ),
+    ]
+    loads = rl.review_load(prs)
+    assert set(loads) == {"Paloma.Gupta"}
+    assert loads["Paloma.Gupta"].verdicts == 1
+    assert "Ibrahim.El-Amin" not in loads
+
+
+def test_author_self_verdict_excluded_folds_name_variants() -> None:
+    """#288: author-exclusion folds through canon, so a self-verdict written in a
+    name variant of the author is still excluded."""
+
+    def canon(name: str) -> str:
+        key = name.replace(".", " ").split(" (")[0].strip().lower()
+        return {"ibrahim el-amin": "Ibrahim El-Amin"}.get(key, name)
+
+    prs = [
+        (
+            6,
+            "Ibrahim.El-Amin",
+            [_verdict("Ibrahim El-Amin (Senior)", "Ibrahim.El-Amin")],
+        ),
+    ]
+    loads = rl.review_load(prs, canon=canon)
+    assert loads == {}
+
+
+def test_unknown_author_disables_exclusion() -> None:
+    """#288 is fail-open: a PR with an unknown (``None``) author excludes nothing
+    — the reviewer's verdict still counts."""
+    loads = rl.review_load([(8, None, [_verdict("Nia.Rossi", "Paloma.Gupta")])])
+    assert loads["Nia.Rossi"].verdicts == 1
+
+
 def test_order_independent() -> None:
-    a = [(1, [_verdict("Nia.Rossi", "X")]), (2, [_verdict("Tariq.Morales", "X")])]
+    a = [(1, "X", [_verdict("Nia.Rossi", "X")]), (2, "X", [_verdict("Tariq.Morales", "X")])]
     b = list(reversed(a))
     assert rl.review_load(a) == rl.review_load(b)
 
@@ -99,8 +148,8 @@ def test_canon_folds_name_variants() -> None:
         return {"nia rossi": "Nia Rossi"}.get(key, name)
 
     prs = [
-        (1, [_verdict("Nia.Rossi", "X")]),
-        (2, [_verdict("Nia Rossi (Staff)", "Y")]),
+        (1, "X", [_verdict("Nia.Rossi", "X")]),
+        (2, "Y", [_verdict("Nia Rossi (Staff)", "Y")]),
     ]
     loads = rl.review_load(prs, canon=canon)
     assert set(loads) == {"Nia Rossi"}


### PR DESCRIPTION
## #288 — make the trust scorer + review-load author-exclusive

The merge gate ignores a PR author's own verdict on their own PR, but
`trust_signals.py` and `review_load.py` did not. In Wave 21 an author's must-fix
reply wore reviewer verdict grammar (`Requestor: <self>` on their own PR, #287),
so the scorer counted the author as a third reviewer of their own PR →
spurious `missed_catches` / `verified_reviews` (worked around by amending). This
fixes it durably.

### Shared helper
`trust_signals.is_author_self_review(requestor, author, canon) -> bool` — true
when a verdict's `Requestor:` canonicalizes to the PR's own author. The
charter's `Requestor:` names the *reviewer*, and a reviewer reviews someone
else's PR, so such a verdict is the author wearing reviewer grammar on their own
PR — never a genuine review. Fail-open/total (missing `requestor` or `author` ⇒
not a self-review); both identities fold through `canon` so name variants
(`Ibrahim.El-Amin` / `Ibrahim El-Amin (Senior)`) compare equal. `review_load`
already imports `trust_signals as ts`, so both surfaces share this one helper
(no new module).

### Surfaces
- **`_account_pr`**: author self-verdicts are dropped from the parsed `verdicts`
  and the `current_verdicts` (gate-bypass) sets before any accounting, and a
  durable ledger catch whose `Requestor:` is the author is skipped. No reviewer
  signal (`must_fix_caught` / `verified_reviews` / `missed_catches` /
  false-positives / the #H5 clean-reviewer count) is ever attributed to the
  author for their own PR.
- **`review_load`**: the pure core now takes `(pr_key, author, comment_bodies)`
  and author-excludes via the same helper; `extract_review_load` threads
  `commit_author_name`. Unknown (`None`) author excludes nothing (fail-open).

### Charter
`team/charter/issues.md` verdict-grammar section now states the grammar is
**reviewer-only** — a PR author's reply to a must-fix is a PLAIN comment, never
a `Requestor:` / `RequestOrReplied:` verdict — with the scorer's author-exclusion
called out as the durable backstop. Dual-tree: canonical template + live
re-rendered through `install_charter` (manifest refreshed).

### Scope — SCORING surfaces only (this fix does NOT touch the merge gate)
#288 makes the two **scoring** surfaces (`trust_signals` + `review_load`)
author-exclusive. It does **not** change the merge gate. An earlier draft of this
PR (and #293) wrongly claimed the scorer "mirrors the merge gate's exclusion of a
self-addressed verdict" — that is false and has been removed everywhere (docstring,
`_account_pr` comment, charter both trees). The armed merge-gate oracle
(`pr_review_state.compute_state`) does **not** author-exclude — see the live
bypass below. No durable claim asserts the gate excludes self-verdicts.

### Prior art (corrected per the #290 audit cross-findings)
What carries over from botfarm is the **shape** of the shared author-resolution
helper its review-gate lineage (#469→#591→#601→#657) consolidated, NOT #657's
behavior — #657 itself is an advisory-**message** refinement (counting/blocking
unchanged), so it is not the counting-exclusion model. Two deliberate
divergences from that helper:
- **Trigger field flipped:** botfarm keys the self-review drop off the
  `Requestee:` (addressed author); our charter puts the reviewer in `Requestor:`,
  so exclusion fires when the **Requestor** resolves-to-author.
- **No multi-anchor resolver:** botfarm's `_resolves_to_author` reconciles
  branch-lastname / PR-author-login / full-identifier because the *hook* juggles
  branch names and GH logins. In the scorer both identities are already folded
  through the roster `canon`, so resolution is a single
  `canon(requestor) == canon(author)` check — porting three anchors would be
  dead code here.

### Related — LIVE gate bypass tracked in #293 (NOT folded in — scope)
Tariq's review surfaced (and the wave lead verified) that this is worse than a
dormant parity gap: the gate is **armed** (`reviewers_required=2` +
`pr_review_gate_enabled=true`), and `pr_review_state.compute_state` counts
approvals over distinct `Requestor`s with no author-exclusion — so an **author
self-verdict + 1 genuine reviewer reaches `approved` at bar=2** (a live
self-approval bypass). It is deliberately **not** fixed here: `compute_state` has
no author input and `ReviewState` is a pinned contract (#194/#193), so the fix
needs new fail-open I/O to fetch the PR author and a change to the pinned
security oracle — that should not be rushed into this in-flight PR. Reclassified
from "dormant deferred parity" to **live bypass** and tracked as high-priority
**#293** (reuses this PR's `is_author_self_review` helper; owner decides whether
it lands this wave or next).

### Tests (all revert→red — verified by neutralizing the helper)
`framework/tests/test_trust_signals.py`:
- `test_account_pr_author_self_verdict_excluded_from_reviewer_signals` — the W21
  exact scenario: author clean self-verdict on a PR with a genuine catch earns
  the author zero `verified_reviews` / `missed_catches`; the genuine reviewer's
  catch and the author's real `must_fix_received` still land.
- `test_account_pr_author_self_request_is_not_a_received_mustfix` — author's own
  `Request`+Must-fix on their own PR: no `must_fix_caught`, no
  `must_fix_received`, no `rework_cycles`.
- `test_account_pr_ledger_self_catch_excluded` — a durable-ledger self-catch is
  excluded; a genuine reviewer's ledger catch on the same PR still counts.

`framework/tests/test_wave_end_review_load.py`:
- `test_author_self_verdict_is_excluded`, `..._excluded_folds_name_variants`,
  `test_unknown_author_disables_exclusion` (+ existing tests migrated to the
  3-tuple shape).

### Checks
- `pytest framework/tests/ -q` → **902 passed**
- `ruff check framework/` → clean
- `python3 framework/install/reinstall.py --check` → **in sync** (review_load.py
  byte-mirrored to `.claude/skills/`; `trust_signals.py` is a lib wired in place,
  no mirror)

### Note for reviewers
A separate P0 in this same file — `Approved` / code-span text miscounted as a
self-retraction — is tracked as **#291** and is intentionally out of scope here;
this diff is kept to author-exclusivity so #291 stays cleanly separable.

Closes #288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
