### PR TITLE
fix(gate): author-exclude the armed merge-gate oracle (#293)

### DIFF
--- a/.claude/team/.charter-manifest.json
+++ b/.claude/team/.charter-manifest.json
@@ -7,7 +7,7 @@
     "commits.md": "c9d5e7349f0ead70cb37dd8cf20a7753fe3bea5c943ad56fe3f661dc4daaab67",
     "hooks.md": "77d72942082cf0dd1fb45da686376d8813d3e2b30ebe1ec4f99e432ef0fdb1d5",
     "issues.md": "85008051a334ad87926be7c00ce0fd58e9b865e2a399db819ccbeaf064cbbde2",
-    "pull-requests.md": "2885ddcd76d6a5f4d8c63e36b77b71163cda165c5e2567d15a8e4d0e104cf1cd",
+    "pull-requests.md": "72b3501e3d149e482d87e155ea61ed40bb9c342bf960dfdab2d8730bcb73917e",
     "skills.md": "dcc93b623b5f62cbac412634d4d3b04c3731c5a4a0892dd3227c70241703e81e"
   }
 }

--- a/.claude/team/charter/pull-requests.md
+++ b/.claude/team/charter/pull-requests.md
@@ -170,17 +170,18 @@ identities**, so assigning fewer than 2 distinct reviewers leaves
 the PR unable to reach `approved` — it cannot merge. Assign the full slate at kickoff
 so the process the gate checks and the process the team runs are the same one.
 
-> **Documented contract the code does NOT yet meet (#293).** The gate is *intended* to
-> count distinct `Requestor:` identities **other than the author**, matching the
-> author-exclusive assignment above. The current oracle
-> (`pr_review_state.compute_state`) does NOT exclude the author — it counts every
-> distinct `Requestor:`, so an author's own clean self-verdict still counts toward the
-> bar (a **live self-approval bypass**: author self-verdict + one genuine reviewer
-> reaches `approved` at `reviewers_required=2`). #293 brings the code up to this
-> contract by reusing `trust_signals.is_author_self_review`. Until it lands, the
-> author-exclusive bar rests on the assignment convention plus the reviewer-only
-> verdict grammar ([issues.md](issues.md)) — not on the gate. (The trust *scorer* is
-> already author-exclusive, per #288.)
+> **The gate enforces author-exclusion (#293, closed).** The oracle counts clean
+> approvals over distinct `Requestor:` identities **other than the author**, matching the
+> author-exclusive assignment above. `pr_review_state.review_state` resolves the PR's
+> head-commit author and `compute_state` drops any verdict whose `Requestor:` resolves to
+> that author — reusing `trust_signals.is_author_self_review` (the same author-exclusion
+> rule the trust *scorer* uses, per #288). An author's own self-verdict counts toward
+> **neither** the approval bar nor the unresolved-`Must-fix` list — an author can neither
+> approve nor block their own PR. This closed the **live self-approval bypass** #293
+> tracked (author self-verdict + one genuine reviewer reaching `approved` at
+> `reviewers_required=2` — now `pending`). Fail-open: if the author cannot be resolved,
+> the gate excludes nothing and degrades to the reviewer-only count — a missing author
+> never tightens the gate into a false block.
 
 ## CI Gates
 

--- a/framework/assets/lib/pr_review_state.py
+++ b/framework/assets/lib/pr_review_state.py
@@ -35,13 +35,19 @@ Per the charter and ``trust_signals.extract_signals``, the **reviewer** is the
 verdict comment's ``Requestor:`` field (``Requestee:`` is the addressed PR
 author). Approvals are therefore counted over distinct **Requestors** whose
 current verdict is clean (a ``Replied`` / non-``Must-fix`` review), NOT over
-requestees. [PINNED-CONTRACT NOTE #194/#193: the frozen ``ReviewState`` *shape*
-is honored exactly — ``state`` / ``approvals`` (int) / ``reviewers_required``
-(int) / ``unresolved_must_fix`` (list). The contract's descriptive comment said
-"distinct requestees"; the charter grammar makes the reviewer the ``Requestor``
-(a requestee is the single PR author, so counting requestees could never reach a
-2-reviewer bar), so this implementation counts distinct Requestors. Flagged to
-Hiro on #193; the dict shape S2/S3 build against is unchanged.]
+requestees. A ``Requestor`` that resolves to the PR's own **author** is excluded
+(#293) — an author cannot review their own PR, so their clean self-verdict must
+not count toward the bar (see :func:`compute_state` and
+``trust_signals.is_author_self_review``). [PINNED-CONTRACT NOTE #194/#193: the
+frozen ``ReviewState`` *shape* is honored exactly — ``state`` / ``approvals``
+(int) / ``reviewers_required`` (int) / ``unresolved_must_fix`` (list). The
+contract's descriptive comment said "distinct requestees"; the charter grammar
+makes the reviewer the ``Requestor`` (a requestee is the single PR author, so
+counting requestees could never reach a 2-reviewer bar), so this implementation
+counts distinct Requestors. #293 adds an optional ``author`` INPUT to
+:func:`compute_state` / :func:`review_state` for author-exclusion; the returned
+dict shape is unchanged. Flagged to Hiro on #193; the dict shape S2/S3 build
+against is unchanged.]
 
 Fail-open posture (FAIL_OPEN = True)
 ====================================
@@ -164,7 +170,11 @@ class ReviewState(TypedDict):
 
 
 def compute_state(
-    verdicts: list[ts.Verdict], reviewers_required: int
+    verdicts: list[ts.Verdict],
+    reviewers_required: int,
+    *,
+    author: str | None = None,
+    canon=None,
 ) -> ReviewState:
     """Pure N-of-M approval state over already-parsed *verdicts*. No I/O.
 
@@ -185,15 +195,49 @@ def compute_state(
     * ``approved`` requires ``approvals >= reviewers_required`` AND no unresolved
       must-fix; otherwise ``pending``.
 
+    Author-exclusion (#293)
+    -----------------------
+    A verdict whose ``Requestor:`` canonicalizes to the PR's own *author* is the
+    author wearing reviewer grammar on their own PR — never a genuine
+    third-party review. Such self-verdicts are dropped **entirely** before
+    anything is computed, so they count toward NEITHER ``approvals`` NOR
+    ``unresolved_must_fix``: an author can neither approve nor block their own
+    PR. This closes the live self-approval bypass where an author's clean
+    ``Requestor: <self>`` supplied one of the required approvals on their own PR
+    (a single real reviewer + the author cleared a 2-reviewer bar). The
+    author-resolution rule is shared with the trust scorer via
+    ``trust_signals.is_author_self_review`` so the gate and the scorer exclude
+    self-verdicts identically (#288 did the scorer; #293 does the gate).
+
+    Fail-open: *author* is optional. With ``author=None`` (the caller could not
+    resolve the PR author) nothing is excluded and behavior is exactly the
+    pre-#293 count — a missing author must never tighten the gate into a false
+    block. Identities fold through *canon* (default
+    ``trust_signals._name_key``), the same fold the approver set uses, so an
+    author written ``Ibrahim El-Amin`` still matches a verdict ``Requestor:
+    Ibrahim.El-Amin``.
+
     Pure and total: never raises on the parsed input, never does I/O.
     """
+    _canon = canon if canon is not None else ts._name_key
+
+    # Author-exclusion (#293): drop the author's own self-verdicts up front so
+    # they influence neither the approval count nor the unresolved-must-fix list.
+    # is_author_self_review is fail-open (a missing requestor/author is never a
+    # self-review), so author=None leaves every verdict in place.
+    scored = [
+        v
+        for v in verdicts
+        if not ts.is_author_self_review(v.requestor, author, _canon)
+    ]
+
     unresolved: list[MustFixEntry] = [
         {
             "requestor": v.requestor,
             "requestee": v.requestee,
             "verdict": v.verdict,
         }
-        for v in verdicts
+        for v in scored
         if v.changes_requested
     ]
 
@@ -202,11 +246,11 @@ def compute_state(
     # still "changes requested" until they amend it.
     blocking_reviewers = {
         ts._name_key(v.requestor)
-        for v in verdicts
+        for v in scored
         if v.changes_requested and v.requestor
     }
     approvers: set[str] = set()
-    for v in verdicts:
+    for v in scored:
         if v.changes_requested or not v.requestor:
             continue
         key = ts._name_key(v.requestor)
@@ -248,6 +292,45 @@ def _reviewers_required(cfg: Any = None) -> int:
     return n if n >= 1 else _FAIL_OPEN_REVIEWERS_REQUIRED
 
 
+def _pr_head_author(repo: str, pr: int) -> str | None:
+    """The PR's head-commit author name, or ``None`` on any failure (fail-open).
+
+    Resolves the same author identity the trust scorer buckets by
+    (``trust_signals.merged_prs`` → the head commit's ``.commit.author.name``,
+    the ``-c user.name`` the committer signed with) rather than a GitHub login,
+    so it lines up with the ``Requestor:`` names in verdict comments once both
+    are folded through the roster ``canon``. Used only to author-exclude the
+    self-verdict from the merge gate (#293).
+
+    FAIL-OPEN and total: any error — a ``gh`` failure/timeout, an empty SHA, a
+    missing author — returns ``None``. A ``None`` author excludes nothing, so an
+    author-fetch failure degrades to the pre-#293 count and can never manufacture
+    a false block. Never raises.
+    """
+    try:
+        sha = ts._run_gh(
+            [
+                "pr",
+                "view",
+                str(int(pr)),
+                "--repo",
+                repo,
+                "--json",
+                "headRefOid",
+                "--jq",
+                ".headRefOid",
+            ]
+        ).strip()
+        if not sha:
+            return None
+        name = ts._run_gh(
+            ["api", f"repos/{repo}/commits/{sha}", "--jq", ".commit.author.name"]
+        ).strip()
+        return name or None
+    except Exception:  # noqa: BLE001 — fail-open: unresolved author => no exclusion
+        return None
+
+
 def review_state(repo: str, pr: int, *, cfg: Any = None) -> ReviewState:
     """Thin I/O wrapper: fetch a PR's comments, parse them, compute the state.
 
@@ -255,6 +338,17 @@ def review_state(repo: str, pr: int, *, cfg: Any = None) -> ReviewState:
     grammar) over the comment bodies from ``trust_signals._pr_comment_bodies``,
     reads ``reviewers_required`` from shared config, and returns the pinned
     :class:`ReviewState`.
+
+    Author-exclusion (#293): also resolves the PR's head-commit author
+    (:func:`_pr_head_author`) and threads it into :func:`compute_state`, folding
+    both author and reviewer identities through the roster ``canon``
+    (``trust_signals._canonicalizer``) so the author's own self-verdict is
+    dropped before approvals are counted — the same author-exclusion rule the
+    trust scorer uses (#288). The author fetch is independently fail-open: an
+    author-resolution failure yields ``None`` (no exclusion, pre-#293 count),
+    never an ``unknown`` state and never a false block. A comment-fetch failure
+    (the state the gate genuinely can't be computed without) still degrades to
+    ``unknown``.
 
     Fail-open: any comment-fetch / parse error returns an ``unknown`` state
     (approvals=0, no must-fix) rather than raising or inventing an approval — an
@@ -275,7 +369,14 @@ def review_state(repo: str, pr: int, *, cfg: Any = None) -> ReviewState:
             "reviewers_required": required,
             "unresolved_must_fix": [],
         }
-    return compute_state(verdicts, required)
+    # Author-exclusion inputs, each independently fail-open (never unknown, never
+    # a false block): an unresolved author or roster simply excludes nothing.
+    author = _pr_head_author(repo, int(pr))
+    try:
+        canon = ts._canonicalizer(cfg if cfg is not None else config())
+    except Exception:  # noqa: BLE001 — no roster => identity-ish canon, no exclusion
+        canon = None
+    return compute_state(verdicts, required, author=author, canon=canon)
 
 
 # ---------------------------------------------------------------------------

--- a/framework/assets/team/charter/pull-requests.md
+++ b/framework/assets/team/charter/pull-requests.md
@@ -170,17 +170,18 @@ identities**, so assigning fewer than {{reviewers_required}} distinct reviewers 
 the PR unable to reach `approved` — it cannot merge. Assign the full slate at kickoff
 so the process the gate checks and the process the team runs are the same one.
 
-> **Documented contract the code does NOT yet meet (#293).** The gate is *intended* to
-> count distinct `Requestor:` identities **other than the author**, matching the
-> author-exclusive assignment above. The current oracle
-> (`pr_review_state.compute_state`) does NOT exclude the author — it counts every
-> distinct `Requestor:`, so an author's own clean self-verdict still counts toward the
-> bar (a **live self-approval bypass**: author self-verdict + one genuine reviewer
-> reaches `approved` at `reviewers_required=2`). #293 brings the code up to this
-> contract by reusing `trust_signals.is_author_self_review`. Until it lands, the
-> author-exclusive bar rests on the assignment convention plus the reviewer-only
-> verdict grammar ([issues.md](issues.md)) — not on the gate. (The trust *scorer* is
-> already author-exclusive, per #288.)
+> **The gate enforces author-exclusion (#293, closed).** The oracle counts clean
+> approvals over distinct `Requestor:` identities **other than the author**, matching the
+> author-exclusive assignment above. `pr_review_state.review_state` resolves the PR's
+> head-commit author and `compute_state` drops any verdict whose `Requestor:` resolves to
+> that author — reusing `trust_signals.is_author_self_review` (the same author-exclusion
+> rule the trust *scorer* uses, per #288). An author's own self-verdict counts toward
+> **neither** the approval bar nor the unresolved-`Must-fix` list — an author can neither
+> approve nor block their own PR. This closed the **live self-approval bypass** #293
+> tracked (author self-verdict + one genuine reviewer reaching `approved` at
+> `reviewers_required=2` — now `pending`). Fail-open: if the author cannot be resolved,
+> the gate excludes nothing and degrades to the reviewer-only count — a missing author
+> never tightens the gate into a false block.
 
 ## CI Gates
 

--- a/framework/tests/test_pr_review_state.py
+++ b/framework/tests/test_pr_review_state.py
@@ -204,6 +204,179 @@ def test_blocking_reviewer_not_double_counted_as_approver():
 
 
 # ---------------------------------------------------------------------------
+# Author-exclusion (#293): the author's own self-verdict never counts toward the
+# merge bar. Closes the live self-approval bypass — an author's clean
+# `Requestor: <self>` supplied one of the required approvals on their own PR, so
+# a single real reviewer + the author cleared a 2-reviewer bar.
+# ---------------------------------------------------------------------------
+
+
+def test_author_self_clean_verdict_excluded_bypass_repro():
+    """Tariq's exact repro (#293): author self-verdict + ONE genuine reviewer at
+    bar=2 must read `pending`, not `approved`.
+
+    BEFORE #293 this was `approvals=2 / approved` — the author supplied one of
+    the two "approvals" on their own PR. Mutation bar: neutralizing the
+    author-exclusion (dropping the `is_author_self_review` filter) flips this
+    back to approved -> fails.
+    """
+    verdicts = [
+        _approval("Ibrahim.El-Amin"),  # author's own clean self-verdict
+        _approval("Nia.Rossi"),  # the ONE genuine reviewer
+    ]
+    state = prs.compute_state(
+        verdicts, reviewers_required=2, author="Ibrahim.El-Amin"
+    )
+    assert state["approvals"] == 1  # only Nia — the author self-verdict dropped
+    assert state["state"] == "pending"
+
+
+def test_two_genuine_reviewers_still_approved_with_author_set():
+    """Author-exclusion must not tighten the gate for legitimate PRs: two
+    genuine (non-author) reviewers still reach `approved` even when the author is
+    threaded in.
+
+    Mutation bar: an over-broad exclusion (e.g. excluding by Requestee, or
+    dropping every verdict) would strip a real reviewer here -> fails.
+    """
+    verdicts = [_approval("Nia.Rossi"), _approval("Tariq.Morales")]
+    state = prs.compute_state(
+        verdicts, reviewers_required=2, author="Ibrahim.El-Amin"
+    )
+    assert state["approvals"] == 2
+    assert state["state"] == "approved"
+
+
+def test_author_self_must_fix_does_not_manufacture_a_blocking_reviewer():
+    """An author's own `Must-fix` self-verdict is dropped entirely (#293): it
+    creates NEITHER an unresolved-must-fix blocker NOR a phantom reviewer. An
+    author can neither block nor approve their own PR.
+
+    Here the author self-blocks and two genuine reviewers approve at bar=2 ->
+    the self-block must not flip the state to changes_requested.
+
+    Mutation bar: excluding the author only from `approvers` but NOT from
+    `unresolved_must_fix` would leave the self-must-fix standing and read
+    changes_requested -> fails.
+    """
+    verdicts = [
+        _changes_requested("Ibrahim.El-Amin"),  # author self-`Must-fix`
+        _approval("Nia.Rossi"),
+        _approval("Tariq.Morales"),
+    ]
+    state = prs.compute_state(
+        verdicts, reviewers_required=2, author="Ibrahim.El-Amin"
+    )
+    assert state["unresolved_must_fix"] == []  # self-block dropped, not standing
+    assert state["approvals"] == 2  # the two genuine reviewers
+    assert state["state"] == "approved"
+
+
+def test_author_exclusion_folds_name_variants():
+    """Author `Ibrahim El-Amin` and verdict `Requestor: Ibrahim.El-Amin` are the
+    same person — the self-verdict is excluded despite the punctuation variant
+    (default canon folds via `_name_key`, the same fold the approver set uses).
+
+    Mutation bar: comparing raw (unfolded) strings would miss the variant and
+    count the author self-verdict -> the bypass repro would reach approved.
+    """
+    verdicts = [
+        _approval("Ibrahim.El-Amin"),  # author's self-verdict (dotted form)
+        _approval("Nia.Rossi"),
+    ]
+    state = prs.compute_state(
+        verdicts, reviewers_required=2, author="Ibrahim El-Amin"  # spaced form
+    )
+    assert state["approvals"] == 1
+    assert state["state"] == "pending"
+
+
+def test_author_none_fails_open_to_pre_293_count():
+    """FAIL-OPEN: an unresolved author (`author=None`, the default) excludes
+    nothing — behavior is exactly the pre-#293 count. A missing author must never
+    tighten the gate into a false block.
+
+    The bypass repro WITHOUT a resolved author still reaches `approved` (the
+    pre-fix behavior), proving the exclusion is gated on a known author and never
+    fabricated. Mutation bar: making author-exclusion fire on `author=None` (or
+    raising) would flip this to pending -> fails.
+    """
+    verdicts = [_approval("Ibrahim.El-Amin"), _approval("Nia.Rossi")]
+
+    # explicit None
+    state = prs.compute_state(verdicts, reviewers_required=2, author=None)
+    assert state["approvals"] == 2
+    assert state["state"] == "approved"
+
+    # default (author param omitted) — identical pre-#293 behavior
+    state_default = prs.compute_state(verdicts, reviewers_required=2)
+    assert state_default["approvals"] == 2
+    assert state_default["state"] == "approved"
+
+
+def test_review_state_wrapper_threads_author_and_excludes_self(monkeypatch):
+    """End-to-end through the I/O wrapper: the head-commit author is fetched and
+    threaded into `compute_state`, so an author self-verdict + one genuine
+    reviewer at bar=2 reads `pending` — the live merge gate no longer counts a
+    self-approval (#293).
+
+    Mutation bar: reverting `review_state` to call `compute_state` without the
+    fetched author flips this to approved -> fails.
+    """
+    author_body = (
+        "Requestor: Ibrahim.El-Amin\nRequestee: Ibrahim.El-Amin\n"
+        "RequestOrReplied: Replied\n\n**Review: self-check**\n"
+        "Must-fix: None\nTech-debt: None\n"
+    )
+    reviewer_body = (
+        "Requestor: Nia.Rossi\nRequestee: Ibrahim.El-Amin\n"
+        "RequestOrReplied: Replied\n\n**Review: LGTM**\n"
+        "Must-fix: None\nTech-debt: None\n"
+    )
+    monkeypatch.setattr(
+        ts, "_pr_comment_bodies", lambda _repo, _num: [author_body, reviewer_body]
+    )
+    monkeypatch.setattr(prs, "_pr_head_author", lambda _repo, _num: "Ibrahim.El-Amin")
+
+    class _Cfg:
+        def get(self, _dotted, default=None):
+            return 2
+
+    state = prs.review_state("acme/widget", 42, cfg=_Cfg())
+    assert state["approvals"] == 1  # only Nia; the author self-verdict excluded
+    assert state["state"] == "pending"
+
+
+def test_review_state_wrapper_author_fetch_failure_fails_open(monkeypatch):
+    """If the author cannot be resolved (`_pr_head_author` -> None), the wrapper
+    excludes nothing and computes the pre-#293 state — an author-fetch failure
+    must never manufacture a false block or an `unknown`. Two clean Requestors
+    (one of whom happens to be the real author) still reach `approved`.
+
+    Mutation bar: turning an author-fetch failure into a block/unknown would flip
+    this off `approved` -> fails.
+    """
+    body_a = (
+        "Requestor: Ibrahim.El-Amin\nRequestee: Ibrahim.El-Amin\n"
+        "RequestOrReplied: Replied\n\n**Review: self**\nMust-fix: None\nTech-debt: None\n"
+    )
+    body_b = (
+        "Requestor: Nia.Rossi\nRequestee: Ibrahim.El-Amin\n"
+        "RequestOrReplied: Replied\n\n**Review: LGTM**\nMust-fix: None\nTech-debt: None\n"
+    )
+    monkeypatch.setattr(ts, "_pr_comment_bodies", lambda _repo, _num: [body_a, body_b])
+    monkeypatch.setattr(prs, "_pr_head_author", lambda _repo, _num: None)
+
+    class _Cfg:
+        def get(self, _dotted, default=None):
+            return 2
+
+    state = prs.review_state("acme/widget", 42, cfg=_Cfg())
+    assert state["state"] == "approved"  # fail-open: no exclusion
+    assert state["approvals"] == 2
+
+
+# ---------------------------------------------------------------------------
 # Fail-open posture.
 # ---------------------------------------------------------------------------
 
@@ -270,6 +443,10 @@ def test_review_state_wrapper_reuses_parse_verdicts(monkeypatch):
     )
 
     monkeypatch.setattr(ts, "_pr_comment_bodies", lambda _repo, _num: [nia, ibrahim])
+    # Keep hermetic: author-exclusion (#293) added a head-commit author fetch to
+    # the wrapper; stub it (no genuine reviewer here is the author) so the test
+    # never shells out to a live `gh`.
+    monkeypatch.setattr(prs, "_pr_head_author", lambda _repo, _num: None)
 
     class _Cfg:
         def get(self, _dotted, default=None):
@@ -293,6 +470,7 @@ def test_review_state_wrapper_surfaces_must_fix_from_real_body(monkeypatch):
     )
 
     monkeypatch.setattr(ts, "_pr_comment_bodies", lambda _repo, _num: [blocking])
+    monkeypatch.setattr(prs, "_pr_head_author", lambda _repo, _num: None)
 
     class _Cfg:
         def get(self, _dotted, default=None):
@@ -332,6 +510,9 @@ _N2_MUSTFIX_NIA = (
 
 def _n2_state(bodies, monkeypatch):
     monkeypatch.setattr(ts, "_pr_comment_bodies", lambda _repo, _num: bodies)
+    # Hermetic: stub the #293 head-commit author fetch (none of these Requestors
+    # is the PR author) so the wrapper never shells out to a live `gh`.
+    monkeypatch.setattr(prs, "_pr_head_author", lambda _repo, _num: None)
 
     class _Cfg:  # reviewers_required = 2 (the standing N=2 bar)
         def get(self, _dotted, default=None):


### PR DESCRIPTION
## Author-exclude the armed merge-gate oracle (Closes #293)

### The bug (live self-approval bypass)
The merge gate (`validate_pr_review.py`) consumes `pr_review_state.review_state()` as its ONLY oracle. `compute_state()` counted approvals over distinct `Requestor:` identities with **no author-exclusion**, so an author's own clean `Requestor: <self>` verdict counted toward the bar. This repo has the gate **armed** (`policy.reviewers_required=2`, `policy.pr_review_gate_enabled=true`), so an author self-verdict + one genuine reviewer read `approved` → `gh pr merge` allowed. The charter already documented the author-exclusion the code never implemented (#292 flagged the spec/impl mismatch); this PR brings the code up to the documented contract.

### Before / after (Tariq's repro, verified on real charter-grammar bodies)
```
author self-verdict (Requestor: Ibrahim.El-Amin on own PR) + ONE genuine reviewer (Nia), bar=2:
BEFORE (no author-exclusion):     {'approvals': 2, 'state': 'approved'}   ← BUG
AFTER  (author=Ibrahim.El-Amin):  {'approvals': 1, 'state': 'pending'}   ← fixed
```

### The fix
- `review_state` resolves the PR's **head-commit author** (`_pr_head_author`, same identity `trust_signals.merged_prs` buckets by) and threads it into `compute_state`, which drops any verdict whose `Requestor:` resolves to that author — reusing the shared **`trust_signals.is_author_self_review`** helper (#288) so the gate and the trust scorer share ONE author-exclusion rule (no second author-resolution path).
- **Self-verdicts are dropped entirely** — they count toward **neither** `approvals` **nor** `unresolved_must_fix`. Decision: an author's own `Must-fix` self-verdict does NOT stand as a blocker (an author can neither approve nor block their own PR), so it can't manufacture a phantom blocking reviewer either.
- **Pinned `ReviewState` OUTPUT shape preserved (#194/#193):** `compute_state`/`review_state` gain keyword-only *inputs* (`author`, `canon`) only; the returned dict's keys/types/semantics are unchanged. All existing oracle tests (which assert the exact keys) still pass.
- **Fail-open, two independent guards:** `_pr_head_author` returns `None` on any `gh`/parse failure → no exclusion (pre-#293 count), never a false block; a missing roster degrades canon to name-key folding. An unresolved author never tightens the gate. A comment-fetch failure still degrades to `unknown` as before.

### Tests (revert→red — `framework/tests/test_pr_review_state.py`)
- `test_author_self_clean_verdict_excluded_bypass_repro` — Tariq's exact repro (self + 1 reviewer @2 → `pending`).
- `test_two_genuine_reviewers_still_approved_with_author_set` — no over-tightening of legit PRs.
- `test_author_self_must_fix_does_not_manufacture_a_blocking_reviewer` — self-`Must-fix` dropped, not a standing blocker.
- `test_author_exclusion_folds_name_variants` — author `Ibrahim El-Amin` vs verdict `Ibrahim.El-Amin` → excluded.
- `test_author_none_fails_open_to_pre_293_count` + `test_review_state_wrapper_author_fetch_failure_fails_open` — fail-open.
- `test_review_state_wrapper_threads_author_and_excludes_self` — end-to-end through the I/O wrapper.
- **Mutation bar verified:** neutralizing the exclusion (`scored = list(verdicts)`) flips exactly the 4 exclusion-firing tests red; the two fail-open tests stay green; restore → all green.

### Validation
- `pytest framework/tests/ -q` → **909 passed**.
- `ruff check framework/` → clean.
- `python3 framework/install/reinstall.py --check` → rc=0 (lib/hooks wired in place, no `.claude/lib/` mirror; single copy of `compute_state`).
- Charter drift check green after refreshing the manifest checksum for `pull-requests.md`.
- **Live oracle, no regression:** ran against real approved PRs #286/#287/#282 — head-commit author resolved (Paloma/Ibrahim/Nia) and all still read `approved 2/2`.

### Charter
The `pull-requests.md` blockquote (live **and** canonical template, kept in sync + manifest refreshed) is flipped from "Documented contract the code does NOT yet meet (#293)" to "The gate enforces author-exclusion (#293, closed)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FSSf75g21FAh8cTWNHBrX
