### PR TITLE
docs(wave-retro): pluralize reserved-5 to "top relative performer(s)"

### DIFF
--- a/.claude/skills/wave-retro/SKILL.md
+++ b/.claude/skills/wave-retro/SKILL.md
@@ -173,9 +173,16 @@ Every row applies the mechanical policy from `trust_signals.py` and cites its nu
 - **Decay toward neutral:** an engineer with no signal for 3 consecutive waves drifts one
   step toward 3 (`trust_signals.decay(old, waves_since_signal)`). A stale 4 or 2 is no
   longer earned; decay is one step per retro, never a reset.
-- **Distribution discipline:** 5 is reserved for the wave's top relative performer with a
+- **Distribution discipline:** 5 is reserved for the wave's top relative performer(s) with a
   strictly positive composite (`trust_signals.apply_distribution_discipline`) — never
-  handed out for merely-clean work; other proposed 5s are capped to 4.
+  handed out for merely-clean work; other proposed 5s are capped to 4. **A tie at the top
+  composite is a reportable finding, not a blocker:** when two or more engineers share the
+  strictly-positive iteration-max composite, `apply_distribution_discipline` seats **all** of
+  them at 5 by design — the author-vs-reviewer parity #275 was built to produce, so do not
+  force a single winner. Record each tied engineer's composite in the retro and seat them all.
+  A deterministic tie-break was considered and rejected (#301): "fewest negatives" would
+  systematically seat reviewers over authors (`must_fix_received` only accrues to authors),
+  re-creating in reverse the asymmetry #275 removed.
 - **Retirement trigger:** run
   `trust_signals.retirement_trigger(score_history, ci_red_history)` per engineer (both
   histories oldest→newest). If it fires (score ≤ 2 in each of the last 3 waves, or ≥ 1
@@ -233,6 +240,12 @@ Based on pain points, propose specific amendments:
 **Section:** {charter/skill/doc section}
 **Rationale:** {why, anchored to a retro finding}
 ```
+
+**Never open a proposed change with a GitHub closing keyword followed by an issue reference**
+(`Fix #NNN`, `Closes #NNN`, `Resolves #NNN`, …): a later PR body that quotes the proposal
+verbatim will auto-close that issue the moment the PR merges — whether or not the work landed.
+This silently closed #296 via PR #299 (#304). Render the reference as backticked `` `#NNN` `` or
+in prose ("per #NNN", "Address #NNN") instead.
 
 **Do NOT apply any charter or process change without explicit user approval.**
 

--- a/.claude/team/trust_matrix.md
+++ b/.claude/team/trust_matrix.md
@@ -655,10 +655,11 @@ visible in its own telemetry. Signals via `trust_signals.py extract/score 22`.
 
 > **Reserved-5 resolved as a TIE (owner call).** Paloma and Tariq both close at composite **4**
 > — Paloma `1 + 2×1 caught + min(3,2) − 1 recv`, Tariq `0 + 2×2 caught`. `apply_distribution_discipline`
-> permits every engineer at the max composite to hold 5; the charter's "top relative performer" is
-> singular. Owner seated **both**. This is the author-vs-reviewer parity #275 was built to produce:
-> a pure reviewer who caught both of the wave's must-fixes now ranks level with a flagship author.
-> Charter/code wording reconciliation filed as a follow-up.
+> permits every engineer at the max composite to hold 5, and the reserved-5 wording now reads "top
+> relative performer(s)" to match — pluralized in #301 after this tie (at retro time it read singular,
+> which forced the owner call). Owner seated **both**. This is the author-vs-reviewer parity #275 was
+> built to produce: a pure reviewer who caught both of the wave's must-fixes now ranks level with a
+> flagship author.
 
 > **Owner override — Ibrahim held at 3.** The mechanical delta was **−1 → 2** (`missed_catches=1`).
 > The owner held him at **3**: the missed catch was doc-level (a false prior-art claim), while he

--- a/framework/assets/skills/wave-retro/SKILL.md
+++ b/framework/assets/skills/wave-retro/SKILL.md
@@ -173,9 +173,16 @@ Every row applies the mechanical policy from `trust_signals.py` and cites its nu
 - **Decay toward neutral:** an engineer with no signal for 3 consecutive waves drifts one
   step toward 3 (`trust_signals.decay(old, waves_since_signal)`). A stale 4 or 2 is no
   longer earned; decay is one step per retro, never a reset.
-- **Distribution discipline:** 5 is reserved for the wave's top relative performer with a
+- **Distribution discipline:** 5 is reserved for the wave's top relative performer(s) with a
   strictly positive composite (`trust_signals.apply_distribution_discipline`) — never
-  handed out for merely-clean work; other proposed 5s are capped to 4.
+  handed out for merely-clean work; other proposed 5s are capped to 4. **A tie at the top
+  composite is a reportable finding, not a blocker:** when two or more engineers share the
+  strictly-positive iteration-max composite, `apply_distribution_discipline` seats **all** of
+  them at 5 by design — the author-vs-reviewer parity #275 was built to produce, so do not
+  force a single winner. Record each tied engineer's composite in the retro and seat them all.
+  A deterministic tie-break was considered and rejected (#301): "fewest negatives" would
+  systematically seat reviewers over authors (`must_fix_received` only accrues to authors),
+  re-creating in reverse the asymmetry #275 removed.
 - **Retirement trigger:** run
   `trust_signals.retirement_trigger(score_history, ci_red_history)` per engineer (both
   histories oldest→newest). If it fires (score ≤ 2 in each of the last 3 waves, or ≥ 1
@@ -233,6 +240,12 @@ Based on pain points, propose specific amendments:
 **Section:** {charter/skill/doc section}
 **Rationale:** {why, anchored to a retro finding}
 ```
+
+**Never open a proposed change with a GitHub closing keyword followed by an issue reference**
+(`Fix #NNN`, `Closes #NNN`, `Resolves #NNN`, …): a later PR body that quotes the proposal
+verbatim will auto-close that issue the moment the PR merges — whether or not the work landed.
+This silently closed #296 via PR #299 (#304). Render the reference as backticked `` `#NNN` `` or
+in prose ("per #NNN", "Address #NNN") instead.
 
 **Do NOT apply any charter or process change without explicit user approval.**
 


### PR DESCRIPTION
## Summary

- Pluralize the reserved-5 wording to **"top relative performer(s)"** in the three normative sites, reconciling the `/wave-retro` skill and trust-matrix note with `apply_distribution_discipline` (owner decision 2026-07-09). **No behavior change** -- `lib/trust_signals.py` is untouched; the code already seats every engineer at the strictly-positive iteration-max composite, which is the author-vs-reviewer parity #275 was built to produce.
- `/wave-retro` step 5: document that a tie at the top composite is a **reportable finding, not a blocker** -- seat all tied engineers, record their composites; note the rejected fewest-negatives tie-break.
- `/wave-retro` step 7: proposal-writing guidance forbidding a leading closing-keyword + issue reference (satisfies #304's proposal-guidance criterion; wording mirrors the hook regex in #304).

## Related work

Addresses the wording reconciliation tracked in `#301` -- the closing keyword is intentionally kept **out** of this PR body (the `Closes` trailer lives in the commit message) precisely because a quoting PR body auto-closes issues on merge, the defect #304 exists to prevent. Also lands #304's `/wave-retro` proposal-guidance criterion (I own every `skills/wave-retro/` edit this wave).

## Normative vs historical (the AC correction)

Per the pinned AC correction on the issue, only **normative** text is pluralized:

- Changed: `.claude/skills/wave-retro/SKILL.md:176`, its `framework/assets/` mirror, and one blockquote note in `.claude/team/trust_matrix.md` (was line 658).
- Left **byte-for-byte untouched** (historical -- they record the rule as it was when those scores were assigned): `trust_matrix.md:197` (Wave-13 reason cell) and every `feedback_log.md` hit. A grep or test forcing these to change is itself the defect. `git diff` shows zero change to line 197.

### Reviewer call-out: this is a BACK-ANNOTATION of a Wave-22 retro note, not a preamble edit

Be precise about what the `trust_matrix.md` edit touches, because this wave's theme is "the record must not lie." The issue and my commit message call the changed line the "preamble note," but structurally that blockquote sits **inside the Wave 22 Trust Updates section** (immediately below the `Signals via trust_signals.py extract/score 22` line), not in the matrix's top-of-file preamble. So I am editing a **historical retro note** -- the owner explicitly designated it normative in the pinned AC correction, but reviewers should consciously sign off on touching a Wave-22 record.

Why it is defensible rather than history-rewriting: the old text made a **present-tense claim about current policy** -- "the charter's 'top relative performer' is singular" -- which this PR makes false. I **back-annotated** that stale claim to the pluralized wording (`#301`) while **preserving the historical fact**: "at retro time it read singular, which forced the owner call." The Wave-22 outcome itself is untouched -- both still close at composite 4, the owner still seated both, the #275 parity rationale is intact. What changed is only the now-obsolete characterization of the live rule, not the record of what happened. Contrast `trust_matrix.md:197`, a Wave-13 **reason cell** that explains *why a score was assigned under the then-current rule* -- that is left byte-for-byte untouched, because rewriting it would falsify the ledger's history.

## Load-bearing test

Pure documentation / skill-prose change -- no executable behavior, so no revert->red test applies. Created under the configured `docs` load-bearing-test exception class.

## Verification

- **Dual-tree parity:** `diff .claude/skills/wave-retro/SKILL.md framework/assets/skills/wave-retro/SKILL.md` is empty (byte-identical).
- `python3 framework/install/reinstall.py --check` -> in sync.
- `ruff check` -> All checks passed.
- `python3 -m pytest framework/tests -q` -> 909 passed.

## Review Checklist

- [ ] Reviewed by another team member
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)
