### PR TITLE
fix(trust): render every negative signal + reject blank receipts

### DIFF
--- a/framework/assets/lib/trust_signals.py
+++ b/framework/assets/lib/trust_signals.py
@@ -1685,33 +1685,54 @@ def negative_signal_line(name: str, sig: Signals) -> str:
     )
 
 
-# Bare-"None" detector for the forced negative-signal pass. A negative-signal
-# entry of exactly "None" / "n/a" / "-" (case-insensitive, optional bullet /
-# trailing punctuation) is the banned shape.
-_BARE_NONE_RE = re.compile(r"^\s*[-*]?\s*(none|n/?a|-+)\s*[.;]?\s*$", re.IGNORECASE)
+# Vacuous-token detector for a forced-pass receipt BODY (#296). Matches a body
+# that carries no evidence: one of the "no findings" tokens ``none`` / ``n/a`` /
+# ``na`` / ``-`` / ``–`` / ``—`` / ``.`` (case-insensitive, optional leading
+# bullet, optional trailing ``.``/``;``), or repeats of the dash/dot forms
+# (``--`` / ``...``). Tested against the receipt BODY, not the whole line: the
+# forced-pass emitter only ever produces the ``"{name}: {gap}"`` shape, so a
+# whole-line anchor never fires against real input and lets a name-prefixed
+# ``"Name: None"`` — the literal shape the skill header calls banned — slip
+# past. (#296 review must-fix: the original whole-line ``_BARE_NONE_RE`` closed
+# ``"Name: "`` but left ``"Name: None"``, one character away and identically
+# vacuous.)
+_VACUOUS_BODY_RE = re.compile(
+    r"^\s*[-*]?\s*(none|n/?a|[-–—.]+)\s*[.;]?\s*$", re.IGNORECASE
+)
 
-# Blank-entry detector (#296). An entry that carries no evidence after the
-# ``"{name}: "`` prefix — everything after the first colon is whitespace
-# (``"Name: "`` / ``"Name:"``), or the whole line is blank — is just as vacuous
-# as a bare "None". This is the exact blank receipt the unrendered
-# ``missed_catches`` / ``gate_bypasses`` used to emit: the scorer applied a −1
-# that the forced pass then waved through with nothing to cite.
-_BLANK_ENTRY_RE = re.compile(r"^\s*(?:[^:]*:)?\s*$")
+
+def _forced_pass_body(line: str) -> str:
+    """The receipt body: the text after the first ``":"`` (the ``"{name}: "``
+    prefix), or the whole line when there is no colon at all. Whitespace-stripped.
+    A line with no colon (e.g. a bare ``"None"``) is treated as its own body so
+    the pre-#296 whole-line rejection still holds."""
+    _, sep, rest = line.partition(":")
+    return (rest if sep else line).strip()
+
+
+def _is_vacuous_entry(line: str) -> bool:
+    """True when a forced-pass entry carries no citable evidence — the body is
+    empty (blank after the ``"{name}: "`` prefix, or a wholly-blank line) or is a
+    vacuous ``none``/``n/a``/``-``/``.`` token."""
+    body = _forced_pass_body(line)
+    if not body:
+        return True
+    return bool(_VACUOUS_BODY_RE.match(body))
 
 
 def validate_negative_signal_pass(lines: list[str]) -> list[str]:
     """Return the offending lines of a forced-pass (forced-pass violations).
 
     Empty return == the pass is clean. Used by a retro to mechanically reject a
-    pass that left a vacuous entry in the negative-signal column — either a bare
-    "None" / "n/a" / "-" token OR an entry blank after the ``"{name}: "`` prefix
-    (#296). Both shapes assert a delta with no citable evidence.
+    pass that left a vacuous entry in the negative-signal column. An entry is
+    vacuous when the receipt BODY (the part after the ``"{name}: "`` prefix, or a
+    whole line with no colon) is empty OR a "no findings" token
+    (``none`` / ``n/a`` / ``na`` / ``-`` / ``–`` / ``—`` / ``.``,
+    case-insensitive) — including the name-prefixed ``"Name: None"`` shape the
+    emitter actually produces, not just a whole-line bare ``None`` (#296). Every
+    such entry asserts a delta with no citable evidence.
     """
-    return [
-        ln
-        for ln in lines
-        if _BARE_NONE_RE.match(ln) or _BLANK_ENTRY_RE.match(ln)
-    ]
+    return [ln for ln in lines if _is_vacuous_entry(ln)]
 
 
 def retirement_trigger(

--- a/framework/assets/lib/trust_signals.py
+++ b/framework/assets/lib/trust_signals.py
@@ -283,6 +283,27 @@ def _strip_code_markup(text: str) -> str:
     return text
 
 
+# Single source of truth for the negative-signal fields (#296). Both
+# :meth:`Signals.has_negative` (which fields make a wave "dirty") and
+# :func:`negative_signal_line` (how each dirty field renders into a receipt)
+# derive from this ONE list, so a field can never be counted in one place but
+# left unrendered in the other. Each entry is ``(field_name, gap_template)``;
+# the template's ``{n}`` is the field's count. Adding a new negative signal here
+# — and nowhere else — makes it both count toward ``has_negative`` and render a
+# gap string; the loop test ``test_every_negative_field_renders_a_receipt`` fails
+# until a member is covered. (Before #296 these were two hand-maintained parallel
+# lists that had drifted: ``missed_catches`` and ``gate_bypasses`` counted but
+# rendered blank, so the scorer applied a −1 it could not cite.)
+_NEGATIVE_SIGNAL_FIELDS: tuple[tuple[str, str], ...] = (
+    ("ci_red_merges", "{n} CI-red merge(s)"),
+    ("must_fix_received", "{n} must-fix received"),
+    ("rework_cycles", "{n} rework cycle(s)"),
+    ("review_false_positives", "{n} review false-positive(s)"),
+    ("missed_catches", "{n} missed catch(es) as reviewer"),
+    ("gate_bypasses", "{n} gate-bypass merge(s)"),
+)
+
+
 @dataclass
 class Signals:
     """Countable per-engineer signals for one iteration. All fields are evidence."""
@@ -350,14 +371,9 @@ class Signals:
         )
 
     def has_negative(self) -> bool:
-        return bool(
-            self.must_fix_received
-            or self.ci_red_merges
-            or self.review_false_positives
-            or self.rework_cycles
-            or self.missed_catches
-            or self.gate_bypasses
-        )
+        # Derived from the single ``_NEGATIVE_SIGNAL_FIELDS`` source of truth
+        # (#296) so this and :func:`negative_signal_line` can never drift.
+        return any(getattr(self, name) for name, _ in _NEGATIVE_SIGNAL_FIELDS)
 
 
 @dataclass
@@ -1484,6 +1500,22 @@ def apply_distribution_discipline(
     allowed only for the engineer(s) whose composite signal score is the
     iteration maximum AND strictly positive; every other proposed 5 is capped to
     4. Scores of 4 and below pass through untouched.
+
+    **Ties at the top composite are intended — do NOT "fix" this into a single
+    seat (#275, #301).** When two or more engineers share the maximum
+    strictly-positive composite they *all* keep 5; the reserved 5 is not a single
+    rotating seat. This is deliberate: ``difficulty_points`` was author-only and
+    dominated the composite outright, so a flagship *author* always outranked a
+    defect-catching *reviewer* — two live waves rotated the reserved 5 away from
+    the reviewer who caught the wave's only real defect toward a merely-clean
+    author. #275 fixed that by weighting review value (``must_fix_caught`` /
+    ``verified_reviews``) at ``REVIEW_VALUE_WEIGHT`` and capping
+    ``difficulty_points`` at ``DIFFICULTY_COMPOSITE_CAP``, which makes genuine
+    top-of-pool ties reachable and correct. Collapsing a legitimate tie back to
+    one seat would reintroduce exactly the bias #275 removed. The
+    ``top > 0`` guard already prevents the degenerate all-clean-zero-signal wave
+    from handing 5 to everybody, so a tie only forms on real, strictly-positive
+    contribution.
     """
 
     def composite(s: Signals) -> int:
@@ -1634,15 +1666,16 @@ def negative_signal_line(name: str, sig: Signals) -> str:
     that still shows the receipts. Never returns an empty / "None" string.
     """
     if sig.has_negative():
-        gaps = []
-        if sig.ci_red_merges:
-            gaps.append(f"{sig.ci_red_merges} CI-red merge(s)")
-        if sig.must_fix_received:
-            gaps.append(f"{sig.must_fix_received} must-fix received")
-        if sig.rework_cycles:
-            gaps.append(f"{sig.rework_cycles} rework cycle(s)")
-        if sig.review_false_positives:
-            gaps.append(f"{sig.review_false_positives} review false-positive(s)")
+        # Derived from the same ``_NEGATIVE_SIGNAL_FIELDS`` set that
+        # :meth:`Signals.has_negative` tests (#296): every member that is
+        # non-zero renders a number-citing gap. Because the two functions read
+        # one list, a member can never be dirty-but-unrendered — the branch
+        # cannot fall through to a blank ``"{name}: "``.
+        gaps = [
+            template.format(n=count)
+            for name_, template in _NEGATIVE_SIGNAL_FIELDS
+            if (count := getattr(sig, name_))
+        ]
         return f"{name}: " + ", ".join(gaps)
     return (
         f"{name}: metrics clean: prs_merged={sig.prs_merged}, "
@@ -1657,14 +1690,28 @@ def negative_signal_line(name: str, sig: Signals) -> str:
 # trailing punctuation) is the banned shape.
 _BARE_NONE_RE = re.compile(r"^\s*[-*]?\s*(none|n/?a|-+)\s*[.;]?\s*$", re.IGNORECASE)
 
+# Blank-entry detector (#296). An entry that carries no evidence after the
+# ``"{name}: "`` prefix — everything after the first colon is whitespace
+# (``"Name: "`` / ``"Name:"``), or the whole line is blank — is just as vacuous
+# as a bare "None". This is the exact blank receipt the unrendered
+# ``missed_catches`` / ``gate_bypasses`` used to emit: the scorer applied a −1
+# that the forced pass then waved through with nothing to cite.
+_BLANK_ENTRY_RE = re.compile(r"^\s*(?:[^:]*:)?\s*$")
+
 
 def validate_negative_signal_pass(lines: list[str]) -> list[str]:
-    """Return the offending lines that are a bare "None" (forced-pass violation).
+    """Return the offending lines of a forced-pass (forced-pass violations).
 
     Empty return == the pass is clean. Used by a retro to mechanically reject a
-    pass that left a bare "None" in the negative-signal column.
+    pass that left a vacuous entry in the negative-signal column — either a bare
+    "None" / "n/a" / "-" token OR an entry blank after the ``"{name}: "`` prefix
+    (#296). Both shapes assert a delta with no citable evidence.
     """
-    return [ln for ln in lines if _BARE_NONE_RE.match(ln)]
+    return [
+        ln
+        for ln in lines
+        if _BARE_NONE_RE.match(ln) or _BLANK_ENTRY_RE.match(ln)
+    ]
 
 
 def retirement_trigger(

--- a/framework/tests/test_trust_signals.py
+++ b/framework/tests/test_trust_signals.py
@@ -1661,6 +1661,31 @@ def test_difficulty_composite_cap_prevents_single_handed_dominance() -> None:
     assert out["Flagship"] == ts.MAX_SCORE - 1
 
 
+def test_top_composite_tie_keeps_5_for_all_tied() -> None:
+    """Ties at the top composite are INTENDED — two engineers at an equal,
+    strictly-positive max composite both retain 5 (#275, #301). The reserved 5 is
+    not a single rotating seat; collapsing a legitimate tie to one winner would
+    reintroduce the author-only-``difficulty_points`` bias #275 removed. This
+    guards the documented behaviour: if a future reader "fixes" the tie into one
+    seat (e.g. picks a single argmax), one of these two drops to 4 and this fails.
+    """
+    # Two distinct, strictly-positive shapes tuned to the SAME composite (4):
+    #   author   = prs_merged 2 + min(difficulty 2, cap 2)          = 4
+    #   reviewer = REVIEW_VALUE_WEIGHT*(caught 1) + WEIGHT*(verified 1) = 4
+    # Different contribution axes, equal top composite — the exact author-vs-
+    # reviewer parity #275 made reachable.
+    author = ts.Signals(prs_merged=2, difficulty_points=2)
+    reviewer = ts.Signals(must_fix_caught=1, verified_reviews=1)
+    out = ts.apply_distribution_discipline(
+        {
+            "Author": (ts.MAX_SCORE, author),
+            "Reviewer": (ts.MAX_SCORE, reviewer),
+        }
+    )
+    assert out["Author"] == ts.MAX_SCORE  # both tied at the top composite (4)
+    assert out["Reviewer"] == ts.MAX_SCORE  # neither is capped to 4
+
+
 # ------------------------------------------- _pr_comment_histories (I/O, mocked)
 
 
@@ -2278,3 +2303,89 @@ def test_distribution_health_accepts_dict_and_empty() -> None:
     assert d.n == 2 and d.degenerate is False
     e = ts.distribution_health([])
     assert e.n == 0 and e.degenerate is False and e.reasons == ["no scores to assess"]
+
+
+# ---------------------------------- forced negative-signal pass receipts (#296)
+
+
+def test_negative_line_renders_missed_catches() -> None:
+    """Defect A: a ``missed_catches``-only signal set must render a number-citing
+    gap, not the blank ``"Name: "`` receipt. Reverting to the old 4-field ``gaps``
+    list (which omitted ``missed_catches``) makes this line blank → fails.
+    """
+    sig = ts.Signals(prs_merged=1, missed_catches=1, clean_first_pass=1)
+    assert sig.has_negative() is True
+    line = ts.negative_signal_line("Ibrahim El-Amin", sig)
+    assert line == "Ibrahim El-Amin: 1 missed catch(es) as reviewer"
+    # A rendered gap line is NOT a forced-pass violation.
+    assert ts.validate_negative_signal_pass([line]) == []
+
+
+def test_negative_line_renders_gate_bypasses() -> None:
+    """Defect A, second unrendered member: a ``gate_bypasses``-only set renders a
+    number-citing gap. This is the signal Wave 22's #293 made reachable — a
+    self-approved merge now dings ``-1`` and must be citable.
+    """
+    sig = ts.Signals(prs_merged=1, gate_bypasses=2)
+    assert sig.has_negative() is True
+    line = ts.negative_signal_line("X", sig)
+    assert line == "X: 2 gate-bypass merge(s)"
+    assert ts.validate_negative_signal_pass([line]) == []
+
+
+def test_every_negative_field_renders_a_receipt() -> None:
+    """The drift-stopper: for EVERY member of ``has_negative``'s field set, a
+    signal with only that field non-zero yields a non-bare, non-blank,
+    number-citing line that the validator accepts. This is the test that fails
+    when the next-added negative signal is forgotten in the renderer — set alone,
+    the forgotten field would fall through to a blank ``"{name}: "``.
+
+    Driven off the single source of truth ``_NEGATIVE_SIGNAL_FIELDS`` (which
+    ``has_negative`` itself derives from), so the loop can never test fewer fields
+    than the scorer counts.
+    """
+    fields = [name for name, _ in ts._NEGATIVE_SIGNAL_FIELDS]
+    assert fields, "the negative-field source of truth must be non-empty"
+    for name in fields:
+        sig = ts.Signals(**{name: 3})
+        assert sig.has_negative() is True, f"{name} must make has_negative True"
+        line = ts.negative_signal_line("Eng", sig)
+        body = line.split(":", 1)[1].strip()
+        assert body, f"{name}-only rendered a blank receipt: {line!r}"
+        assert not ts._BARE_NONE_RE.match(line), f"{name} rendered a bare-None: {line!r}"
+        assert "3" in body, f"{name} did not cite its count: {line!r}"
+        # The forced-pass validator must accept a real, evidence-carrying line.
+        assert ts.validate_negative_signal_pass([line]) == [], line
+
+
+def test_has_negative_derives_from_negative_field_set() -> None:
+    """``has_negative`` is exactly the OR of ``_NEGATIVE_SIGNAL_FIELDS`` — a
+    non-negative field (e.g. ``prs_merged``) never flips it, and every negative
+    field alone does. Guards the structural derivation against re-drift.
+    """
+    assert ts.Signals(prs_merged=5, must_fix_caught=5).has_negative() is False
+    for name, _ in ts._NEGATIVE_SIGNAL_FIELDS:
+        assert ts.Signals(**{name: 1}).has_negative() is True, name
+
+
+def test_validate_rejects_blank_after_colon() -> None:
+    """Defect B: the validator — whose sole job is banning vacuous entries — must
+    reject an entry blank after the ``"{name}: "`` prefix, the exact shape
+    Defect A used to emit. Reverting the ``_BLANK_ENTRY_RE`` check waves it
+    through (returns ``[]``) → fails.
+    """
+    assert ts.validate_negative_signal_pass(["Ibrahim El-Amin: "]) == ["Ibrahim El-Amin: "]
+    assert ts.validate_negative_signal_pass(["X:"]) == ["X:"]
+    assert ts.validate_negative_signal_pass(["   "]) == ["   "]
+
+
+def test_validate_still_rejects_bare_none_and_accepts_real_gaps() -> None:
+    """No regression on the original contract: bare ``None`` / ``n/a`` / ``-`` are
+    still rejected, and a genuine number-citing gap or a ``metrics clean`` line is
+    still accepted.
+    """
+    assert ts.validate_negative_signal_pass(["None"]) == ["None"]
+    assert ts.validate_negative_signal_pass(["- n/a"]) == ["- n/a"]
+    clean = ts.negative_signal_line("C", ts.Signals(prs_merged=2))
+    gap = ts.negative_signal_line("D", ts.Signals(prs_merged=1, ci_red_merges=1))
+    assert ts.validate_negative_signal_pass([clean, gap]) == []

--- a/framework/tests/test_trust_signals.py
+++ b/framework/tests/test_trust_signals.py
@@ -2352,7 +2352,7 @@ def test_every_negative_field_renders_a_receipt() -> None:
         line = ts.negative_signal_line("Eng", sig)
         body = line.split(":", 1)[1].strip()
         assert body, f"{name}-only rendered a blank receipt: {line!r}"
-        assert not ts._BARE_NONE_RE.match(line), f"{name} rendered a bare-None: {line!r}"
+        assert not ts._is_vacuous_entry(line), f"{name} rendered a vacuous line: {line!r}"
         assert "3" in body, f"{name} did not cite its count: {line!r}"
         # The forced-pass validator must accept a real, evidence-carrying line.
         assert ts.validate_negative_signal_pass([line]) == [], line
@@ -2371,21 +2371,50 @@ def test_has_negative_derives_from_negative_field_set() -> None:
 def test_validate_rejects_blank_after_colon() -> None:
     """Defect B: the validator — whose sole job is banning vacuous entries — must
     reject an entry blank after the ``"{name}: "`` prefix, the exact shape
-    Defect A used to emit. Reverting the ``_BLANK_ENTRY_RE`` check waves it
-    through (returns ``[]``) → fails.
+    Defect A used to emit. Reverting the body-empty check waves it through
+    (returns ``[]``) → fails.
     """
     assert ts.validate_negative_signal_pass(["Ibrahim El-Amin: "]) == ["Ibrahim El-Amin: "]
     assert ts.validate_negative_signal_pass(["X:"]) == ["X:"]
     assert ts.validate_negative_signal_pass(["   "]) == ["   "]
 
 
-def test_validate_still_rejects_bare_none_and_accepts_real_gaps() -> None:
-    """No regression on the original contract: bare ``None`` / ``n/a`` / ``-`` are
-    still rejected, and a genuine number-citing gap or a ``metrics clean`` line is
-    still accepted.
+def test_validate_rejects_name_prefixed_vacuous_token() -> None:
+    """#296 review must-fix: the validator must reject a vacuous token that
+    carries a ``"{name}: "`` prefix — the ONLY shape the forced-pass emitter
+    produces. A whole-line anchor (the original ``_BARE_NONE_RE``) never fired
+    against real input, so ``"Ibrahim El-Amin: None"`` — one character from the
+    already-rejected ``"Ibrahim El-Amin: "`` and identically vacuous — sailed
+    through. Reverting to whole-line anchoring re-accepts all of these → fails.
+    """
+    vacuous = [
+        "Ibrahim El-Amin: None",
+        "Name: none",
+        "Name: -",
+        "Name: n/a",
+        "Name: N/A",
+        "Name: na",
+        "Name: .",
+        "Name: --",
+        "Name: - none.",
+    ]
+    for entry in vacuous:
+        assert ts.validate_negative_signal_pass([entry]) == [entry], entry
+
+
+def test_validate_still_rejects_whole_line_bare_none_and_accepts_real_gaps() -> None:
+    """No regression on the original contract (a whole line with no colon) AND no
+    over-tightening: bare ``None`` / ``n/a`` / ``-`` whole lines are still
+    rejected, while a genuine number-citing gap, a real ``missed_catches``
+    receipt, and a ``metrics clean`` line are all still ACCEPTED.
     """
     assert ts.validate_negative_signal_pass(["None"]) == ["None"]
     assert ts.validate_negative_signal_pass(["- n/a"]) == ["- n/a"]
-    clean = ts.negative_signal_line("C", ts.Signals(prs_merged=2))
-    gap = ts.negative_signal_line("D", ts.Signals(prs_merged=1, ci_red_merges=1))
-    assert ts.validate_negative_signal_pass([clean, gap]) == []
+    real = [
+        "Name: 1 missed catch(es) as reviewer",
+        ts.negative_signal_line("C", ts.Signals(prs_merged=2)),
+        ts.negative_signal_line("D", ts.Signals(prs_merged=1, ci_red_merges=1)),
+        # A gap whose text merely CONTAINS a vacuous substring must not trip it.
+        "Name: 2 gate-bypass merge(s), 1 review false-positive(s)",
+    ]
+    assert ts.validate_negative_signal_pass(real) == []


### PR DESCRIPTION
## Summary

The forced negative-signal pass — the mechanism whose entire job is to ban vacuous
entries — both **emitted** and **accepted** a blank receipt for a `missed_catches`-
or `gate_bypasses`-only wave, so the scorer applied a `-1` it could not cite.

Root cause: **two hand-maintained parallel field lists**. `Signals.has_negative()`
tested six negative fields; `negative_signal_line()`'s `gaps` list rendered only four.
`missed_catches` and `gate_bypasses` fell through to a blank `"Name: "`, and
`validate_negative_signal_pass()` waved that blank through.

- **One source of truth** — `_NEGATIVE_SIGNAL_FIELDS` (field name + gap template
  together). Both `has_negative()` and `negative_signal_line()` derive from it, so the
  field set and its renderer **cannot drift again**: a negative added there — and
  nowhere else — both counts and renders.
- `validate_negative_signal_pass()` now rejects an entry **blank after the `"{name}: "`
  prefix** (and the wholly-blank line), not just bare `None`/`n/a`/`-`.
- `apply_distribution_discipline` docstring now states that **ties at the top composite
  are intended** (per the #275 rationale: `difficulty_points` was author-only and
  dominated the composite, so a flagship author always outranked a defect-catching
  reviewer; weighting review value at `REVIEW_VALUE_WEIGHT` and capping difficulty at
  `DIFFICULTY_COMPOSITE_CAP` fixed it). A future reader must not "fix" the reserved 5
  into a single seat. (Satisfies the criterion from #301 that lives in this file.)

Trackers this addresses: #296 (the closing keyword is in the **commit trailer**, not
this body — deliberately, so this PR cannot re-trigger the #304 auto-close footgun that
already bit #296 via PR #299), plus the docstring criterion from #301.

## Before / after (reproduction from the issue)

```
# before (main @ 8b43481)
negative_signal_line('Ibrahim El-Amin', Signals(missed_catches=1, ...))  ->  'Ibrahim El-Amin: '   # blank
validate_negative_signal_pass(['Ibrahim El-Amin: '])                     ->  []                    # accepted (bug)
negative_signal_line('X', Signals(gate_bypasses=1))                      ->  'X: '                 # blank

# after (this PR)
negative_signal_line('Ibrahim El-Amin', Signals(missed_catches=1, ...))  ->  'Ibrahim El-Amin: 1 missed catch(es) as reviewer'
validate_negative_signal_pass(['Ibrahim El-Amin: '])                     ->  ['Ibrahim El-Amin: ']  # rejected
negative_signal_line('X', Signals(gate_bypasses=1))                      ->  'X: 1 gate-bypass merge(s)'
```

Note: the issue's one-liner ends with `bool(validate_negative_signal_pass([line]))`.
After the fix `line` is a **valid** gap string, so the validator correctly returns `[]`
(not rejected) → that literal still prints `False`. The meaningful change is `repr(line)`
going from blank to a real gap; blank-line rejection is shown against `'Ibrahim El-Amin: '`
above.

## Load-bearing tests — revert→red evidence

Each new behavior has a test that FAILS when the behavior is reverted. Reverts run
against the committed fix, then restored.

**1. Renderer reverted to the old 4-field `gaps` list** (drops `missed_catches` /
`gate_bypasses`):
```
FAILED test_negative_line_renders_missed_catches
FAILED test_negative_line_renders_gate_bypasses
FAILED test_every_negative_field_renders_a_receipt
  E  AssertionError: missed_catches-only rendered a blank receipt: 'Eng: '
3 failed, 131 deselected
```

**2. Validator reverted to bare-`None`-only** (drop the `_BLANK_ENTRY_RE` check):
```
FAILED test_validate_rejects_blank_after_colon
  E  AssertionError: assert [] == ['Ibrahim El-Amin: ']
1 failed, 1 passed, 132 deselected
```

**3. `apply_distribution_discipline` reverted to a single-seat argmax** (one winner
keeps 5):
```
FAILED test_top_composite_tie_keeps_5_for_all_tied
  E  assert 4 == 5   (Reviewer capped though tied at top composite)
1 failed, 133 deselected
```

## Test + lint

- `pytest framework/tests/test_trust_signals.py` → **134 passed**
- `pytest framework/tests/` (full suite) → **916 passed**
- `ruff check` → clean
- `reinstall.py --check` → `.claude/` in sync (`lib/` is wired in place; no mirror)
- No existing test's expected values moved; `apply_distribution_discipline` return
  values for existing tests are unchanged (docstring-only change to that function).

## Review Checklist
- [ ] Reviewed by another team member
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)
