### PR TITLE
docs(wave-end): recompute wave counters from trust_signals extract (#300)

### DIFF
--- a/.claude/skills/wave-end/SKILL.md
+++ b/.claude/skills/wave-end/SKILL.md
@@ -58,41 +58,69 @@ and reads the counters recorded here.
    # wave-branch    → BASE=<branch.integration template, the wave's phase + $W>
    # direct-to-main → BASE=<default branch>; add `--label "wave-$W"` to scope the wave
 
-   # --pr-count is identity-AGNOSTIC — it counts merged PRs, not authors — so the raw
-   # `gh` list is correct here even in a single-account (dogfooded) repo where every PR
-   # carries one `author.login` and team identity lives only in `Co-Authored-By`:
-   PR_COUNT="$(gh pr list --state merged --base "$BASE" --json number | jq 'length')"
+   # REFUSE to derive counters from a read you cannot trust. `extract` fails SILENT
+   # under a GraphQL rate limit (returns `{}`, exit 0), and `gh pr list --json` is
+   # GraphQL-backed too — the SAME 5,000/hr bucket — so when the budget is pre-exhausted
+   # BOTH come back empty and a naive `${PR_COUNT:-0}` collapses to 0, then the
+   # cross-check compares 0 == 0 and reports health (#307 review). Three ORTHOGONAL
+   # defenses run before any counter is derived or `wave wrapup` is called:
+
+   # (A) Preflight the GraphQL budget over an INDEPENDENT channel. `gh api rate_limit`
+   #     is served over REST — a different bucket that does NOT drain with GraphQL — so
+   #     it stays readable when `gh pr list` / `extract` cannot. If GraphQL is at/near
+   #     zero, the wave read WILL return empty-but-successful; abort now, naming the
+   #     limit. `GQL_FLOOR` is a fail-fast margin; (B) and (C) are the hard guarantees.
+   GQL_FLOOR=100
+   GQL_REMAINING="$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null)"
+   case "$GQL_REMAINING" in
+       ''|*[!0-9]*)
+           echo 'ABORT: could not read the GraphQL rate-limit budget (REST rate_limit failed).' >&2
+           echo '  Cannot establish that the wave read will succeed — refusing to record counters.' >&2
+           exit 1 ;;
+   esac
+   if [ "$GQL_REMAINING" -lt "$GQL_FLOOR" ]; then
+       echo "ABORT: GraphQL budget near-exhausted ($GQL_REMAINING < $GQL_FLOOR)." >&2
+       echo '  gh pr list and trust_signals extract both draw on this bucket and would' >&2
+       echo '  return empty-but-successful, recording FALSE zero counters. Wait for reset —' >&2
+       echo '  gh api rate_limit --jq .resources.graphql — then re-run step 3 from the top.' >&2
+       exit 1
+   fi
+
+   # (B) --pr-count is identity-AGNOSTIC (a count of PRs, not authors, so `gh`'s single
+   #     dogfood `.author.login` is fine here) — but its READ can still fail. Capture the
+   #     exit status EXPLICITLY: a failed `gh pr list` must not collapse into '' and then
+   #     0 via `${VAR:-0}`. A non-zero exit, or non-numeric stdout, is an ABORT, not a
+   #     zero. (This is what the pre-exhausted case trips — `gh pr list` exits non-zero.)
+   PR_LIST="$(gh pr list --state merged --base "$BASE" --json number)"; PR_LIST_RC=$?
+   PR_COUNT="$(printf '%s' "$PR_LIST" | jq 'length' 2>/dev/null)"
+   if [ "$PR_LIST_RC" -ne 0 ] || ! printf '%s' "$PR_COUNT" | grep -Eq '^[0-9]+$'; then
+       echo "ABORT: gh pr list failed (exit $PR_LIST_RC) or returned a non-numeric count." >&2
+       echo '  A failed read is NOT an empty wave — refusing to record zero counters.' >&2
+       exit 1
+   fi
 
    # --cr-cycles and --concentration are BOTH identity-SENSITIVE, so both derive from
-   # `trust_signals.py extract` — the only source that resolves team-member identity
-   # (it parses the `Co-Authored-By` trailers). Grouping `gh`'s `.author.login` instead
-   # collapses every PR into the single bot/owner account in a dogfooded repo, pinning
-   # concentration at ~100% forever — exactly the drift this derivation exists to kill.
-   # Extract once and read both counters off it — a second call could straddle a
-   # rate-limit boundary and return different data:
+   # `trust_signals.py extract` — the only source that resolves team-member identity (it
+   # parses the `Co-Authored-By` trailers); grouping `gh`'s `.author.login` would collapse
+   # a dogfooded repo to ~100% concentration forever (#307). Extract ONCE — a second call
+   # could straddle a rate-limit boundary and return different data:
    SIG="$(python3 "$LIB/trust_signals.py" extract "$W")"
 
-   # GUARDRAIL — `extract` fails SILENT (#300 follow-up; the fix at the `extract`
-   # level is tracked separately on the trust_signals surface). It is SCM-dependent,
-   # and under a GitHub API rate limit it returns `{}` with exit 0 and no stderr. The
-   # `add // 0` / zero-total guards below would then record `cr_cycles=0,
-   # concentration=0` — a PLAUSIBLE-looking lie (a genuinely clean wave IS 0),
-   # indistinguishable from "we could not read GitHub". So the record must not be
-   # written from an unreadable extract. You already know PR_COUNT independently from
-   # `gh pr list`; cross-check it against extract's identity-aware `authored_prs`
-   # total. An empty map — or ANY disagreement, which also catches a PARTIAL read —
-   # for a wave that merged PRs is an ABORT, never a zero:
-   SIG_ENGINEERS="$(echo "$SIG" | jq 'length' 2>/dev/null || echo 0)"
-   SIG_PR_TOTAL="$(echo "$SIG" | jq '[.[].authored_prs | length] | add // 0' 2>/dev/null || echo 0)"
-   if [ "${PR_COUNT:-0}" -gt 0 ] && { [ "${SIG_ENGINEERS:-0}" -eq 0 ] || [ "${SIG_PR_TOTAL:-0}" -ne "${PR_COUNT}" ]; }; then
+   # (C) Cross-check `extract` against the now-TRUSTED PR_COUNT (reads (A)+(B) confirmed
+   #     succeeded). `extract` still fails SILENT (`{}`, exit 0) — the #300 follow-up; the
+   #     library-level fix is #311 on the trust_signals surface, not touched here. An
+   #     empty map — or ANY disagreement, which also catches a PARTIAL read — for a wave
+   #     that merged PRs is an ABORT, never a zero. A genuinely empty wave reaches here
+   #     only after the reads SUCCEEDED, so PR_COUNT == 0 is then a real zero and proceeds:
+   SIG_ENGINEERS="$(printf '%s' "$SIG" | jq 'length' 2>/dev/null || echo 0)"
+   SIG_PR_TOTAL="$(printf '%s' "$SIG" | jq '[.[].authored_prs | length] | add // 0' 2>/dev/null || echo 0)"
+   if [ "$PR_COUNT" -gt 0 ] && { [ "${SIG_ENGINEERS:-0}" -eq 0 ] || [ "${SIG_PR_TOTAL:-0}" -ne "$PR_COUNT" ]; }; then
        echo "ABORT: trust_signals extract could not be trusted for wave $W" >&2
        echo "  gh pr list count = $PR_COUNT, but extract shows $SIG_ENGINEERS engineer(s)" >&2
-       echo "  covering $SIG_PR_TOTAL authored PR(s). An empty/short extract for a wave" >&2
-       echo "  that merged PRs means the READ FAILED (usually a GraphQL rate limit)," >&2
-       echo "  NOT that no rework happened. Do NOT run 'wave wrapup' with these numbers —" >&2
-       echo "  it would write false counters into state.json that nothing downstream" >&2
-       echo "  could tell from real zeros. Wait for reset —" >&2
-       echo "  'gh api rate_limit --jq .resources.graphql' — and re-run step 3 from the top." >&2
+       echo "  covering $SIG_PR_TOTAL authored PR(s). An empty/short extract for a wave that" >&2
+       echo "  merged PRs means the READ FAILED (usually a GraphQL rate limit), NOT that no" >&2
+       echo "  rework happened. Do NOT run 'wave wrapup' with these numbers. Wait for reset" >&2
+       echo "  and re-run step 3 from the top." >&2
        exit 1
    fi
 

--- a/.claude/skills/wave-end/SKILL.md
+++ b/.claude/skills/wave-end/SKILL.md
@@ -68,8 +68,33 @@ and reads the counters recorded here.
    # (it parses the `Co-Authored-By` trailers). Grouping `gh`'s `.author.login` instead
    # collapses every PR into the single bot/owner account in a dogfooded repo, pinning
    # concentration at ~100% forever — exactly the drift this derivation exists to kill.
-   # Extract once and read both counters off it:
+   # Extract once and read both counters off it — a second call could straddle a
+   # rate-limit boundary and return different data:
    SIG="$(python3 "$LIB/trust_signals.py" extract "$W")"
+
+   # GUARDRAIL — `extract` fails SILENT (#300 follow-up; the fix at the `extract`
+   # level is tracked separately on the trust_signals surface). It is SCM-dependent,
+   # and under a GitHub API rate limit it returns `{}` with exit 0 and no stderr. The
+   # `add // 0` / zero-total guards below would then record `cr_cycles=0,
+   # concentration=0` — a PLAUSIBLE-looking lie (a genuinely clean wave IS 0),
+   # indistinguishable from "we could not read GitHub". So the record must not be
+   # written from an unreadable extract. You already know PR_COUNT independently from
+   # `gh pr list`; cross-check it against extract's identity-aware `authored_prs`
+   # total. An empty map — or ANY disagreement, which also catches a PARTIAL read —
+   # for a wave that merged PRs is an ABORT, never a zero:
+   SIG_ENGINEERS="$(echo "$SIG" | jq 'length' 2>/dev/null || echo 0)"
+   SIG_PR_TOTAL="$(echo "$SIG" | jq '[.[].authored_prs | length] | add // 0' 2>/dev/null || echo 0)"
+   if [ "${PR_COUNT:-0}" -gt 0 ] && { [ "${SIG_ENGINEERS:-0}" -eq 0 ] || [ "${SIG_PR_TOTAL:-0}" -ne "${PR_COUNT}" ]; }; then
+       echo "ABORT: trust_signals extract could not be trusted for wave $W" >&2
+       echo "  gh pr list count = $PR_COUNT, but extract shows $SIG_ENGINEERS engineer(s)" >&2
+       echo "  covering $SIG_PR_TOTAL authored PR(s). An empty/short extract for a wave" >&2
+       echo "  that merged PRs means the READ FAILED (usually a GraphQL rate limit)," >&2
+       echo "  NOT that no rework happened. Do NOT run 'wave wrapup' with these numbers —" >&2
+       echo "  it would write false counters into state.json that nothing downstream" >&2
+       echo "  could tell from real zeros. Wait for reset —" >&2
+       echo "  'gh api rate_limit --jq .resources.graphql' — and re-run step 3 from the top." >&2
+       exit 1
+   fi
 
    # --cr-cycles = PRs that took >=1 changes-requested round. `trust_signals.py`
    # increments an author's `rework_cycles` exactly ONCE per PR that carried a rework

--- a/.claude/skills/wave-end/SKILL.md
+++ b/.claude/skills/wave-end/SKILL.md
@@ -36,21 +36,80 @@ and reads the counters recorded here.
    d. Create tech-debt issues for findings (label: next phase)
    e. Merge if CI green
    f. Close referenced issues
-3. Record the wave's counters and close it **live** — the `wrapup` transition writes
-   `wave_{W}_completed_at`, deactivates the wave, advances `last_completed_wave`, and
-   records the three counters `/wave-retro` reads for drift verification:
+3. **Derive the wave's counters mechanically — never transcribe them from the
+   handoff.** The three counters `/wave-retro` step 2 reads for drift verification
+   MUST be computed from the merged-PR set and `trust_signals.py extract` — the same
+   authority the retro reconciles against. The session handoff narrates *final
+   verdict state* (a PR amended in place after its fix lands reads "clean"); the
+   counters track *round history*. Transcribing the prose is a second source of truth
+   and guarantees drift — it bit twice: Wave 22 recorded `--cr-cycles 1` because the
+   handoff read "3 PRs / 1 CR cycle" and called #290 "2 clean" (true of its amended
+   final state, false of its round history — #290 carried a real rework round), and
+   `trust_signals.py extract 22` disagreed on sight; Wave 11 produced the analogous
+   rollup slip that motivated the `origin/<wave>` runbook step (#255).
+
+   Compute all three from the same merged-PR set the retro uses, then pass the derived
+   values to `wrapup` — do not type numbers from memory:
+
+   ```bash
+   # BASE = the wave's PR base — the integration branch for a wave-branch merge model,
+   # the default branch otherwise (same resolution as step 1 / `/wave-retro` step 1).
+   MM="$(python3 "$LIB/lifecycle.py" merge-model get "$W" 2>/dev/null || echo direct-to-main)"
+   # wave-branch    → BASE=<branch.integration template, the wave's phase + $W>
+   # direct-to-main → BASE=<default branch>; add `--label "wave-$W"` to scope the wave
+
+   # --pr-count and --concentration come from the merged-PR list itself:
+   PRS_JSON="$(gh pr list --state merged --base "$BASE" --json number,author)"
+   PR_COUNT="$(echo "$PRS_JSON" | jq 'length')"
+   CONCENTRATION="$(echo "$PRS_JSON" | jq -r '
+       if length == 0 then 0
+       else ((group_by(.author.login) | map(length) | max) * 100 / length | floor)
+       end')"
+
+   # --cr-cycles = PRs that took >=1 changes-requested round. `trust_signals.py`
+   # increments an author's `rework_cycles` exactly ONCE per PR that carried a rework
+   # round, and the extraction is edit-history-aware (the #164 catch ledger / #229
+   # comment histories), so an in-place verdict amendment does NOT erase the round.
+   # Summing `rework_cycles` across engineers therefore counts reworked PRs per-PR,
+   # not per-verdict (a PR with `reviewers_required=2` can carry two ChangesRequested
+   # verdicts in one round — still one reworked PR). This is the SAME extraction
+   # `/wave-retro` steps 2-3 run, so the wrapup counter and the retro recompute can
+   # never diverge:
+   CR_CYCLES="$(python3 "$LIB/trust_signals.py" extract "$W" \
+       | jq '[.[].rework_cycles] | add // 0')"
+
+   echo "derived counters → --pr-count $PR_COUNT --cr-cycles $CR_CYCLES --concentration $CONCENTRATION"
+   ```
+
+   For a `meta-and-children` project, sweep every repo in `project.repos` (this is
+   what `trust_signals.py` does internally) and union the per-repo `pr list` results
+   before computing `--pr-count` / `--concentration`.
+
+   Then record the counters and close the wave **live** — the `wrapup` transition
+   writes `wave_{W}_completed_at`, deactivates the wave, advances `last_completed_wave`,
+   and stores the three counters `/wave-retro` reads for drift verification:
 
    ```bash
    python3 "$LIB/lifecycle.py" wave wrapup "$W" \
-       --pr-count {N} --cr-cycles {C} --concentration {PCT}
+       --pr-count "$PR_COUNT" --cr-cycles "$CR_CYCLES" --concentration "$CONCENTRATION"
    ```
 
-   Count them from the actual merged-PR set, not from memory: `--pr-count` = merged PRs
-   this wave, `--cr-cycles` = **PRs** that took >=1 changes-requested round (per-PR, not
-   per-verdict — a PR with `reviewers_required=2` can carry 2 ChangesRequested verdicts in
-   one round; count the PR once). This mirrors `trust_signals.py`'s `rework_cycles` signal
-   ("PRs they authored that needed >=1 rework round") so the two counters never drift.
-   `--concentration` = max(PRs by one author) × 100 / total.
+   **The recomputed-vs-claimed reconciliation is bidirectional.** `/wave-retro` step 2
+   independently recomputes these counters; deriving them mechanically here makes the
+   two agree by construction, but state both directions so the reconciliation is
+   unambiguous whenever they differ:
+   - **recomputed `<` claimed AND the gap is fully explained by edited-in-place
+     verdicts** → the **claimed value stands**. A naive recompute from *current*
+     comment bodies under-counts a ChangesRequested verdict that was amended in place
+     to Approved after the fix landed — the historic round still happened, so the
+     wrapup-time count is authoritative-historic. Record a
+     `wave_{W}_counter_corrections` entry documenting the measurement conflict; do NOT
+     correct the historic count downward. (Deriving `--cr-cycles` from the
+     history-aware `extract` above avoids this under-count in the first place.)
+   - **recomputed `>` claimed** → **recomputed wins** — the wrapup missed a real round.
+     This was Wave 22 (claimed 1, recomputed 2: `extract` found `rework_cycles=1` on
+     both #290 and #292). Because this step now derives `--cr-cycles` from that same
+     `extract`, this direction should not resurface at retro time again.
 
    **Emit review-load next to concentration** (#231): concentration tracks *authoring*
    load; the companion number is *reviewing* load — per-reviewer verdict counts, so a

--- a/.claude/skills/wave-end/SKILL.md
+++ b/.claude/skills/wave-end/SKILL.md
@@ -58,13 +58,18 @@ and reads the counters recorded here.
    # wave-branch    → BASE=<branch.integration template, the wave's phase + $W>
    # direct-to-main → BASE=<default branch>; add `--label "wave-$W"` to scope the wave
 
-   # --pr-count and --concentration come from the merged-PR list itself:
-   PRS_JSON="$(gh pr list --state merged --base "$BASE" --json number,author)"
-   PR_COUNT="$(echo "$PRS_JSON" | jq 'length')"
-   CONCENTRATION="$(echo "$PRS_JSON" | jq -r '
-       if length == 0 then 0
-       else ((group_by(.author.login) | map(length) | max) * 100 / length | floor)
-       end')"
+   # --pr-count is identity-AGNOSTIC — it counts merged PRs, not authors — so the raw
+   # `gh` list is correct here even in a single-account (dogfooded) repo where every PR
+   # carries one `author.login` and team identity lives only in `Co-Authored-By`:
+   PR_COUNT="$(gh pr list --state merged --base "$BASE" --json number | jq 'length')"
+
+   # --cr-cycles and --concentration are BOTH identity-SENSITIVE, so both derive from
+   # `trust_signals.py extract` — the only source that resolves team-member identity
+   # (it parses the `Co-Authored-By` trailers). Grouping `gh`'s `.author.login` instead
+   # collapses every PR into the single bot/owner account in a dogfooded repo, pinning
+   # concentration at ~100% forever — exactly the drift this derivation exists to kill.
+   # Extract once and read both counters off it:
+   SIG="$(python3 "$LIB/trust_signals.py" extract "$W")"
 
    # --cr-cycles = PRs that took >=1 changes-requested round. `trust_signals.py`
    # increments an author's `rework_cycles` exactly ONCE per PR that carried a rework
@@ -75,15 +80,22 @@ and reads the counters recorded here.
    # verdicts in one round — still one reworked PR). This is the SAME extraction
    # `/wave-retro` steps 2-3 run, so the wrapup counter and the retro recompute can
    # never diverge:
-   CR_CYCLES="$(python3 "$LIB/trust_signals.py" extract "$W" \
-       | jq '[.[].rework_cycles] | add // 0')"
+   CR_CYCLES="$(echo "$SIG" | jq '[.[].rework_cycles] | add // 0')"
+
+   # --concentration = max(PRs by one author) × 100 / total, over the SAME identity-aware
+   # `authored_prs` lists `/wave-retro` step 2 reconciles against (integer floor; guard
+   # total == 0):
+   CONCENTRATION="$(echo "$SIG" | jq '
+       [ .[].authored_prs | length ] as $lens
+       | ($lens | add) as $total
+       | if ($total // 0) == 0 then 0 else (($lens | max) * 100 / $total | floor) end')"
 
    echo "derived counters → --pr-count $PR_COUNT --cr-cycles $CR_CYCLES --concentration $CONCENTRATION"
    ```
 
-   For a `meta-and-children` project, sweep every repo in `project.repos` (this is
-   what `trust_signals.py` does internally) and union the per-repo `pr list` results
-   before computing `--pr-count` / `--concentration`.
+   For a `meta-and-children` project, `trust_signals.py extract` already sweeps every
+   repo in `project.repos` internally, so `--cr-cycles` / `--concentration` need no
+   manual sweep; union the per-repo `gh pr list` results yourself only for `--pr-count`.
 
    Then record the counters and close the wave **live** — the `wrapup` transition
    writes `wave_{W}_completed_at`, deactivates the wave, advances `last_completed_wave`,

--- a/framework/assets/skills/wave-end/SKILL.md
+++ b/framework/assets/skills/wave-end/SKILL.md
@@ -58,41 +58,69 @@ and reads the counters recorded here.
    # wave-branch    → BASE=<branch.integration template, the wave's phase + $W>
    # direct-to-main → BASE=<default branch>; add `--label "wave-$W"` to scope the wave
 
-   # --pr-count is identity-AGNOSTIC — it counts merged PRs, not authors — so the raw
-   # `gh` list is correct here even in a single-account (dogfooded) repo where every PR
-   # carries one `author.login` and team identity lives only in `Co-Authored-By`:
-   PR_COUNT="$(gh pr list --state merged --base "$BASE" --json number | jq 'length')"
+   # REFUSE to derive counters from a read you cannot trust. `extract` fails SILENT
+   # under a GraphQL rate limit (returns `{}`, exit 0), and `gh pr list --json` is
+   # GraphQL-backed too — the SAME 5,000/hr bucket — so when the budget is pre-exhausted
+   # BOTH come back empty and a naive `${PR_COUNT:-0}` collapses to 0, then the
+   # cross-check compares 0 == 0 and reports health (#307 review). Three ORTHOGONAL
+   # defenses run before any counter is derived or `wave wrapup` is called:
+
+   # (A) Preflight the GraphQL budget over an INDEPENDENT channel. `gh api rate_limit`
+   #     is served over REST — a different bucket that does NOT drain with GraphQL — so
+   #     it stays readable when `gh pr list` / `extract` cannot. If GraphQL is at/near
+   #     zero, the wave read WILL return empty-but-successful; abort now, naming the
+   #     limit. `GQL_FLOOR` is a fail-fast margin; (B) and (C) are the hard guarantees.
+   GQL_FLOOR=100
+   GQL_REMAINING="$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null)"
+   case "$GQL_REMAINING" in
+       ''|*[!0-9]*)
+           echo 'ABORT: could not read the GraphQL rate-limit budget (REST rate_limit failed).' >&2
+           echo '  Cannot establish that the wave read will succeed — refusing to record counters.' >&2
+           exit 1 ;;
+   esac
+   if [ "$GQL_REMAINING" -lt "$GQL_FLOOR" ]; then
+       echo "ABORT: GraphQL budget near-exhausted ($GQL_REMAINING < $GQL_FLOOR)." >&2
+       echo '  gh pr list and trust_signals extract both draw on this bucket and would' >&2
+       echo '  return empty-but-successful, recording FALSE zero counters. Wait for reset —' >&2
+       echo '  gh api rate_limit --jq .resources.graphql — then re-run step 3 from the top.' >&2
+       exit 1
+   fi
+
+   # (B) --pr-count is identity-AGNOSTIC (a count of PRs, not authors, so `gh`'s single
+   #     dogfood `.author.login` is fine here) — but its READ can still fail. Capture the
+   #     exit status EXPLICITLY: a failed `gh pr list` must not collapse into '' and then
+   #     0 via `${VAR:-0}`. A non-zero exit, or non-numeric stdout, is an ABORT, not a
+   #     zero. (This is what the pre-exhausted case trips — `gh pr list` exits non-zero.)
+   PR_LIST="$(gh pr list --state merged --base "$BASE" --json number)"; PR_LIST_RC=$?
+   PR_COUNT="$(printf '%s' "$PR_LIST" | jq 'length' 2>/dev/null)"
+   if [ "$PR_LIST_RC" -ne 0 ] || ! printf '%s' "$PR_COUNT" | grep -Eq '^[0-9]+$'; then
+       echo "ABORT: gh pr list failed (exit $PR_LIST_RC) or returned a non-numeric count." >&2
+       echo '  A failed read is NOT an empty wave — refusing to record zero counters.' >&2
+       exit 1
+   fi
 
    # --cr-cycles and --concentration are BOTH identity-SENSITIVE, so both derive from
-   # `trust_signals.py extract` — the only source that resolves team-member identity
-   # (it parses the `Co-Authored-By` trailers). Grouping `gh`'s `.author.login` instead
-   # collapses every PR into the single bot/owner account in a dogfooded repo, pinning
-   # concentration at ~100% forever — exactly the drift this derivation exists to kill.
-   # Extract once and read both counters off it — a second call could straddle a
-   # rate-limit boundary and return different data:
+   # `trust_signals.py extract` — the only source that resolves team-member identity (it
+   # parses the `Co-Authored-By` trailers); grouping `gh`'s `.author.login` would collapse
+   # a dogfooded repo to ~100% concentration forever (#307). Extract ONCE — a second call
+   # could straddle a rate-limit boundary and return different data:
    SIG="$(python3 "$LIB/trust_signals.py" extract "$W")"
 
-   # GUARDRAIL — `extract` fails SILENT (#300 follow-up; the fix at the `extract`
-   # level is tracked separately on the trust_signals surface). It is SCM-dependent,
-   # and under a GitHub API rate limit it returns `{}` with exit 0 and no stderr. The
-   # `add // 0` / zero-total guards below would then record `cr_cycles=0,
-   # concentration=0` — a PLAUSIBLE-looking lie (a genuinely clean wave IS 0),
-   # indistinguishable from "we could not read GitHub". So the record must not be
-   # written from an unreadable extract. You already know PR_COUNT independently from
-   # `gh pr list`; cross-check it against extract's identity-aware `authored_prs`
-   # total. An empty map — or ANY disagreement, which also catches a PARTIAL read —
-   # for a wave that merged PRs is an ABORT, never a zero:
-   SIG_ENGINEERS="$(echo "$SIG" | jq 'length' 2>/dev/null || echo 0)"
-   SIG_PR_TOTAL="$(echo "$SIG" | jq '[.[].authored_prs | length] | add // 0' 2>/dev/null || echo 0)"
-   if [ "${PR_COUNT:-0}" -gt 0 ] && { [ "${SIG_ENGINEERS:-0}" -eq 0 ] || [ "${SIG_PR_TOTAL:-0}" -ne "${PR_COUNT}" ]; }; then
+   # (C) Cross-check `extract` against the now-TRUSTED PR_COUNT (reads (A)+(B) confirmed
+   #     succeeded). `extract` still fails SILENT (`{}`, exit 0) — the #300 follow-up; the
+   #     library-level fix is #311 on the trust_signals surface, not touched here. An
+   #     empty map — or ANY disagreement, which also catches a PARTIAL read — for a wave
+   #     that merged PRs is an ABORT, never a zero. A genuinely empty wave reaches here
+   #     only after the reads SUCCEEDED, so PR_COUNT == 0 is then a real zero and proceeds:
+   SIG_ENGINEERS="$(printf '%s' "$SIG" | jq 'length' 2>/dev/null || echo 0)"
+   SIG_PR_TOTAL="$(printf '%s' "$SIG" | jq '[.[].authored_prs | length] | add // 0' 2>/dev/null || echo 0)"
+   if [ "$PR_COUNT" -gt 0 ] && { [ "${SIG_ENGINEERS:-0}" -eq 0 ] || [ "${SIG_PR_TOTAL:-0}" -ne "$PR_COUNT" ]; }; then
        echo "ABORT: trust_signals extract could not be trusted for wave $W" >&2
        echo "  gh pr list count = $PR_COUNT, but extract shows $SIG_ENGINEERS engineer(s)" >&2
-       echo "  covering $SIG_PR_TOTAL authored PR(s). An empty/short extract for a wave" >&2
-       echo "  that merged PRs means the READ FAILED (usually a GraphQL rate limit)," >&2
-       echo "  NOT that no rework happened. Do NOT run 'wave wrapup' with these numbers —" >&2
-       echo "  it would write false counters into state.json that nothing downstream" >&2
-       echo "  could tell from real zeros. Wait for reset —" >&2
-       echo "  'gh api rate_limit --jq .resources.graphql' — and re-run step 3 from the top." >&2
+       echo "  covering $SIG_PR_TOTAL authored PR(s). An empty/short extract for a wave that" >&2
+       echo "  merged PRs means the READ FAILED (usually a GraphQL rate limit), NOT that no" >&2
+       echo "  rework happened. Do NOT run 'wave wrapup' with these numbers. Wait for reset" >&2
+       echo "  and re-run step 3 from the top." >&2
        exit 1
    fi
 

--- a/framework/assets/skills/wave-end/SKILL.md
+++ b/framework/assets/skills/wave-end/SKILL.md
@@ -68,8 +68,33 @@ and reads the counters recorded here.
    # (it parses the `Co-Authored-By` trailers). Grouping `gh`'s `.author.login` instead
    # collapses every PR into the single bot/owner account in a dogfooded repo, pinning
    # concentration at ~100% forever — exactly the drift this derivation exists to kill.
-   # Extract once and read both counters off it:
+   # Extract once and read both counters off it — a second call could straddle a
+   # rate-limit boundary and return different data:
    SIG="$(python3 "$LIB/trust_signals.py" extract "$W")"
+
+   # GUARDRAIL — `extract` fails SILENT (#300 follow-up; the fix at the `extract`
+   # level is tracked separately on the trust_signals surface). It is SCM-dependent,
+   # and under a GitHub API rate limit it returns `{}` with exit 0 and no stderr. The
+   # `add // 0` / zero-total guards below would then record `cr_cycles=0,
+   # concentration=0` — a PLAUSIBLE-looking lie (a genuinely clean wave IS 0),
+   # indistinguishable from "we could not read GitHub". So the record must not be
+   # written from an unreadable extract. You already know PR_COUNT independently from
+   # `gh pr list`; cross-check it against extract's identity-aware `authored_prs`
+   # total. An empty map — or ANY disagreement, which also catches a PARTIAL read —
+   # for a wave that merged PRs is an ABORT, never a zero:
+   SIG_ENGINEERS="$(echo "$SIG" | jq 'length' 2>/dev/null || echo 0)"
+   SIG_PR_TOTAL="$(echo "$SIG" | jq '[.[].authored_prs | length] | add // 0' 2>/dev/null || echo 0)"
+   if [ "${PR_COUNT:-0}" -gt 0 ] && { [ "${SIG_ENGINEERS:-0}" -eq 0 ] || [ "${SIG_PR_TOTAL:-0}" -ne "${PR_COUNT}" ]; }; then
+       echo "ABORT: trust_signals extract could not be trusted for wave $W" >&2
+       echo "  gh pr list count = $PR_COUNT, but extract shows $SIG_ENGINEERS engineer(s)" >&2
+       echo "  covering $SIG_PR_TOTAL authored PR(s). An empty/short extract for a wave" >&2
+       echo "  that merged PRs means the READ FAILED (usually a GraphQL rate limit)," >&2
+       echo "  NOT that no rework happened. Do NOT run 'wave wrapup' with these numbers —" >&2
+       echo "  it would write false counters into state.json that nothing downstream" >&2
+       echo "  could tell from real zeros. Wait for reset —" >&2
+       echo "  'gh api rate_limit --jq .resources.graphql' — and re-run step 3 from the top." >&2
+       exit 1
+   fi
 
    # --cr-cycles = PRs that took >=1 changes-requested round. `trust_signals.py`
    # increments an author's `rework_cycles` exactly ONCE per PR that carried a rework

--- a/framework/assets/skills/wave-end/SKILL.md
+++ b/framework/assets/skills/wave-end/SKILL.md
@@ -36,21 +36,80 @@ and reads the counters recorded here.
    d. Create tech-debt issues for findings (label: next phase)
    e. Merge if CI green
    f. Close referenced issues
-3. Record the wave's counters and close it **live** — the `wrapup` transition writes
-   `wave_{W}_completed_at`, deactivates the wave, advances `last_completed_wave`, and
-   records the three counters `/wave-retro` reads for drift verification:
+3. **Derive the wave's counters mechanically — never transcribe them from the
+   handoff.** The three counters `/wave-retro` step 2 reads for drift verification
+   MUST be computed from the merged-PR set and `trust_signals.py extract` — the same
+   authority the retro reconciles against. The session handoff narrates *final
+   verdict state* (a PR amended in place after its fix lands reads "clean"); the
+   counters track *round history*. Transcribing the prose is a second source of truth
+   and guarantees drift — it bit twice: Wave 22 recorded `--cr-cycles 1` because the
+   handoff read "3 PRs / 1 CR cycle" and called #290 "2 clean" (true of its amended
+   final state, false of its round history — #290 carried a real rework round), and
+   `trust_signals.py extract 22` disagreed on sight; Wave 11 produced the analogous
+   rollup slip that motivated the `origin/<wave>` runbook step (#255).
+
+   Compute all three from the same merged-PR set the retro uses, then pass the derived
+   values to `wrapup` — do not type numbers from memory:
+
+   ```bash
+   # BASE = the wave's PR base — the integration branch for a wave-branch merge model,
+   # the default branch otherwise (same resolution as step 1 / `/wave-retro` step 1).
+   MM="$(python3 "$LIB/lifecycle.py" merge-model get "$W" 2>/dev/null || echo direct-to-main)"
+   # wave-branch    → BASE=<branch.integration template, the wave's phase + $W>
+   # direct-to-main → BASE=<default branch>; add `--label "wave-$W"` to scope the wave
+
+   # --pr-count and --concentration come from the merged-PR list itself:
+   PRS_JSON="$(gh pr list --state merged --base "$BASE" --json number,author)"
+   PR_COUNT="$(echo "$PRS_JSON" | jq 'length')"
+   CONCENTRATION="$(echo "$PRS_JSON" | jq -r '
+       if length == 0 then 0
+       else ((group_by(.author.login) | map(length) | max) * 100 / length | floor)
+       end')"
+
+   # --cr-cycles = PRs that took >=1 changes-requested round. `trust_signals.py`
+   # increments an author's `rework_cycles` exactly ONCE per PR that carried a rework
+   # round, and the extraction is edit-history-aware (the #164 catch ledger / #229
+   # comment histories), so an in-place verdict amendment does NOT erase the round.
+   # Summing `rework_cycles` across engineers therefore counts reworked PRs per-PR,
+   # not per-verdict (a PR with `reviewers_required=2` can carry two ChangesRequested
+   # verdicts in one round — still one reworked PR). This is the SAME extraction
+   # `/wave-retro` steps 2-3 run, so the wrapup counter and the retro recompute can
+   # never diverge:
+   CR_CYCLES="$(python3 "$LIB/trust_signals.py" extract "$W" \
+       | jq '[.[].rework_cycles] | add // 0')"
+
+   echo "derived counters → --pr-count $PR_COUNT --cr-cycles $CR_CYCLES --concentration $CONCENTRATION"
+   ```
+
+   For a `meta-and-children` project, sweep every repo in `project.repos` (this is
+   what `trust_signals.py` does internally) and union the per-repo `pr list` results
+   before computing `--pr-count` / `--concentration`.
+
+   Then record the counters and close the wave **live** — the `wrapup` transition
+   writes `wave_{W}_completed_at`, deactivates the wave, advances `last_completed_wave`,
+   and stores the three counters `/wave-retro` reads for drift verification:
 
    ```bash
    python3 "$LIB/lifecycle.py" wave wrapup "$W" \
-       --pr-count {N} --cr-cycles {C} --concentration {PCT}
+       --pr-count "$PR_COUNT" --cr-cycles "$CR_CYCLES" --concentration "$CONCENTRATION"
    ```
 
-   Count them from the actual merged-PR set, not from memory: `--pr-count` = merged PRs
-   this wave, `--cr-cycles` = **PRs** that took >=1 changes-requested round (per-PR, not
-   per-verdict — a PR with `reviewers_required=2` can carry 2 ChangesRequested verdicts in
-   one round; count the PR once). This mirrors `trust_signals.py`'s `rework_cycles` signal
-   ("PRs they authored that needed >=1 rework round") so the two counters never drift.
-   `--concentration` = max(PRs by one author) × 100 / total.
+   **The recomputed-vs-claimed reconciliation is bidirectional.** `/wave-retro` step 2
+   independently recomputes these counters; deriving them mechanically here makes the
+   two agree by construction, but state both directions so the reconciliation is
+   unambiguous whenever they differ:
+   - **recomputed `<` claimed AND the gap is fully explained by edited-in-place
+     verdicts** → the **claimed value stands**. A naive recompute from *current*
+     comment bodies under-counts a ChangesRequested verdict that was amended in place
+     to Approved after the fix landed — the historic round still happened, so the
+     wrapup-time count is authoritative-historic. Record a
+     `wave_{W}_counter_corrections` entry documenting the measurement conflict; do NOT
+     correct the historic count downward. (Deriving `--cr-cycles` from the
+     history-aware `extract` above avoids this under-count in the first place.)
+   - **recomputed `>` claimed** → **recomputed wins** — the wrapup missed a real round.
+     This was Wave 22 (claimed 1, recomputed 2: `extract` found `rework_cycles=1` on
+     both #290 and #292). Because this step now derives `--cr-cycles` from that same
+     `extract`, this direction should not resurface at retro time again.
 
    **Emit review-load next to concentration** (#231): concentration tracks *authoring*
    load; the companion number is *reviewing* load — per-reviewer verdict counts, so a

--- a/framework/assets/skills/wave-end/SKILL.md
+++ b/framework/assets/skills/wave-end/SKILL.md
@@ -58,13 +58,18 @@ and reads the counters recorded here.
    # wave-branch    → BASE=<branch.integration template, the wave's phase + $W>
    # direct-to-main → BASE=<default branch>; add `--label "wave-$W"` to scope the wave
 
-   # --pr-count and --concentration come from the merged-PR list itself:
-   PRS_JSON="$(gh pr list --state merged --base "$BASE" --json number,author)"
-   PR_COUNT="$(echo "$PRS_JSON" | jq 'length')"
-   CONCENTRATION="$(echo "$PRS_JSON" | jq -r '
-       if length == 0 then 0
-       else ((group_by(.author.login) | map(length) | max) * 100 / length | floor)
-       end')"
+   # --pr-count is identity-AGNOSTIC — it counts merged PRs, not authors — so the raw
+   # `gh` list is correct here even in a single-account (dogfooded) repo where every PR
+   # carries one `author.login` and team identity lives only in `Co-Authored-By`:
+   PR_COUNT="$(gh pr list --state merged --base "$BASE" --json number | jq 'length')"
+
+   # --cr-cycles and --concentration are BOTH identity-SENSITIVE, so both derive from
+   # `trust_signals.py extract` — the only source that resolves team-member identity
+   # (it parses the `Co-Authored-By` trailers). Grouping `gh`'s `.author.login` instead
+   # collapses every PR into the single bot/owner account in a dogfooded repo, pinning
+   # concentration at ~100% forever — exactly the drift this derivation exists to kill.
+   # Extract once and read both counters off it:
+   SIG="$(python3 "$LIB/trust_signals.py" extract "$W")"
 
    # --cr-cycles = PRs that took >=1 changes-requested round. `trust_signals.py`
    # increments an author's `rework_cycles` exactly ONCE per PR that carried a rework
@@ -75,15 +80,22 @@ and reads the counters recorded here.
    # verdicts in one round — still one reworked PR). This is the SAME extraction
    # `/wave-retro` steps 2-3 run, so the wrapup counter and the retro recompute can
    # never diverge:
-   CR_CYCLES="$(python3 "$LIB/trust_signals.py" extract "$W" \
-       | jq '[.[].rework_cycles] | add // 0')"
+   CR_CYCLES="$(echo "$SIG" | jq '[.[].rework_cycles] | add // 0')"
+
+   # --concentration = max(PRs by one author) × 100 / total, over the SAME identity-aware
+   # `authored_prs` lists `/wave-retro` step 2 reconciles against (integer floor; guard
+   # total == 0):
+   CONCENTRATION="$(echo "$SIG" | jq '
+       [ .[].authored_prs | length ] as $lens
+       | ($lens | add) as $total
+       | if ($total // 0) == 0 then 0 else (($lens | max) * 100 / $total | floor) end')"
 
    echo "derived counters → --pr-count $PR_COUNT --cr-cycles $CR_CYCLES --concentration $CONCENTRATION"
    ```
 
-   For a `meta-and-children` project, sweep every repo in `project.repos` (this is
-   what `trust_signals.py` does internally) and union the per-repo `pr list` results
-   before computing `--pr-count` / `--concentration`.
+   For a `meta-and-children` project, `trust_signals.py extract` already sweeps every
+   repo in `project.repos` internally, so `--cr-cycles` / `--concentration` need no
+   manual sweep; union the per-repo `gh pr list` results yourself only for `--pr-count`.
 
    Then record the counters and close the wave **live** — the `wrapup` transition
    writes `wave_{W}_completed_at`, deactivates the wave, advances `last_completed_wave`,

--- a/framework/tests/test_wave_end_counter_derivation.py
+++ b/framework/tests/test_wave_end_counter_derivation.py
@@ -7,16 +7,25 @@ come from `trust_signals.py extract` (which resolves team identity from
 single-account repo every PR carries one login, so grouping by it collapses
 concentration to ~100% forever (Paloma's Wave-23 must-fix on PR #307).
 
-Two layers, no network:
+Three layers, no network:
   * an arithmetic mirror of the documented jq derivation, exercised on the real
     Wave-22 ``extract`` shape → asserts `cr_cycles == 2` AND `concentration == 33`
     (matching `wave_22_top_concentration_pct` in state and the retro recompute);
+  * a mirror of the step-3 abort gate distinguishing the THREE states the original
+    guard conflated — genuinely-empty wave (proceed), read-failed (abort), reads-
+    disagree (abort). `gh pr list` is GraphQL-backed, the SAME bucket ``extract``
+    drains, so under a pre-exhausted budget both fail in lockstep and a naive
+    ``${PR_COUNT:-0}`` collapse sails past a cross-check that also anchors on 0 (the
+    #307 review defect). The gate anchors on the ORTHOGONAL REST ``rate_limit`` bucket
+    and on ``gh pr list``'s captured exit status, neither of which fails in lockstep;
   * a content guard that both SKILL.md trees derive concentration from the
-    identity-aware ``authored_prs`` and never re-introduce ``group_by(.author.login)``.
+    identity-aware ``authored_prs`` (never ``group_by(.author.login)``) and carry all
+    three abort defenses.
 """
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 _FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
@@ -43,18 +52,58 @@ def _concentration(sig: dict) -> int:
     return 0 if total == 0 else (max(lens) * 100) // total
 
 
-def _should_abort(sig: dict, pr_count: int) -> bool:
-    """Mirror of SKILL.md step-3 guardrail: refuse to derive counters from an
-    extract that cannot be trusted. `extract` fails SILENT under a rate limit
-    (returns `{}`, exit 0), so an empty/short result for a wave that merged PRs is
-    the read having FAILED, not a genuine zero. Cross-check extract's identity-aware
-    `authored_prs` total against the independently-known PR count; any disagreement
-    (empty OR partial) aborts. A legitimately empty wave (pr_count == 0) proceeds."""
+_GQL_FLOOR = 100
+
+
+def _read_trusted(
+    graphql_remaining: object, pr_list_rc: int, pr_list_stdout: object
+) -> tuple[bool, int | None]:
+    """Mirror of SKILL.md defenses (A)+(B): establish that the reads SUCCEEDED before
+    any zero is believed. (A) the GraphQL budget, probed over the ORTHOGONAL REST
+    `rate_limit` bucket, must be numeric and >= the floor — a pre-exhausted budget
+    means `gh pr list` / `extract` would return empty-but-successful in lockstep. (B)
+    `gh pr list` must exit 0 AND yield a numeric count — a failed read must NOT
+    collapse into an empty string and then a 0. Returns (trusted, pr_count)."""
+    # (A) orthogonal budget probe
+    if not isinstance(graphql_remaining, int) or isinstance(graphql_remaining, bool):
+        return (False, None)
+    if graphql_remaining < _GQL_FLOOR:
+        return (False, None)
+    # (B) explicit exit-status + numeric-count discipline
+    if pr_list_rc != 0:
+        return (False, None)
+    try:
+        parsed = json.loads(pr_list_stdout)  # type: ignore[arg-type]
+    except (ValueError, TypeError):
+        return (False, None)
+    if not isinstance(parsed, list):
+        return (False, None)
+    return (True, len(parsed))
+
+
+def _crosscheck_aborts(sig: dict, pr_count: int) -> bool:
+    """Mirror of SKILL.md defense (C): with a TRUSTED pr_count, cross-check extract's
+    identity-aware `authored_prs` total. `extract` fails SILENT (returns `{}`, exit 0),
+    so an empty/short result for a wave that merged PRs is the read having FAILED, not
+    a genuine zero; any disagreement (empty OR partial) aborts. pr_count == 0 here is a
+    real empty wave (the reads already proved trustworthy) and proceeds."""
     if pr_count <= 0:
         return False
     engineers = len(sig)
     sig_pr_total = sum(len(v.get("authored_prs", [])) for v in sig.values())
     return engineers == 0 or sig_pr_total != pr_count
+
+
+def _derivation_aborts(
+    *, graphql_remaining: object, pr_list_rc: int, pr_list_stdout: object, sig: dict
+) -> bool:
+    """The full step-3 gate: an untrusted read aborts BEFORE the cross-check ever sees
+    a (possibly collapsed) zero; only a trusted read reaches the cross-check."""
+    trusted, pr_count = _read_trusted(graphql_remaining, pr_list_rc, pr_list_stdout)
+    if not trusted:
+        return True
+    assert pr_count is not None
+    return _crosscheck_aborts(sig, pr_count)
 
 
 # The real `trust_signals.py extract 22` shape (identity-resolved from trailers):
@@ -103,30 +152,133 @@ def test_concentration_floor_matches_jq() -> None:
     assert _concentration(sig) == 66
 
 
-# ------------------------------------------------------- silent-extract-failure abort
+# ------------------------------------------- defense (C): cross-check on a TRUSTED count
 
 
-def test_empty_extract_with_merged_prs_aborts() -> None:
-    """The core defect: `extract` returned `{}` (rate-limited, exit 0) but the wave
-    merged PRs. Recording cr_cycles=0/concentration=0 would be a silent lie — abort."""
-    assert _should_abort({}, pr_count=3) is True
+def test_crosscheck_empty_extract_with_merged_prs_aborts() -> None:
+    """`extract` returned `{}` (silent, exit 0) but the wave merged 3 PRs. Recording
+    cr_cycles=0/concentration=0 would be a silent lie — abort."""
+    assert _crosscheck_aborts({}, pr_count=3) is True
 
 
-def test_partial_extract_aborts() -> None:
-    """A partial read (2 of the wave's 3 PRs) also disagrees with PR_COUNT — abort,
-    so the cross-check catches truncated reads, not only total failures."""
+def test_crosscheck_partial_extract_aborts() -> None:
+    """A partial read (2 of the wave's 3 PRs) disagrees with PR_COUNT — abort, so the
+    cross-check catches truncated reads, not only total failures."""
     partial = {"Nia Rossi": {"authored_prs": [290]}, "Paloma Gupta": {"authored_prs": [292]}}
-    assert _should_abort(partial, pr_count=3) is True
+    assert _crosscheck_aborts(partial, pr_count=3) is True
 
 
-def test_healthy_extract_proceeds() -> None:
+def test_crosscheck_healthy_extract_proceeds() -> None:
     """The Wave-22 read matches PR_COUNT (3 authored PRs) — derive and record."""
-    assert _should_abort(_WAVE_22, pr_count=3) is False
+    assert _crosscheck_aborts(_WAVE_22, pr_count=3) is False
+
+
+# -------------------- defenses (A)+(B): distinguish the THREE states the bug conflated
+# genuinely empty wave (reads succeeded, 0 PRs) -> proceed;  read failed -> abort;
+# reads disagree -> abort.  The old suite asserted `_should_abort({}, 0) is False`,
+# which ENCODED the pre-exhausted bug as intended behavior (#307 review).
+
+_HEALTHY_GQL = 4800  # REST rate_limit reports GraphQL healthy while a wave is read
 
 
 def test_genuinely_empty_wave_proceeds() -> None:
-    """A wave that merged nothing is a real zero, not a failed read — no abort."""
-    assert _should_abort({}, pr_count=0) is False
+    """State 1 — reads SUCCEEDED (budget healthy, `gh pr list` exit 0, `[]`) and the
+    wave merged nothing. A real zero: proceed."""
+    assert (
+        _derivation_aborts(
+            graphql_remaining=_HEALTHY_GQL, pr_list_rc=0, pr_list_stdout="[]", sig={}
+        )
+        is False
+    )
+
+
+def test_pre_exhausted_lockstep_read_aborts() -> None:
+    """State 2, the revert->red case (#307 review): GraphQL is pre-exhausted, so BOTH
+    `gh pr list` (exit 1, empty stdout) and `extract` (`{}`) fail in lockstep. The old
+    code let PR_COUNT collapse to 0 and the cross-check compared 0 == 0 and 'passed'.
+    Now the orthogonal REST budget probe AND the captured exit status BOTH abort."""
+    assert (
+        _derivation_aborts(
+            graphql_remaining=0, pr_list_rc=1, pr_list_stdout="", sig={}
+        )
+        is True
+    )
+
+
+def test_gh_pr_list_nonzero_exit_aborts() -> None:
+    """State 2 — even with a (stale) healthy-looking budget, a non-zero `gh pr list`
+    exit is a failed read, not an empty wave: abort, never a collapsed 0."""
+    assert (
+        _derivation_aborts(
+            graphql_remaining=_HEALTHY_GQL, pr_list_rc=1, pr_list_stdout="", sig={}
+        )
+        is True
+    )
+
+
+def test_gh_pr_list_nonnumeric_stdout_aborts() -> None:
+    """State 2 — `gh pr list` exited 0 but stdout is not a JSON array (a warning line,
+    a truncated body): the count is untrustworthy — abort."""
+    assert (
+        _derivation_aborts(
+            graphql_remaining=_HEALTHY_GQL,
+            pr_list_rc=0,
+            pr_list_stdout="GraphQL: API rate limit exceeded",
+            sig={},
+        )
+        is True
+    )
+
+
+def test_rate_limit_probe_unreadable_aborts() -> None:
+    """State 2 — the orthogonal budget probe itself failed (non-int remaining): we
+    cannot establish the read will succeed, so refuse to record."""
+    assert (
+        _derivation_aborts(
+            graphql_remaining=None, pr_list_rc=0, pr_list_stdout="[]", sig={}
+        )
+        is True
+    )
+
+
+def test_near_zero_budget_aborts_before_reading() -> None:
+    """State 2 — budget positive but below the fail-fast floor: abort with the
+    rate-limit diagnostic rather than proceeding into a read that will come back
+    empty-but-successful."""
+    assert (
+        _derivation_aborts(
+            graphql_remaining=_GQL_FLOOR - 1,
+            pr_list_rc=0,
+            pr_list_stdout="[]",
+            sig={},
+        )
+        is True
+    )
+
+
+def test_reads_disagree_aborts() -> None:
+    """State 3 — reads succeeded (budget healthy, 3 PRs listed) but `extract` only
+    covers 2 of them (a partial GraphQL read): abort on the disagreement."""
+    listed = json.dumps([{"number": 290}, {"number": 292}, {"number": 294}])
+    partial = {"Nia Rossi": {"authored_prs": [290]}, "Paloma Gupta": {"authored_prs": [292]}}
+    assert (
+        _derivation_aborts(
+            graphql_remaining=_HEALTHY_GQL, pr_list_rc=0, pr_list_stdout=listed, sig=partial
+        )
+        is True
+    )
+
+
+def test_full_healthy_path_proceeds() -> None:
+    """All three defenses pass: healthy budget, 3 PRs listed, extract covers all 3 —
+    derive and record."""
+    listed = json.dumps([{"number": 290}, {"number": 292}, {"number": 294}])
+    assert (
+        _derivation_aborts(
+            graphql_remaining=_HEALTHY_GQL, pr_list_rc=0, pr_list_stdout=listed, sig=_WAVE_22
+        )
+        is False
+    )
 
 
 # ---------------------------------------------------------------- skill content guard
@@ -150,12 +302,19 @@ def test_both_trees_derive_cr_cycles_from_extract() -> None:
 
 def test_both_trees_guard_against_silent_extract_failure() -> None:
     """Both trees must abort — not record zeros — when a merged-PR wave yields an
-    empty/short extract (the silent rate-limit failure, #300 follow-up)."""
+    empty/short extract, AND when the reads themselves failed (pre-exhausted budget /
+    non-zero `gh pr list`). The three orthogonal defenses (#307 review) must be present."""
     for path in _SKILL_TREES:
         text = path.read_text(encoding="utf-8")
+        # (A) orthogonal REST budget probe — cannot fail in lockstep with GraphQL.
+        assert ".resources.graphql.remaining" in text, f"{path}: missing REST rate_limit preflight (A)"
+        assert "ABORT: GraphQL budget near-exhausted" in text, f"{path}: missing near-exhausted abort (A)"
+        # (B) explicit `gh pr list` exit-status capture — no ${VAR:-0} collapse.
+        assert "PR_LIST_RC=$?" in text, f"{path}: missing gh pr list exit-status capture (B)"
+        assert "ABORT: gh pr list failed" in text, f"{path}: missing failed-read abort (B)"
+        # (C) cross-check against the trusted count, catching empty/partial extracts.
         assert "ABORT: trust_signals extract could not be trusted" in text, (
-            f"{path}: missing the silent-extract-failure abort guardrail"
+            f"{path}: missing the silent-extract-failure abort guardrail (C)"
         )
-        # The cross-check that catches partial reads, and the single-call capture.
-        assert "[.[].authored_prs | length] | add" in text, f"{path}: missing PR_COUNT cross-check"
+        assert "[.[].authored_prs | length] | add" in text, f"{path}: missing PR_COUNT cross-check (C)"
         assert text.count('extract "$W")') == 1, f"{path}: extract must be called exactly once"

--- a/framework/tests/test_wave_end_counter_derivation.py
+++ b/framework/tests/test_wave_end_counter_derivation.py
@@ -43,6 +43,20 @@ def _concentration(sig: dict) -> int:
     return 0 if total == 0 else (max(lens) * 100) // total
 
 
+def _should_abort(sig: dict, pr_count: int) -> bool:
+    """Mirror of SKILL.md step-3 guardrail: refuse to derive counters from an
+    extract that cannot be trusted. `extract` fails SILENT under a rate limit
+    (returns `{}`, exit 0), so an empty/short result for a wave that merged PRs is
+    the read having FAILED, not a genuine zero. Cross-check extract's identity-aware
+    `authored_prs` total against the independently-known PR count; any disagreement
+    (empty OR partial) aborts. A legitimately empty wave (pr_count == 0) proceeds."""
+    if pr_count <= 0:
+        return False
+    engineers = len(sig)
+    sig_pr_total = sum(len(v.get("authored_prs", [])) for v in sig.values())
+    return engineers == 0 or sig_pr_total != pr_count
+
+
 # The real `trust_signals.py extract 22` shape (identity-resolved from trailers):
 # #290 Nia and #292 Paloma each carried one rework round; #294 Ibrahim clean.
 _WAVE_22 = {
@@ -89,6 +103,32 @@ def test_concentration_floor_matches_jq() -> None:
     assert _concentration(sig) == 66
 
 
+# ------------------------------------------------------- silent-extract-failure abort
+
+
+def test_empty_extract_with_merged_prs_aborts() -> None:
+    """The core defect: `extract` returned `{}` (rate-limited, exit 0) but the wave
+    merged PRs. Recording cr_cycles=0/concentration=0 would be a silent lie — abort."""
+    assert _should_abort({}, pr_count=3) is True
+
+
+def test_partial_extract_aborts() -> None:
+    """A partial read (2 of the wave's 3 PRs) also disagrees with PR_COUNT — abort,
+    so the cross-check catches truncated reads, not only total failures."""
+    partial = {"Nia Rossi": {"authored_prs": [290]}, "Paloma Gupta": {"authored_prs": [292]}}
+    assert _should_abort(partial, pr_count=3) is True
+
+
+def test_healthy_extract_proceeds() -> None:
+    """The Wave-22 read matches PR_COUNT (3 authored PRs) — derive and record."""
+    assert _should_abort(_WAVE_22, pr_count=3) is False
+
+
+def test_genuinely_empty_wave_proceeds() -> None:
+    """A wave that merged nothing is a real zero, not a failed read — no abort."""
+    assert _should_abort({}, pr_count=0) is False
+
+
 # ---------------------------------------------------------------- skill content guard
 
 
@@ -106,3 +146,16 @@ def test_both_trees_derive_cr_cycles_from_extract() -> None:
     for path in _SKILL_TREES:
         text = path.read_text(encoding="utf-8")
         assert "[.[].rework_cycles] | add" in text, f"{path}: cr-cycles must sum rework_cycles from extract"
+
+
+def test_both_trees_guard_against_silent_extract_failure() -> None:
+    """Both trees must abort — not record zeros — when a merged-PR wave yields an
+    empty/short extract (the silent rate-limit failure, #300 follow-up)."""
+    for path in _SKILL_TREES:
+        text = path.read_text(encoding="utf-8")
+        assert "ABORT: trust_signals extract could not be trusted" in text, (
+            f"{path}: missing the silent-extract-failure abort guardrail"
+        )
+        # The cross-check that catches partial reads, and the single-call capture.
+        assert "[.[].authored_prs | length] | add" in text, f"{path}: missing PR_COUNT cross-check"
+        assert text.count('extract "$W")') == 1, f"{path}: extract must be called exactly once"

--- a/framework/tests/test_wave_end_counter_derivation.py
+++ b/framework/tests/test_wave_end_counter_derivation.py
@@ -1,0 +1,108 @@
+"""Regression tests for the wave-end skill's step-3 counter derivation (#300).
+
+`/wave-end` derives the three wrapup counters mechanically so they cannot drift
+against `/wave-retro`'s recompute. Two of the three are IDENTITY-SENSITIVE and must
+come from `trust_signals.py extract` (which resolves team identity from
+``Co-Authored-By`` trailers), NOT from ``gh``'s ``.author.login`` — in a dogfooded
+single-account repo every PR carries one login, so grouping by it collapses
+concentration to ~100% forever (Paloma's Wave-23 must-fix on PR #307).
+
+Two layers, no network:
+  * an arithmetic mirror of the documented jq derivation, exercised on the real
+    Wave-22 ``extract`` shape → asserts `cr_cycles == 2` AND `concentration == 33`
+    (matching `wave_22_top_concentration_pct` in state and the retro recompute);
+  * a content guard that both SKILL.md trees derive concentration from the
+    identity-aware ``authored_prs`` and never re-introduce ``group_by(.author.login)``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_FRAMEWORK_ROOT = Path(__file__).resolve().parent.parent
+_REPO_ROOT = _FRAMEWORK_ROOT.parent
+_SKILL_TREES = (
+    _REPO_ROOT / ".claude" / "skills" / "wave-end" / "SKILL.md",
+    _FRAMEWORK_ROOT / "assets" / "skills" / "wave-end" / "SKILL.md",
+)
+
+
+# ------------------------------------------------------------ documented arithmetic
+# Pure mirrors of the SKILL.md jq. `--cr-cycles` sums per-engineer `rework_cycles`
+# (one increment per reworked PR); `--concentration` is max/total over the same
+# identity-aware `authored_prs` lists, integer floor, guarded for total == 0.
+
+
+def _cr_cycles(sig: dict) -> int:
+    return sum(int(v.get("rework_cycles", 0)) for v in sig.values())
+
+
+def _concentration(sig: dict) -> int:
+    lens = [len(v.get("authored_prs", [])) for v in sig.values()]
+    total = sum(lens)
+    return 0 if total == 0 else (max(lens) * 100) // total
+
+
+# The real `trust_signals.py extract 22` shape (identity-resolved from trailers):
+# #290 Nia and #292 Paloma each carried one rework round; #294 Ibrahim clean.
+_WAVE_22 = {
+    "Ibrahim El-Amin": {"rework_cycles": 0, "authored_prs": [294], "must_fix_received": 0},
+    "Nia Rossi": {"rework_cycles": 1, "authored_prs": [290], "must_fix_received": 2},
+    "Paloma Gupta": {"rework_cycles": 1, "authored_prs": [292], "must_fix_received": 1},
+    "Tariq Morales": {"rework_cycles": 0, "authored_prs": []},
+}
+
+
+def test_wave22_cr_cycles_is_two() -> None:
+    """The bar: Wave 22 replays to cr_cycles = 2, refuting the handoff's `1`."""
+    assert _cr_cycles(_WAVE_22) == 2
+
+
+def test_wave22_concentration_is_33_identity_aware() -> None:
+    """The must-fix bar: concentration derives from `authored_prs` → 33 (matching
+    `wave_22_top_concentration_pct` and the retro), NOT the ~100 an `.author.login`
+    group_by yields when all three PRs share one dogfood account."""
+    assert _concentration(_WAVE_22) == 33
+    assert _concentration(_WAVE_22) != 100
+
+    # The single-account collapse the fix removes: with all three PRs under one
+    # `.author.login`, group_by yields a single group of size 3 → 3*100//3 = 100.
+    logins = ["parametrization", "parametrization", "parametrization"]
+    groups: dict[str, int] = {}
+    for login in logins:
+        groups[login] = groups.get(login, 0) + 1
+    collapsed_pct = max(groups.values()) * 100 // len(logins)
+    assert collapsed_pct == 100  # what group_by(.author.login) produced — the bug
+
+
+def test_concentration_guards_zero_total() -> None:
+    assert _concentration({"A": {"authored_prs": []}}) == 0
+    assert _concentration({}) == 0
+
+
+def test_concentration_floor_matches_jq() -> None:
+    """max*100/total floored — 2 of 3 PRs → 66 (parity with jq `| floor`)."""
+    sig = {
+        "A": {"authored_prs": [1, 2]},
+        "B": {"authored_prs": [3]},
+    }
+    assert _concentration(sig) == 66
+
+
+# ---------------------------------------------------------------- skill content guard
+
+
+def test_both_trees_derive_concentration_from_authored_prs() -> None:
+    for path in _SKILL_TREES:
+        text = path.read_text(encoding="utf-8")
+        assert ".[].authored_prs | length" in text, f"{path}: concentration must use authored_prs"
+        assert "group_by(.author.login)" not in text, (
+            f"{path}: concentration must NOT group by .author.login "
+            "(collapses to ~100% in a single-account repo — #300)"
+        )
+
+
+def test_both_trees_derive_cr_cycles_from_extract() -> None:
+    for path in _SKILL_TREES:
+        text = path.read_text(encoding="utf-8")
+        assert "[.[].rework_cycles] | add" in text, f"{path}: cr-cycles must sum rework_cycles from extract"


### PR DESCRIPTION
## Summary
- `/wave-end` step 3 now **derives** the three wrapup counters mechanically instead of accepting numbers transcribed from the session handoff's prose — the handoff narrates *final verdict state* (an in-place-amended PR reads "clean") while the counters track *round history*, so transcription is a second source of truth that guarantees drift against `/wave-retro` step 2 (bit twice: Wave 22 `--cr-cycles 1` for a two-rework-round wave; Wave 11 → the `origin/<wave>` runbook step #255).
- `--cr-cycles` (`sum(rework_cycles)`) **and** `--concentration` (`max/total` over `authored_prs`) both derive from `trust_signals.py extract {W}` — the identity-aware source the retro reconciles against (it resolves team identity from `Co-Authored-By` trailers). Grouping `gh`'s `.author.login` collapses this dogfooded repo's single account to ~100% every wave, so both identity-sensitive counters avoid it. `--pr-count` stays on `gh pr list | jq length` — a count of PRs, not authors, so it is identity-agnostic and correct as-is.
- Writes the recomputed-vs-claimed reconciliation in **both** directions: recomputed `<` claimed explained by edited-in-place verdicts → claimed stands (corrections entry); recomputed `>` claimed → recomputed wins (the Wave 22 mirror image the old docs never covered).
- **Silent-failure guardrail (three orthogonal defenses).** `extract` fails silent under a rate limit (`{}`, exit 0), and `gh pr list` is GraphQL-backed — the *same* bucket — so under a pre-exhausted budget both fail in lockstep, `${PR_COUNT:-0}` collapses to 0, and a cross-check that also anchors on 0 passes (the #307 review defect). Step 3 now, before deriving anything: **(A)** preflights the GraphQL budget over `gh api rate_limit` (served over REST — a bucket that can't fail in lockstep), aborting near zero; **(B)** captures `gh pr list`'s exit status explicitly (non-zero exit / non-numeric stdout → abort, never a `${VAR:-0}` collapse); **(C)** captures `extract` once and cross-checks its identity-aware `authored_prs` total against the now-trusted `PR_COUNT` (empty or partial → abort). A genuinely empty wave proceeds only after (A)+(B) prove the reads succeeded. Live-verified: at `graphql.remaining=0`, defense (A) aborts and `wave wrapup` is not called.
- Dual-tree (`.claude/` + `framework/assets/`), byte-parity verified; `reinstall.py --check` reports in-sync.

## Follow-up (separate surface — not touched here)
`trust_signals.py extract` reporting an API failure as an empty success (`{}`, exit 0) is the library-level half of this defect, tracked as **#311** on the `trust_signals.py` surface which this story must not touch. The `/wave-end` guard defends the record independently — it never trusts an `extract` result it can't corroborate against an orthogonal read.

## Related Issues
Refs #300 (closing keyword intentionally kept in the commit message, not here — PR-body closers auto-close on merge regardless of outcome, #304).

## Verification
- **Wave-22 replay through the documented procedure yields `cr_cycles = 2` and `concentration = 33`** (`trust_signals.py extract 22`: Nia `rework_cycles=1`/`authored_prs=[290]`, Paloma `rework_cycles=1`/`[292]`, Ibrahim `[294]` → cr-cycles sum 2, concentration `max 1 * 100 // total 3` = 33, matching `wave_22_top_concentration_pct`) — output pasted in the PR thread.
- Regression `framework/tests/test_wave_end_counter_derivation.py`: Wave-22 arithmetic (2 and 33); the abort gate distinguishing the three states (empty-wave → proceed; read-failed, incl. the pre-exhausted lockstep case → abort; reads-disagree → abort) with revert→red confirmed; and content guards that both SKILL.md trees use `authored_prs`, never re-introduce `group_by(.author.login)`, carry all three abort defenses, and call `extract` exactly once.
- `ruff check` clean; framework test suite 927 passed.
- Byte-parity between the two skill trees confirmed via `diff` (identical; no mustache placeholders in the edited section); `reinstall.py --check` in sync.

## Review Checklist
- [ ] Reviewed by another team member
- [ ] Must-fix items resolved
- [ ] Tech debt items filed as GitHub Issues (if any)
